### PR TITLE
#43 - Updated step runner to partial match for command arguments.

### DIFF
--- a/src/steps.bash
+++ b/src/steps.bash
@@ -193,7 +193,7 @@ run_steps() {
         mock_args_actual="$(mock_get_call_args "${mock_cmd}" "${mock_cmd_index}")"
         substepdebug "        actual args : ${mock_args_actual}"
 
-        assert_equal "${command_args}" "${mock_args_actual}"
+        assert_contains "${command_args}" "${mock_args_actual}"
 
         # shellcheck disable=SC2181
         if [[ $? -ne 0 ]]; then

--- a/tests/steps.bats
+++ b/tests/steps.bats
@@ -100,7 +100,33 @@ load _test_helper
 
 @test "Command, args - negative: wrong args" {
   declare -a STEPS=(
+    "@somebin --opt4 --opt5 # 0 # someval"
+  )
+
+  mocks="$(run_steps "setup")"
+  run somebin --opt1 --opt2 --opt3
+  assert_output_contains "someval"
+
+  run run_steps "assert" "${mocks[@]}"
+  assert_failure
+}
+
+@test "Command, args - argument substring match" {
+  declare -a STEPS=(
     "@somebin --opt1 --opt2 # 0 # someval"
+  )
+
+  mocks="$(run_steps "setup")"
+  run somebin --opt1 --opt2 --opt3
+  assert_output_contains "someval"
+
+  run run_steps "assert" "${mocks[@]}"
+  assert_success
+}
+
+@test "Command, args - different ordering of arguments" {
+  declare -a STEPS=(
+    "@somebin --opt2 --opt1 # 0 # someval"
   )
 
   mocks="$(run_steps "setup")"


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number
  as `[#123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was
  done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and
  they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Updated step helper check for arguments to match substring rather than check for equality

## Screenshots
