### PR TITLE
[#106] Added support for deterministic test setup

### DIFF
--- a/docs/content/mocking.mdx
+++ b/docs/content/mocking.mdx
@@ -60,13 +60,18 @@ setup() {
 
 ### `mock_create`
 
-- **Description**: Creates a mock program that can be executed and tracked.
-- **Arguments**: None
+- **Description**: Creates a mock program that can be executed and tracked. Optionally creates a named command.
+- **Arguments**:
+  - Command name (optional) - If provided, creates a symbolic link with the given name
 - **Global Variables**: Uses `BATS_MOCK_TMPDIR` if set, otherwise `BATS_TMPDIR`
-- **Outputs**: Path to the created mock file
+- **Outputs**: Path to the created mock file or mocked command
 - **Usage**:
   ```bash
+  # Create unnamed mock
   mock=$(mock_create)
+
+  # Create named mock command
+  mock_wget=$(mock_create wget)
   ```
 
 ### `setup_mock`
@@ -118,6 +123,18 @@ Setup mock support. Call this function from your test's `setup()` method.
 - **Usage**:
   ```bash
   mock_set_side_effect "${mock}" "echo 'side effect executed' > /tmp/log"
+  ```
+
+### `teardown_mock`
+
+- **Description**: Cleans up all mock files and directories created during tests.
+- **Arguments**: None
+- **Global Variables**: Uses `BATS_MOCK_TMPDIR` if set, otherwise `BATS_TMPDIR`
+- **Usage**:
+  ```bash
+  teardown() {
+    teardown_mock
+  }
   ```
 
 ### `path_prefix`

--- a/docs/content/mocking.mdx
+++ b/docs/content/mocking.mdx
@@ -137,6 +137,32 @@ Setup mock support. Call this function from your test's `setup()` method.
   }
   ```
 
+## Deterministic Test Setup
+
+These functions enable you to create isolated, deterministic test environments by manipulating the `PATH` variable and creating controlled command environments. This is particularly useful for negative testing scenarios where you need to test behavior when certain commands are unavailable.
+
+### `mock_chroot`
+
+- **Description**: Creates a directory populated with symbolic links to basic system commands. This provides a controlled environment for testing.
+- **Arguments**:
+  - List of commands (optional) - If provided, only creates links for specified commands. If not provided, creates links for a default set of common commands.
+- **Returns**: Exit code 1 if a specified command cannot be found
+- **Outputs**: Path to the chroot directory
+- **Usage**:
+  ```bash
+  # Create chroot with default commands
+  chroot_path=$(mock_chroot)
+
+  # Create chroot with specific commands only
+  chroot_path=$(mock_chroot cat ls grep)
+  ```
+
+:::note
+
+`mock_create` with a command name and `mock_chroot` both place commands in the same directory (`bats-mock.$$.bin`), making them work seamlessly together.
+
+:::
+
 ### `path_prefix`
 
 - **Description**: Returns a PATH string with the mock directory prepended. This ensures mocked commands are found first.
@@ -166,6 +192,29 @@ Setup mock support. Call this function from your test's `setup()` method.
   # Remove directory containing curl
   new_path=$(path_rm "$(command -v curl)")
   ```
+
+### Example: Testing Command Fallback
+
+This example demonstrates testing a script that falls back from `curl` to `wget` when `curl` is not available:
+
+```bash
+@test "Script falls back to wget when curl unavailable" {
+  # Create mock wget
+  mock_wget=$(mock_create wget)
+  mock_set_output "${mock_wget}" "Downloaded successfully"
+
+  # Create isolated environment without curl
+  chroot_path=$(mock_chroot cat echo bash)
+  test_path=$(path_prefix "${chroot_path}" "$(path_rm /usr/bin "$(path_rm /bin)")")
+
+  # Run script in isolated environment
+  PATH="${test_path}" run ./download-script.sh "http://example.com/file"
+
+  assert_success
+  assert_output_contains "Downloaded successfully"
+  assert_equal 1 "$(mock_get_call_num "${mock_wget}")"
+}
+```
 
 ## Assertion functions
 

--- a/docs/content/mocking.mdx
+++ b/docs/content/mocking.mdx
@@ -120,6 +120,36 @@ Setup mock support. Call this function from your test's `setup()` method.
   mock_set_side_effect "${mock}" "echo 'side effect executed' > /tmp/log"
   ```
 
+### `path_prefix`
+
+- **Description**: Returns a PATH string with the mock directory prepended. This ensures mocked commands are found first.
+- **Arguments**:
+  - Path to mock/command/directory to prepend
+  - PATH to modify (optional) - Defaults to `$PATH` if not provided
+- **Outputs**: Modified PATH string
+- **Usage**:
+  ```bash
+  mock_wget=$(mock_create wget)
+  new_path=$(path_prefix "${mock_wget}")
+  PATH="${new_path}" run ./script.sh
+  ```
+
+### `path_rm`
+
+- **Description**: Returns a PATH string with a specific directory removed. Useful for testing command unavailability.
+- **Arguments**:
+  - Path or command to remove
+  - PATH to modify (optional) - Defaults to `$PATH` if not provided
+- **Outputs**: Modified PATH string
+- **Usage**:
+  ```bash
+  # Remove /usr/bin from PATH
+  new_path=$(path_rm /usr/bin)
+
+  # Remove directory containing curl
+  new_path=$(path_rm "$(command -v curl)")
+  ```
+
 ## Assertion functions
 
 ### `mock_get_call_args`

--- a/tests/mock.bats
+++ b/tests/mock.bats
@@ -78,14 +78,103 @@ load _test_helper
 }
 
 @test "Mock: BATS_MOCK_TMPDIR with spaces" {
+  # shellcheck disable=SC2030
   export BATS_MOCK_TMPDIR="/tmp/bats mock with spaces"
   mkdir -p "${BATS_MOCK_TMPDIR}"
   mock_curl=$(mock_command "curl")
 
-  PATH="${BATS_MOCK_TMPDIR}":$PATH run curl example.com
+  # We have to modify the PATH since the setup_mock uses a different BATS_MOCK_TMPDIR
+  PATH="$(path_prefix "${mock_curl}")" curl example.com
+  assert_equal 1 "$(mock_get_call_num "${mock_curl}")"
 
-  assert_success
   rm -rf "${BATS_MOCK_TMPDIR}"
+}
+
+# Tests for enhanced mock_create with command parameter
+@test "Mock: mock_create with command name" {
+  # Returns the newly created mock for 'wget' command
+  mock_wget=$(mock_create wget)
+
+  # Use the mocked 'wget'
+  # @note: setup_mock will have already prepended the mock directory to PATH
+  wget http://example.com/some-file
+  assert_equal 1 "$(mock_get_call_num "${mock_wget}")"
+}
+
+@test "Mock: mock_create without command (backward compatibility)" {
+  mock=$(mock_create)
+
+  ${mock} foo
+  assert_equal 1 "$(mock_get_call_num "${mock}")"
+  assert_equal "foo" "$(mock_get_call_args "${mock}")"
+}
+
+@test "Mock: mock_create names programs uniquely" {
+  mock1=$(mock_create)
+  mock2=$(mock_create)
+
+  test "${mock1}" != "${mock2}"
+}
+
+@test "Mock: mock_create command uses a directory unique to the test run" {
+  mock_wget=$(mock_create wget)
+
+  run dirname "${mock_wget}"
+  assert_success
+  # The directory should include the PID to avoid collisions with tests running
+  # in parallel.
+  assert_output_contains "bats-mock.$$.bin"
+}
+
+@test "Mock: mock_create creates program in BATS_MOCK_TMPDIR" {
+  mock=$(mock_create)
+  # shellcheck disable=SC2031
+  expected_dir="${BATS_MOCK_TMPDIR}"
+
+  run dirname "${mock}"
+  assert_success
+  assert_equal "${expected_dir}" "${output}"
+}
+
+@test "Mock: mock_create command with absolute path" {
+  absolute_path="${BATS_TMPDIR}/custom-path"
+  mkdir -p "${absolute_path}"
+
+  mock_foo=$(mock_create "${absolute_path}/foo")
+  assert_equal "${absolute_path}/foo" "${mock_foo}"
+
+  # Adjust PATH, otherwise foo is not found
+  PATH="$(path_prefix "${mock_foo}")" foo
+  assert_equal 1 "$(mock_get_call_num "${mock_foo}")"
+}
+
+@test "Mock: mock_create command twice with same name fails" {
+  mock_wget=$(mock_create wget)
+
+  run mock_create wget
+  assert_failure
+  # Error message may vary by OS. The most likely reason is that someone tried
+  # to mock an existing command.
+  # TODO: Improve error message to be more specific.
+  assert_output_contains "File exists"
+}
+
+@test "Mock: mock_create with absolute path to existing command fails" {
+  # Try to create a mock at an existing system command location
+  run mock_create /bin/ls
+  assert_failure
+  # Error message varies by OS: "File exists" on Linux, "Operation not permitted" on macOS
+}
+
+# Tests for teardown_mock
+@test "Mock: teardown_mock removes all mock files" {
+  mock1=$(mock_create)
+  mock2=$(mock_create curl)
+
+  teardown_mock
+
+  assert_file_not_exists "${mock1}"
+  assert_file_not_exists "${mock2}"
 }
 
 # Tests for path_prefix
@@ -132,7 +221,6 @@ load _test_helper
 @test "Mock: path_rm removes directory from PATH" {
   run path_rm "/usr/bin"
   assert_success
-  run echo "${output}"
   assert_output_not_contains ":/usr/bin:"
 }
 


### PR DESCRIPTION
Closes #106 

I split the implementation in 3 smaller commits.

* New Features
  * `mock_create` can accept an optional command name and returns either the mocked command or mock path. `mock_command` just forwards the call to `mock_create` with the provided command. 
  * Added `teardown_mock`, a one-step teardown to remove mock artifacts.
  * Added `mock_chroot` for deterministic test setup: chroot-style mock command directory.
  * Added `path_prefix` and `path_rm` PATH utilities to prepend or remove path segments..

* Bug fix:
  * `mock_command` also works when running tests in parallel. 

* Documentation
  * Added teardown and deterministic setup sections, examples, notes on named/unnamed mocks, PATH behavior, and integration guidance.

* Tests
  * Expanded coverage for mocks, teardown, PATH utilities, chroot setup, and integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-test isolated mock workspaces with unique mock naming
  * Added mock_chroot, path_prefix, and path_rm for deterministic mock PATH management
  * mock_create can accept optional command names; teardown_mock cleans up artifacts

* **Documentation**
  * Expanded guidance with deterministic test setup, command-fallback example, and usage/assertion updates

* **Tests**
  * New and updated tests covering isolation, PATH helpers, chroot behavior, teardown, and command-fallback scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->