### PR TITLE
Added 'normal' and 'lowest' dependency legs to the shell test matrix.

### DIFF
--- a/.github/workflows/test-shell.yml
+++ b/.github/workflows/test-shell.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install lowest dependencies
         if: matrix.deps == 'lowest'
-        run: npm install --no-save bats@1.11.0
+        run: npm install --no-save bats@1.10.0
 
       - name: Install Kcov
         if: matrix.os == 'ubuntu-latest' && matrix.deps == 'normal'

--- a/.github/workflows/test-shell.yml
+++ b/.github/workflows/test-shell.yml
@@ -18,6 +18,8 @@ on:
 
 env:
   BATS_LIB_PATH: "./node_modules"
+  # Oldest supported version, kept in sync with the "bats" range in package.json.
+  BATS_VERSION_LOWEST: "1.10.0"
 
 jobs:
   test-shell:
@@ -61,7 +63,7 @@ jobs:
 
       - name: Install lowest dependencies
         if: matrix.deps == 'lowest'
-        run: npm install --no-save bats@1.10.0
+        run: npm install --no-save "bats@${BATS_VERSION_LOWEST}"
 
       - name: Install Kcov
         if: matrix.os == 'ubuntu-latest' && matrix.deps == 'normal'

--- a/.github/workflows/test-shell.yml
+++ b/.github/workflows/test-shell.yml
@@ -21,7 +21,9 @@ env:
 
 jobs:
   test-shell:
+    name: ${{ matrix.os }}, Deps ${{ matrix.deps }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
@@ -29,6 +31,9 @@ jobs:
           - ubuntu-24.04
           - macos-14
           - macos-15
+        deps:
+          - normal
+          - lowest
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -46,15 +51,20 @@ jobs:
 
       - name: Setup sh-checker
         uses: luizm/action-sh-checker@v0.10.0
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.deps == 'normal'
         env:
           SHFMT_OPTS: -i 2 -ci -s -d
 
       - name: Install dependencies
+        if: matrix.deps == 'normal'
         run: npm install
 
+      - name: Install lowest dependencies
+        if: matrix.deps == 'lowest'
+        run: npm install --no-save bats@1.11.0
+
       - name: Install Kcov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.deps == 'normal'
         run: |
           KCOV_VERSION=v43 && \
           sudo apt update && \
@@ -67,21 +77,21 @@ jobs:
       - name: Config Git user for tests.
         run: git config --global user.name "Test user" && git config --global user.email "someone@example.com"
 
-      - name: Run tests
-        if: matrix.os == 'ubuntu-latest'
+      - name: Run tests with coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.deps == 'normal'
         run: kcov --clean --include-pattern=.bash --bash-parse-files-in-dir=. --exclude-path=node_modules,vendor,coverage "$(pwd)"/coverage ./node_modules/.bin/bats tests
         shell: bash
 
       - name: Upload coverage reports to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.deps == 'normal'
         uses: codecov/codecov-action@v7
         with:
           directory: ./coverage
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Run Tests on other OSes
-        if: matrix.os != 'ubuntu-latest'
+      - name: Run tests
+        if: matrix.os != 'ubuntu-latest' || matrix.deps != 'normal'
         run: ./node_modules/.bin/bats tests
         shell: bash
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ## Installation
 
-Requires [bats-core](https://github.com/bats-core/bats-core) `1.11` or newer.
+Requires [bats-core](https://github.com/bats-core/bats-core) `1.10` or newer.
 
 ### NPM
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
 
 ## Installation
 
+Requires [bats-core](https://github.com/bats-core/bats-core) `1.11` or newer.
+
 ### NPM
 
 ```shell

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "lint-fix": "shfmt -i 2 -ci -s -w src/*.bash load.bash tests/*.bats"
     },
     "dependencies": {
-        "bats": "^1.11"
+        "bats": "^1.10"
     },
     "keywords": [
         "bats",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "lint-fix": "shfmt -i 2 -ci -s -w src/*.bash load.bash tests/*.bats"
     },
     "dependencies": {
-        "bats": "^1"
+        "bats": "^1.11"
     },
     "keywords": [
         "bats",


### PR DESCRIPTION
## Summary

This PR adds a dependency-range testing axis to the shell test matrix so bats-helpers is verified against both the newest and the oldest supported version of bats-core. It also corrects the `bats` dependency range in `package.json` to match the version the suite actually requires, and documents that minimum in the README. The job-naming convention follows `AlexSkrypnyk/scaffold`'s `.github/workflows/test-php.yml`.

## Changes

- `.github/workflows/test-shell.yml`: added a `deps` matrix axis (`normal`, `lowest`) crossed with the existing 5-value `os` axis for 10 jobs total, with `fail-fast: false` and a job `name` of `${{ matrix.os }}, Deps ${{ matrix.deps }}`.
- The `normal` leg keeps `npm install`; the new `lowest` leg runs `npm install --no-save "bats@${BATS_VERSION_LOWEST}"` to pin the floor version without touching `package.json`.
- The floor version is declared once as a workflow-level `BATS_VERSION_LOWEST` env var, next to the existing `BATS_LIB_PATH`, so it is visible at the top of the config and changes in one place.
- The single-run steps (sh-checker, kcov install, coverage test run, Codecov upload) were narrowed from `matrix.os == 'ubuntu-latest'` to also require `matrix.deps == 'normal'`, so they still run exactly once across the 10-job matrix.
- The plain test-run step's condition became the exact complement, `matrix.os != 'ubuntu-latest' || matrix.deps != 'normal'`, so all 10 jobs run the suite exactly once between the two test steps.
- Two test steps were renamed to `Run tests with coverage` and `Run tests`, since the distinction between them is now coverage rather than OS.
- `package.json`: narrowed the `bats` dependency range from `^1` to `^1.10`. The old `^1` range was inaccurate: the suite cannot run at all on bats 1.0.0-1.1.0, fails 43 of 109 tests on 1.2.1-1.3.0 (`BATS_FILE_TMPDIR` was only added in bats 1.4.0), and fails one test on 1.5.0. `bats_load_library`, the only loading mechanism the README documents, was only added in bats 1.6.0.
- Version 1.10.0 (released 2023-07-15) is the oldest version kept in support, and it passes all 109 tests.
- `README.md`: documented the bats-core 1.10 minimum in the Installation section.
- Verified that the suite passes on bats 1.10.0 (the floor), 1.13.0 (current npm latest), and 1.14.0; no library source changes were needed.

Note for maintainers: adding the `deps` axis changes every check name, so the `main` ruleset's required status checks were updated from the five `test-shell (<os>)` contexts to the ten `<os>, Deps <deps>` contexts. Any future change to the matrix will require the same update.

## Before / After

```
Before
┌──────────────────────────────────────────────────┐
│ matrix: os only (5 values)                       │
│ -> 5 jobs, all running npm install               │
│                                                  │
│ package.json: "bats": "^1" (untested floor)      │
└──────────────────────────────────────────────────┘
         │
         v
After
┌──────────────────────────────────────────────────┐
│ env: BATS_VERSION_LOWEST: "1.10.0"               │
│                                                  │
│ matrix: os (5) x deps (2 values)                 │
│ -> 10 jobs, fail-fast: false                     │
│                                                  │
│ deps=normal -> npm install                       │
│ deps=lowest -> npm install bats@$BATS_VERSION_.. │
│                                                  │
│ package.json: "bats": "^1.10" (floor verified)   │
└──────────────────────────────────────────────────┘
```
