### PR TITLE
[#152] Added a deprecation helper for renamed public functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Starts with `- ` (minus followed by a space).
 
 A renamed function keeps working under its old name and announces its replacement:
 
-```
+```text
 # Deprecated: 'old_name' will be removed in the next version of bats-helpers. Use 'new_name' instead.
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
   - [Mocking](#mocking) - Command mocking
   - [Step Runner](#step-runner) - Sequential test assertions
   - [Helpers](#helpers) - Utility functions
+  - [Deprecations](#deprecations) - Notices for renamed functions
 - [Maintenance](#maintenance)
 
 ## Installation
@@ -349,12 +350,32 @@ Starts with `- ` (minus followed by a space).
 | `read_env`                | Reads .env file and evaluates variable expressions in that context            |
 | `format_error`            | Formats error messages with decorative borders and includes command output    |
 | `flunk`                   | Causes a test to fail with an optional error message                          |
+| `deprecated`              | Announces that a function was renamed, once per name per test run             |
 | `mktouch`                 | Creates a file and any necessary parent directories                           |
 | `fixture_export_codebase` | Export codebase source code at the latest commit to the destination directory |
 | `fixture_prepare_dir`     | Prepares a directory for fixture use by removing existing content             |
 | `random_string`           | Generates a random alphanumeric string of specified length                    |
 | `trim_file`               | Removes the last line from a file                                             |
 | `tui_run`                 | Runs a TUI script with predefined answers, simulating user input              |
+
+### Deprecations
+
+A renamed function keeps working under its old name and announces its replacement:
+
+```
+# Deprecated: 'old_name' will be removed in the next version of bats-helpers. Use 'new_name' instead.
+```
+
+The notice goes to file descriptor 3, which Bats leaves out of both `run` capture and command substitution, so it never appears in `${output}` and never corrupts a value returned through STDOUT. It is printed once per deprecated name per test run. Set `BATS_DEPRECATION_NOTICE_ENABLED=0` to silence it.
+
+Call `deprecated` to announce renames of your own helpers:
+
+```bash
+old_name() {
+  deprecated "old_name" "new_name"
+  new_name "$@"
+}
+```
 
 ## Acknowledgments
 

--- a/load.bash
+++ b/load.bash
@@ -7,6 +7,8 @@
 #
 # shellcheck disable=SC1090
 
+source "$(dirname "${BASH_SOURCE[0]}")/src/deprecation.bash"
+
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.base.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.string.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.command.bash"

--- a/src/deprecation.bash
+++ b/src/deprecation.bash
@@ -53,12 +53,12 @@ deprecated() {
     marker_dir="${BATS_SUITE_TMPDIR}/bats-helpers-deprecated"
     marker="${marker_dir}/${old_name//[^a-zA-Z0-9_.-]/_}"
 
+    # Creating a directory is atomic, so parallel jobs racing on the same name
+    # produce exactly one notice between them.
     if mkdir -p "${marker_dir}" 2>/dev/null; then
-      if [ -f "${marker}" ]; then
+      if ! mkdir "${marker}" 2>/dev/null; then
         return 0
       fi
-
-      : >"${marker}" 2>/dev/null || true
     fi
   fi
 

--- a/src/deprecation.bash
+++ b/src/deprecation.bash
@@ -29,8 +29,8 @@
 ##
 
 deprecated() {
-  local old_name="${1?'Deprecated name must be specified'}"
-  local new_name="${2?'Replacement name must be specified'}"
+  local old_name="${1:?'Deprecated name must be specified'}"
+  local new_name="${2:?'Replacement name must be specified'}"
 
   if [ "${BATS_DEPRECATION_NOTICE_ENABLED:-1}" != "1" ]; then
     return 0

--- a/src/deprecation.bash
+++ b/src/deprecation.bash
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# A Bats helper library for announcing deprecated functions.
+#
+
+##
+# Announce that a function has been renamed.
+#
+# The notice is printed once per deprecated name per test run, so a deprecated
+# function called in a loop does not flood the output.
+#
+# Arguments:
+#   1. old_name: The deprecated function name.
+#   2. new_name: The replacement function name.
+#
+# Global Variables:
+#   BATS_DEPRECATION_NOTICE_ENABLED: Set to '0' to suppress notices. Defaults to '1'.
+#   BATS_DEPRECATION_NOTICE_SEEN: Names already announced in the current shell.
+#
+# Outputs:
+#   FD3: The notice, when the descriptor is open.
+#   STDERR: The notice, when the descriptor is not open.
+#
+# Examples:
+#   assert_dir_contains_string() {
+#     deprecated "assert_dir_contains_string" "assert_dir_contains"
+#     assert_dir_contains "$@"
+#   }
+##
+
+deprecated() {
+  local old_name="${1?'Deprecated name must be specified'}"
+  local new_name="${2?'Replacement name must be specified'}"
+
+  if [ "${BATS_DEPRECATION_NOTICE_ENABLED:-1}" != "1" ]; then
+    return 0
+  fi
+
+  case " ${BATS_DEPRECATION_NOTICE_SEEN-} " in
+    *" ${old_name} "*) return 0 ;;
+  esac
+
+  BATS_DEPRECATION_NOTICE_SEEN="${BATS_DEPRECATION_NOTICE_SEEN-}${old_name} "
+
+  # Bats runs every test in its own subshell, so the variable above cannot
+  # carry a name across tests, while a marker file in the suite-wide temporary
+  # directory can. The directory is created and removed per run, which scopes
+  # the markers to exactly one run.
+  local marker_dir
+  local marker
+
+  if [ -n "${BATS_SUITE_TMPDIR-}" ]; then
+    marker_dir="${BATS_SUITE_TMPDIR}/bats-helpers-deprecated"
+    marker="${marker_dir}/${old_name//[^a-zA-Z0-9_.-]/_}"
+
+    if mkdir -p "${marker_dir}" 2>/dev/null; then
+      if [ -f "${marker}" ]; then
+        return 0
+      fi
+
+      : >"${marker}" 2>/dev/null || true
+    fi
+  fi
+
+  local message="# Deprecated: '${old_name}' will be removed in the next version of bats-helpers. Use '${new_name}' instead."
+
+  # Descriptor 3 is the only stream that Bats leaves out of both 'run' capture
+  # and command substitution, so functions returning a value through STDOUT
+  # keep returning it intact.
+  if { true >&3; } 2>/dev/null; then
+    echo "${message}" >&3
+    return 0
+  fi
+
+  echo "${message}" >&2
+
+  return 0
+}

--- a/tests/deprecation.bats
+++ b/tests/deprecation.bats
@@ -100,4 +100,10 @@ load _test_helper
 
   run bash -c "source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated 'old_incomplete'"
   assert_failure
+
+  run bash -c "source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated '' 'new_incomplete'"
+  assert_failure
+
+  run bash -c "source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated 'old_incomplete' ''"
+  assert_failure
 }

--- a/tests/deprecation.bats
+++ b/tests/deprecation.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+#
+# BATS tests for deprecation helpers.
+#
+# Every test uses a deprecated name of its own: notices are deduplicated for
+# the whole suite run, so a shared name would make one test silence another.
+#
+
+load _test_helper
+
+@test "Notice names both functions" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  deprecated "old_content" "new_content" 3>"${notice}"
+
+  assert_file_contains "${notice}" "old_content"
+  assert_file_contains "${notice}" "new_content"
+  assert_file_contains "${notice}" "will be removed in the next version of bats-helpers"
+}
+
+@test "Notice is not printed to stdout" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  captured="$(deprecated "old_stdout" "new_stdout" 3>"${notice}")"
+
+  assert_empty "${captured}"
+  assert_file_contains "${notice}" "old_stdout"
+}
+
+@test "Notice is printed once per name" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  deprecated "old_repeated" "new_repeated" 3>"${notice}"
+  deprecated "old_repeated" "new_repeated" 3>>"${notice}"
+  deprecated "old_repeated" "new_repeated" 3>>"${notice}"
+
+  assert_equal "1" "$(grep -c "old_repeated" "${notice}")"
+}
+
+@test "Notice is printed for every name" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  deprecated "old_first" "new_first" 3>"${notice}"
+  deprecated "old_second" "new_second" 3>>"${notice}"
+
+  assert_file_contains "${notice}" "old_first"
+  assert_file_contains "${notice}" "old_second"
+}
+
+@test "Notice is printed once across processes" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+  script="export BATS_SUITE_TMPDIR='${BATS_SUITE_TMPDIR}'; source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated 'old_shared' 'new_shared'"
+
+  bash -c "${script}" 3>"${notice}"
+  bash -c "${script}" 3>>"${notice}"
+
+  assert_equal "1" "$(grep -c "old_shared" "${notice}")"
+}
+
+@test "Notice is printed without a suite temporary directory" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+  script="unset BATS_SUITE_TMPDIR; source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated 'old_unshared' 'new_unshared'"
+
+  bash -c "${script}" 3>"${notice}"
+  bash -c "${script}" 3>>"${notice}"
+
+  assert_equal "2" "$(grep -c "old_unshared" "${notice}")"
+}
+
+@test "Notice is suppressed" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  BATS_DEPRECATION_NOTICE_ENABLED=0 deprecated "old_suppressed" "new_suppressed" 3>"${notice}"
+
+  assert_file_exists "${notice}"
+  assert_empty "$(cat "${notice}")"
+}
+
+@test "Notice falls back to stderr" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  deprecated "old_stderr" "new_stderr" 3>&- 2>"${notice}"
+
+  assert_file_contains "${notice}" "old_stderr"
+}
+
+@test "Notice does not alter the exit status" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  deprecated "old_status" "new_status" 3>"${notice}"
+  assert_equal "0" "$?"
+
+  deprecated "old_status" "new_status" 3>>"${notice}"
+  assert_equal "0" "$?"
+}
+
+@test "Notice requires both names" {
+  run bash -c "source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated"
+  assert_failure
+
+  run bash -c "source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated 'old_incomplete'"
+  assert_failure
+}

--- a/tests/deprecation.bats
+++ b/tests/deprecation.bats
@@ -49,20 +49,28 @@ load _test_helper
 
 @test "Notice is printed once across processes" {
   notice="${BATS_TEST_TMPDIR}/notice.txt"
-  script="export BATS_SUITE_TMPDIR='${BATS_SUITE_TMPDIR}'; source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated 'old_shared' 'new_shared'"
+  script="${BATS_TEST_TMPDIR}/shared.sh"
 
-  bash -c "${script}" 3>"${notice}"
-  bash -c "${script}" 3>>"${notice}"
+  echo "export BATS_SUITE_TMPDIR='${BATS_SUITE_TMPDIR}'" >"${script}"
+  echo "source '${BATS_TEST_DIRNAME}/../load.bash'" >>"${script}"
+  echo "deprecated 'old_shared' 'new_shared'" >>"${script}"
+
+  bash "${script}" 3>"${notice}"
+  bash "${script}" 3>>"${notice}"
 
   assert_equal "1" "$(grep -c "old_shared" "${notice}")"
 }
 
 @test "Notice is printed without a suite temporary directory" {
   notice="${BATS_TEST_TMPDIR}/notice.txt"
-  script="unset BATS_SUITE_TMPDIR; source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated 'old_unshared' 'new_unshared'"
+  script="${BATS_TEST_TMPDIR}/unshared.sh"
 
-  bash -c "${script}" 3>"${notice}"
-  bash -c "${script}" 3>>"${notice}"
+  echo "unset BATS_SUITE_TMPDIR" >"${script}"
+  echo "source '${BATS_TEST_DIRNAME}/../load.bash'" >>"${script}"
+  echo "deprecated 'old_unshared' 'new_unshared'" >>"${script}"
+
+  bash "${script}" 3>"${notice}"
+  bash "${script}" 3>>"${notice}"
 
   assert_equal "2" "$(grep -c "old_unshared" "${notice}")"
 }
@@ -95,15 +103,21 @@ load _test_helper
 }
 
 @test "Notice requires both names" {
-  run bash -c "source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated"
+  script="${BATS_TEST_TMPDIR}/incomplete.sh"
+
+  echo "source '${BATS_TEST_DIRNAME}/../load.bash'" >"${script}"
+  # shellcheck disable=SC2016
+  echo 'deprecated "${@}"' >>"${script}"
+
+  run bash "${script}"
   assert_failure
 
-  run bash -c "source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated 'old_incomplete'"
+  run bash "${script}" "old_incomplete"
   assert_failure
 
-  run bash -c "source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated '' 'new_incomplete'"
+  run bash "${script}" "" "new_incomplete"
   assert_failure
 
-  run bash -c "source '${BATS_TEST_DIRNAME}/../load.bash'; deprecated 'old_incomplete' ''"
+  run bash "${script}" "old_incomplete" ""
   assert_failure
 }


### PR DESCRIPTION
Closes #152

## Summary

Renaming any of bats-helpers' public functions is a breaking change for npm consumers, so issue #152 asks for a shared helper that lets a renamed function keep working under its old name while announcing the replacement. This PR adds that helper, `deprecated()`, along with its tests and documentation. No existing function is renamed here - this is only the mechanism future renames will call.

## Changes

- Added `src/deprecation.bash` with a `deprecated(old_name, new_name)` function that prints a one-line notice naming both and stating the old name will be removed in the next version of bats-helpers.
- The notice is written to file descriptor 3, the one stream Bats excludes from both `run` capture and command substitution, so it can never land in a consumer's `${output}` or corrupt a helper that returns its value via STDOUT (such as `random_string` or `mock_command`). Falls back to STDERR when FD 3 is not open.
- Notices are deduplicated once per deprecated name per test run, combining an in-shell variable with an atomically-created marker directory under `BATS_SUITE_TMPDIR`, since the variable alone cannot span the subshells Bats runs each test in.
- Added `BATS_DEPRECATION_NOTICE_ENABLED=0` to suppress notices; defaults to enabled.
- `deprecated()` always returns `0` on every path, so it cannot alter a caller's control flow under the `set -eu` that `src/steps.bash` puts into effect.
- Sourced `src/deprecation.bash` first in `load.bash`, ahead of the assertion modules.
- Added `tests/deprecation.bats` with 10 tests covering notice content, STDOUT purity, once-per-name deduplication, per-name independence, cross-process deduplication via the marker, the fallback when no suite directory exists, suppression, the STDERR fallback, exit status, and rejection of missing or empty names.
- Updated `README.md` with a `deprecated` row in the Helpers table, a new Deprecations section documenting the notice format and the environment variable, and a table-of-contents entry.

## Before / After

```text
BEFORE: renaming a public function breaks every consumer
┌────────────────────────────────────────────┐
│ old_name() is renamed or removed outright. │
│ Every consumer still calling old_name()    │
│ breaks, with no warning beforehand.        │
└────────────────────────────────────────────┘

AFTER: the old name aliases the new one
┌────────────────────────────────────┐
│ old_name() {                       │
│   deprecated "old_name" "new_name" │
│   new_name "$@"                    │
│ }                                  │
└────────────────────────────────────┘

Inside deprecated(), once per name per test run:

  deprecated(old, new)
    │
    ├─ already seen? ──yes──▶ return 0 (silent)
    │
    no
    │
    ▼
  print notice once
    │
    ├─ FD 3 open? ──yes──▶ write to FD 3 (skipped by `run` / `$(...)`)
    │
    no
    │
    ▼
  write to STDERR (fallback)
```
