### PR TITLE
[#154] Stopped five assertions when their precondition assertion fails.

### DIFF
--- a/src/assert.file.bash
+++ b/src/assert.file.bash
@@ -68,7 +68,7 @@ assert_dir_empty() {
 
 assert_dir_not_empty() {
   local dir="${1:-$(pwd)}"
-  assert_dir_exists "${dir}"
+  assert_dir_exists "${dir}" || return 1
 
   if [ "$(ls -A "${dir}")" ]; then
     return 0
@@ -105,7 +105,7 @@ assert_file_mode() {
   local file="${1}"
   local perm="${2}"
   local parsed
-  assert_file_exists "${file}"
+  assert_file_exists "${file}" || return 1
 
   if [ "$(uname)" = "Darwin" ]; then
     parsed=$(printf "%.3o\n" $(($(stat -f '0%Lp' "$file") & ~0022)))
@@ -123,7 +123,7 @@ assert_file_mode() {
 assert_file_contains() {
   local file="${1}"
   local string="${2}"
-  assert_file_exists "${file}"
+  assert_file_exists "${file}" || return 1
 
   local contents
   contents="$(cat "${file}")"

--- a/src/assert.git.bash
+++ b/src/assert.git.bash
@@ -68,7 +68,7 @@ assert_git_clean() {
   local dir="${1:-$(pwd)}"
   local message
 
-  assert_git_repo "${dir}"
+  assert_git_repo "${dir}" || return 1
 
   message="$(git --work-tree="${dir}" --git-dir="${dir}/.git" status)"
   assert_contains "nothing to commit" "${message}"
@@ -78,7 +78,7 @@ assert_git_not_clean() {
   local dir="${1:-$(pwd)}"
   local message
 
-  assert_git_repo "${dir}"
+  assert_git_repo "${dir}" || return 1
 
   message="$(git --work-tree="${dir}" --git-dir="${dir}/.git" status)"
   assert_not_contains "nothing to commit" "${message}"

--- a/tests/assert.file.bats
+++ b/tests/assert.file.bats
@@ -120,6 +120,11 @@ load _test_helper
   chmod 777 "${BATS_TEST_TMPDIR}/fixture_mode/1.txt"
   assert_file_mode "${BATS_TEST_TMPDIR}/fixture_mode/1.txt" "755"
 
+  run assert_file_mode "${BATS_TEST_TMPDIR}/fixture_mode/non_existing.txt" "644"
+  assert_failure
+  assert_output_contains "does not exist"
+  assert_output_not_contains "File permissions for file"
+
   run assert_file_mode "${BATS_TEST_TMPDIR}/fixture_mode/1.txt" "644"
   assert_failure
 }
@@ -131,6 +136,11 @@ load _test_helper
   echo "one more line of existing text" >>"${BATS_TEST_TMPDIR}/fixture_file_assert/1.txt"
 
   assert_file_contains "${BATS_TEST_TMPDIR}/fixture_file_assert/1.txt" "some existing text"
+
+  run assert_file_contains "${BATS_TEST_TMPDIR}/fixture_file_assert/non_existing.txt" "some existing text"
+  assert_failure
+  assert_output_contains "does not exist"
+  assert_output_not_contains "does not contain"
 
   run assert_file_contains "${BATS_TEST_TMPDIR}/fixture_file_assert/1.txt" "other non-existing text"
   assert_failure
@@ -172,10 +182,12 @@ load _test_helper
 
   assert_dir_not_empty "${BATS_TEST_TMPDIR}/fixture/dir2"
 
-  run assert_dir_not_empty "${BATS_TEST_TMPDIR}/fixture/dir1"
-  assert_failure
-
   run assert_dir_not_empty "${BATS_TEST_TMPDIR}/non_existing"
+  assert_failure
+  assert_output_contains "does not exist"
+  assert_output_not_contains "is empty, but should not be"
+
+  run assert_dir_not_empty "${BATS_TEST_TMPDIR}/fixture/dir1"
   assert_failure
 }
 

--- a/tests/assert.git.bats
+++ b/tests/assert.git.bats
@@ -45,10 +45,16 @@ load _test_helper
 
 @test "assert_git_clean" {
   fixture_prepare_dir "${BATS_TEST_TMPDIR}/fixture/git_repo"
+  fixture_prepare_dir "${BATS_TEST_TMPDIR}/fixture/not_git_repo"
   git --work-tree="${BATS_TEST_TMPDIR}/fixture/git_repo" --git-dir="${BATS_TEST_TMPDIR}/fixture/git_repo/.git" init >/dev/null
   assert_git_repo "${BATS_TEST_TMPDIR}/fixture/git_repo"
 
   assert_git_clean "${BATS_TEST_TMPDIR}/fixture/git_repo"
+
+  run assert_git_clean "${BATS_TEST_TMPDIR}/fixture/not_git_repo"
+  assert_failure
+  assert_output_contains "not a git repository"
+  assert_output_not_contains "nothing to commit"
 
   mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/uncommitted_file"
   run assert_git_clean "${BATS_TEST_TMPDIR}/fixture/git_repo"
@@ -65,8 +71,13 @@ load _test_helper
 
 @test "assert_git_not_clean" {
   fixture_prepare_dir "${BATS_TEST_TMPDIR}/fixture/git_repo"
+  fixture_prepare_dir "${BATS_TEST_TMPDIR}/fixture/not_git_repo"
   git --work-tree="${BATS_TEST_TMPDIR}/fixture/git_repo" --git-dir="${BATS_TEST_TMPDIR}/fixture/git_repo/.git" init >/dev/null
   assert_git_repo "${BATS_TEST_TMPDIR}/fixture/git_repo"
+
+  run assert_git_not_clean "${BATS_TEST_TMPDIR}/fixture/not_git_repo"
+  assert_failure
+  assert_output_contains "not a git repository"
 
   run assert_git_not_clean "${BATS_TEST_TMPDIR}/fixture/git_repo"
   assert_failure


### PR DESCRIPTION
Closes #154

## Summary

Five assertion functions called a precondition assertion (`assert_dir_exists`, `assert_file_exists`, or `assert_git_repo`) without checking its exit status, so a failed precondition let execution fall through into the function's own logic instead of stopping there. That produced a second, misleading error on top of the real one, and in `assert_git_not_clean` it went further: the function returned success for a directory that isn't a git repository at all. Each of the five calls now short-circuits with `|| return 1`, so a failed precondition stops the function immediately and reports a single, correct error. A failure-path test was added per function to lock this in.

## Changes

- `src/assert.file.bash`: added `|| return 1` after the precondition call in `assert_dir_not_empty` (`assert_dir_exists`), `assert_file_mode` (`assert_file_exists`), and `assert_file_contains` (`assert_file_exists`).
- `src/assert.git.bash`: added `|| return 1` after the `assert_git_repo` precondition call in `assert_git_clean` and `assert_git_not_clean`.
- `tests/assert.file.bats`: added a failure-path test for each of `assert_file_mode`, `assert_file_contains`, and `assert_dir_not_empty`, asserting the precondition's own error is shown and the function's follow-on error text is not.
- `tests/assert.git.bats`: added a failure-path test for each of `assert_git_clean` and `assert_git_not_clean` against a directory that is not a git repository, asserting the `not a git repository` error is shown.

Each new failure-path case is placed as the first `run` in its test, because `format_error` appends the previous `run`'s `$output` to its message, which would otherwise defeat the `assert_output_not_contains` check.

## Behaviour change

`assert_git_not_clean` previously returned exit status 0 for a directory that is not a git repository: after the discarded `assert_git_repo` failure, it ran `git status` against a non-repo, got empty output, grepped that output for `nothing to commit`, found no match, and treated "not found" as a pass. It now returns 1, matching `assert_git_clean` and every other assertion in the library.

## Out of scope

`src/fixture.bash` (`fixture_export_codebase`, lines 17-18) has the same unguarded-precondition shape (`assert_dir_exists "${dst}"` and `assert_git_repo "${src}"`), but it belongs to a different function family (fixture helpers, not assertions) and is gated behind `BATS_FIXTURE_EXPORT_CODEBASE_ENABLED`, so it was deliberately left out of this change and is worth a follow-up. `fixture_prepare_dir`'s `assert_dir_exists` call is unaffected either way, since it is already the last statement in the function and its exit status is already the function's return value.

`assert_file_not_contains` and `assert_dir_not_contains_string` keep their `[ ! -f "${file}" ] && return 0` shape, which passes vacuously when the target is absent. That is correct for a negative assertion and is not part of this change.

## Before / After

```
BEFORE: a failed precondition falls through

┌───────────────────────────────────────────────┐
│ assert_dir_not_empty "$dir"                   │
└─────────────────────┬─────────────────────────┘
                      ▼
┌───────────────────────────────────────────────┐
│ assert_dir_exists "$dir"  ->  status 1        │
└─────────────────────┬─────────────────────────┘
                      │ status discarded, no return
                      ▼
┌───────────────────────────────────────────────┐
│ ls -A "$dir"   <- runs anyway on missing dir  │
└─────────────────────┬─────────────────────────┘
                      ▼
        two errors: "does not exist"
        AND "is empty, but should not be"


┌───────────────────────────────────────────────┐
│ assert_git_not_clean "$dir"                   │
└─────────────────────┬─────────────────────────┘
                      ▼
┌───────────────────────────────────────────────┐
│ assert_git_repo "$dir"  ->  status 1          │
└─────────────────────┬─────────────────────────┘
                      │ status discarded, no return
                      ▼
┌───────────────────────────────────────────────┐
│ git status   <- runs on non-repo, empty text  │
└─────────────────────┬─────────────────────────┘
                      ▼
┌───────────────────────────────────────────────┐
│ assert_not_contains "nothing to commit" ...   │
│ grep finds nothing -> assertion PASSES        │
└─────────────────────┬─────────────────────────┘
                      ▼
               return 0  <- misleading pass


AFTER: a failed precondition stops the assertion

┌───────────────────────────────────────────────┐
│ assert_dir_not_empty "$dir"                   │
└─────────────────────┬─────────────────────────┘
                      ▼
┌───────────────────────────────────────────────┐
│ assert_dir_exists "$dir"  ->  status 1        │
└─────────────────────┬─────────────────────────┘
                      │ || return 1
                      ▼
               function exits here
        one error: "does not exist", return 1


┌───────────────────────────────────────────────┐
│ assert_git_not_clean "$dir"                   │
└─────────────────────┬─────────────────────────┘
                      ▼
┌───────────────────────────────────────────────┐
│ assert_git_repo "$dir"  ->  status 1          │
└─────────────────────┬─────────────────────────┘
                      │ || return 1
                      ▼
               function exits here
        one error: "not a git repository", return 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for missing files and directories, ensuring checks stop promptly and report the correct “does not exist” error.
  - Prevented misleading permission, content, or directory-state diagnostics when required paths are unavailable.
  - Git cleanliness checks now fail clearly when run outside a valid Git repository.

- **Tests**
  - Added coverage for missing paths and non-Git directories to verify accurate failures and diagnostic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
