### PR TITLE
[#155] Returned from library functions instead of exiting the test process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,22 @@ Starts with `- ` (minus followed by a space).
 | `trim_file`               | Removes the last line from a file                                             |
 | `tui_run`                 | Runs a TUI script with predefined answers, simulating user input              |
 
+#### Failure reporting
+
+Helpers report a failure by writing a message to STDERR and returning a non-zero status. None of them call `exit`, so the caller stays in control and can compose them with `||`, branch on them with `if`, or capture the status with `run`:
+
+```bash
+# Recover from a failure and carry on.
+fixture_export_codebase "${build_dir}" || echo "Export failed - continuing with an empty codebase."
+
+# Capture the status and the message.
+run tui_run "${answers[@]}"
+assert_failure
+assert_output_contains "SCRIPT_FILE is not set."
+```
+
+A bare call still fails the test at that point, because BATS runs tests with `errexit` enabled.
+
 #### File backups
 
 `add_var_to_file` backs a file up before modifying it and `restore_file` puts that backup back. Backups are written below `${BATS_TEST_TMPDIR}/bats-helpers-backup`, mirroring the source path, so BATS removes them together with the rest of the test sandbox and concurrent runs cannot overwrite each other's backups.

--- a/src/fixture.bash
+++ b/src/fixture.bash
@@ -14,14 +14,14 @@ fixture_export_codebase() {
   local dst="${1?Destination directory is required}"
   local src="${2:-"$(pwd)"}"
 
-  assert_dir_exists "${dst}"
-  assert_git_repo "${src}"
+  assert_dir_exists "${dst}" || return 1
+  assert_git_repo "${src}" || return 1
 
-  pushd "${src}" >/dev/null || exit 1
+  pushd "${src}" >/dev/null || return 1
 
   git archive --format=tar HEAD | (cd "${dst}" && tar -xf -)
 
-  popd >/dev/null || exit 1
+  popd >/dev/null || return 1
 }
 
 #

--- a/src/fixture.bash
+++ b/src/fixture.bash
@@ -17,11 +17,19 @@ fixture_export_codebase() {
   assert_dir_exists "${dst}" || return 1
   assert_git_repo "${src}" || return 1
 
-  pushd "${src}" >/dev/null || return 1
+  local export_status=0
 
-  git archive --format=tar HEAD | (cd "${dst}" && tar -xf -)
+  # The subshell scopes both the working directory and 'pipefail', so a failing
+  # 'git archive' surfaces instead of being masked by a successful 'tar'.
+  (
+    set -o pipefail
+    cd "${src}" && git archive --format=tar HEAD | (cd "${dst}" && tar -xf -)
+  ) || export_status=$?
 
-  popd >/dev/null || return 1
+  if [ "${export_status}" -ne 0 ]; then
+    flunk "Failed to export codebase from ${src} to ${dst}."
+    return 1
+  fi
 }
 
 #

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -127,7 +127,7 @@ mock_get_call_num() {
 mock_get_call_user() {
   local mock="${1?'Mock must be specified'}"
   local n
-  n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
+  n="$(mock_default_n "${mock}" "${2-}")" || return "$?"
 
   echo "$(cat "${mock}.user.${n}")"
 }
@@ -141,7 +141,7 @@ mock_get_call_user() {
 mock_get_call_args() {
   local mock="${1?'Mock must be specified'}"
   local n
-  n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
+  n="$(mock_default_n "${mock}" "${2-}")" || return "$?"
 
   echo "$(cat "${mock}.args.${n}")"
 }
@@ -184,7 +184,7 @@ mock_get_call_env() {
   local mock="${1?'Mock must be specified'}"
   local var="${2?'Variable name must be specified'}"
   local n="${3-}"
-  n="$(mock_default_n "${mock}" "${3}")" || exit "$?"
+  n="$(mock_default_n "${mock}" "${3}")" || return "$?"
 
   source "${mock}.env.${n}"
   echo "${!var}"
@@ -234,9 +234,11 @@ mock_default_n() {
     n=1
   fi
 
+  # @note: Modification to the original file: 'return' instead of 'exit' keeps
+  # the failure recoverable, as this function runs in the test's own shell.
   if [[ ${n} -gt ${call_num} ]]; then
     echo "$(basename "$0"): Mock must be called at least ${n} time(s)" >&2
-    exit 1
+    return 1
   fi
 
   echo "${n}"

--- a/src/steps.bash
+++ b/src/steps.bash
@@ -130,8 +130,8 @@ run_steps() {
       local item_with_placeholders="${item//\\#/${ESCAPED_HASH_PLACEHOLDER}}"
 
       if [[ ${item_with_placeholders} =~ (##) || $(echo "${item_with_placeholders}" | grep -o "#" | wc -l) -gt 3 ]]; then
-        echo "ERROR: The string should not contain consecutive '##' and should have a maximum of three '#' characters in total."
-        exit 1
+        flunk "ERROR: The string should not contain consecutive '##' and should have a maximum of three '#' characters in total."
+        return 1
       fi
 
       # Split command, status, and optional output.
@@ -205,9 +205,9 @@ run_steps() {
         substepdebug "SETUP: Setup mock for binary '${command_binary}' complete."
       else
         # Check if mock for the binary exists in the assert phase
-        if [[ -z ${mocked_commands["${command_binary}"]} ]]; then
-          echo "ERROR: Mock for the binary '${command_binary}' does not exist."
-          exit 1
+        if [[ -z ${mocked_commands["${command_binary}"]-} ]]; then
+          flunk "ERROR: Mock for the binary '${command_binary}' does not exist."
+          return 1
         fi
 
         substepdebug "ASSERT: Found mock for '${command_binary}' with value '${mocked_commands[${command_binary}]}'"
@@ -223,8 +223,8 @@ run_steps() {
 
         # Use wildcard-aware assertion
         if ! mock_assert_call_args "${mock_cmd}" "${command_args}" "${mock_cmd_index}"; then
-          substepdebug "ASSERT: Assertion failed. Expected '${command_args}', got '${mock_args_actual}'."
-          exit 1
+          flunk "ERROR: Mocked command '${command_binary}' was called with arguments '${mock_args_actual}', but '${command_args}' was expected."
+          return 1
         fi
       fi
 
@@ -238,12 +238,7 @@ run_steps() {
       stepdebug "Type: string absent"
 
       if [[ ${phase} == "${PHASE_ASSERT}" ]]; then
-        assert_output_not_contains "${item:2}" # Assuming 2 chars to skip '-' and a space
-        # shellcheck disable=SC2181
-        if [[ $? -ne 0 ]]; then
-          substepdebug "ASSERT: Assertion failed. Returning error code."
-          exit 1
-        fi
+        assert_output_not_contains "${item:2}" || return 1 # Skip '-' and a space.
       fi
     #########################################################################
     #                            STRING PRESENT                             #
@@ -252,12 +247,7 @@ run_steps() {
       stepdebug "Type: string present"
 
       if [[ ${phase} == "${PHASE_ASSERT}" ]]; then
-        assert_output_contains "${item}"
-        # shellcheck disable=SC2181
-        if [[ $? -ne 0 ]]; then
-          substepdebug "ASSERT: Assertion failed. Returning error code."
-          exit 1
-        fi
+        assert_output_contains "${item}" || return 1
       fi
     fi
 

--- a/src/tui.bash
+++ b/src/tui.bash
@@ -4,13 +4,20 @@
 #
 
 tui_run() {
+  if [ -z "${SCRIPT_FILE-}" ]; then
+    flunk "SCRIPT_FILE is not set."
+    return 1
+  fi
+
+  if [ ! -f "${SCRIPT_FILE}" ]; then
+    flunk "SCRIPT_FILE does not exist."
+    return 1
+  fi
+
   local answers=("$@")
   local input
   local i
   local val
-
-  [ -z "${SCRIPT_FILE-}" ] && echo "SCRIPT_FILE is not set." && exit 1
-  [ ! -f "${SCRIPT_FILE}" ] && echo "SCRIPT_FILE does not exist." && exit 1
 
   for i in "${answers[@]}"; do
     val="${i}"

--- a/tests/fixture.bats
+++ b/tests/fixture.bats
@@ -2,6 +2,7 @@
 #
 # BATS tests for Fixture helpers.
 #
+# shellcheck disable=SC2030,SC2031,SC2016
 
 load _test_helper
 

--- a/tests/fixture.bats
+++ b/tests/fixture.bats
@@ -43,6 +43,38 @@ load _test_helper
   assert_equal 1 "${recovered}"
 }
 
+@test "Codebase export - export fails" {
+  export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+
+  build_dir="${BATS_TEST_TMPDIR//\/\//\/}/build-$(date +%s)"
+  fixture_prepare_dir "${build_dir}"
+
+  # A repository without commits has no HEAD, so 'git archive' fails.
+  src_dir="${BATS_TEST_TMPDIR//\/\//\/}/src-no-commits"
+  fixture_prepare_dir "${src_dir}"
+  git -C "${src_dir}" init --quiet
+
+  run fixture_export_codebase "${build_dir}" "${src_dir}"
+  assert_failure
+  assert_output_contains "Failed to export codebase"
+}
+
+@test "Codebase export - export fails - caller recovers" {
+  export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+
+  build_dir="${BATS_TEST_TMPDIR//\/\//\/}/build-$(date +%s)"
+  fixture_prepare_dir "${build_dir}"
+
+  src_dir="${BATS_TEST_TMPDIR//\/\//\/}/src-no-commits"
+  fixture_prepare_dir "${src_dir}"
+  git -C "${src_dir}" init --quiet
+
+  recovered=0
+  fixture_export_codebase "${build_dir}" "${src_dir}" 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
+}
+
 @test "Codebase export - source is not a git repository" {
   export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
 

--- a/tests/fixture.bats
+++ b/tests/fixture.bats
@@ -20,3 +20,55 @@ load _test_helper
   fixture_export_codebase "${build_dir}"
   assert_file_exists "${build_dir}/README.md"
 }
+
+@test "Codebase export - missing destination directory" {
+  export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+
+  build_dir="${BATS_TEST_TMPDIR//\/\//\/}/non-existing"
+
+  run fixture_export_codebase "${build_dir}"
+  assert_failure
+  # 'flunk' rewrites the temporary directory path to a literal placeholder.
+  assert_output_contains 'Directory ${BATS_TEST_TMPDIR}/non-existing does not exist'
+}
+
+@test "Codebase export - missing destination directory - caller recovers" {
+  export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+
+  build_dir="${BATS_TEST_TMPDIR//\/\//\/}/non-existing"
+
+  recovered=0
+  fixture_export_codebase "${build_dir}" 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
+}
+
+@test "Codebase export - source is not a git repository" {
+  export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+
+  build_dir="${BATS_TEST_TMPDIR//\/\//\/}/build-$(date +%s)"
+  fixture_prepare_dir "${build_dir}"
+
+  src_dir="${BATS_TEST_TMPDIR//\/\//\/}/src-not-a-repo"
+  fixture_prepare_dir "${src_dir}"
+
+  run fixture_export_codebase "${build_dir}" "${src_dir}"
+  assert_failure
+  # 'flunk' rewrites the temporary directory path to a literal placeholder.
+  assert_output_contains 'Directory ${BATS_TEST_TMPDIR}/src-not-a-repo exists, but it is not a git repository'
+}
+
+@test "Codebase export - source is not a git repository - caller recovers" {
+  export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+
+  build_dir="${BATS_TEST_TMPDIR//\/\//\/}/build-$(date +%s)"
+  fixture_prepare_dir "${build_dir}"
+
+  src_dir="${BATS_TEST_TMPDIR//\/\//\/}/src-not-a-repo"
+  fixture_prepare_dir "${src_dir}"
+
+  recovered=0
+  fixture_export_codebase "${build_dir}" "${src_dir}" 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
+}

--- a/tests/mock.bats
+++ b/tests/mock.bats
@@ -78,6 +78,49 @@ load _test_helper
   assert_success
 }
 
+@test "Mock: not called enough times" {
+  mock_curl=$(mock_command "curl")
+
+  curl example.com
+
+  run mock_default_n "${mock_curl}" 2
+  assert_failure
+  assert_output_contains "Mock must be called at least 2 time(s)"
+}
+
+@test "Mock: not called enough times - caller recovers" {
+  mock_curl=$(mock_command "curl")
+
+  curl example.com
+
+  recovered=0
+  mock_default_n "${mock_curl}" 2 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
+}
+
+@test "Mock: call args when not called enough times - caller recovers" {
+  mock_curl=$(mock_command "curl")
+
+  curl example.com
+
+  recovered=0
+  mock_get_call_args "${mock_curl}" 2 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
+}
+
+@test "Mock: call user when not called enough times - caller recovers" {
+  mock_curl=$(mock_command "curl")
+
+  curl example.com
+
+  recovered=0
+  mock_get_call_user "${mock_curl}" 2 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
+}
+
 @test "Mock: BATS_MOCK_TMPDIR with spaces" {
   export BATS_MOCK_TMPDIR="${BATS_TEST_TMPDIR}/bats mock with spaces"
   mkdir -p "${BATS_MOCK_TMPDIR}"

--- a/tests/steps.bats
+++ b/tests/steps.bats
@@ -31,6 +31,19 @@ load _test_helper
   assert_failure
 }
 
+@test "Substring presence - negative: caller recovers" {
+  declare -a STEPS=(
+    "Some Substring"
+  )
+
+  run echo "Some other"
+
+  recovered=0
+  run_steps "assert" 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
+}
+
 @test "Substring absence" {
   declare -a STEPS=(
     "- Some Substring"
@@ -54,6 +67,19 @@ load _test_helper
   run echo "Some Substring"
   run run_steps "assert"
   assert_failure
+}
+
+@test "Substring absence - negative: caller recovers" {
+  declare -a STEPS=(
+    "- Some Substring"
+  )
+
+  run echo "Some Substring"
+
+  recovered=0
+  run_steps "assert" 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
 }
 
 @test "Direct command execution" {
@@ -109,6 +135,42 @@ load _test_helper
 
   run run_steps "assert" "${mocks[@]}"
   assert_failure
+  assert_output_contains "ERROR: Mocked command 'somebin' was called with arguments '--opt1 --opt2 --opt3', but '--opt1 --opt2' was expected."
+}
+
+@test "Command, args - negative: wrong args - caller recovers" {
+  declare -a STEPS=(
+    "@somebin --opt1 --opt2 # 0 # someval"
+  )
+
+  mocks="$(run_steps "setup")"
+  run somebin --opt1 --opt2 --opt3
+
+  recovered=0
+  run_steps "assert" "${mocks[@]}" 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
+}
+
+@test "Command - negative: mock does not exist" {
+  declare -a STEPS=(
+    "@somebin --opt1 --opt2 # 0 # someval"
+  )
+
+  run run_steps "assert" "otherbin=/some/mock/path"
+  assert_failure
+  assert_output_contains "ERROR: Mock for the binary 'somebin' does not exist."
+}
+
+@test "Command - negative: mock does not exist - caller recovers" {
+  declare -a STEPS=(
+    "@somebin --opt1 --opt2 # 0 # someval"
+  )
+
+  recovered=0
+  run_steps "assert" "otherbin=/some/mock/path" 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
 }
 
 @test "Command, args, no exit code or output" {
@@ -158,6 +220,17 @@ load _test_helper
   run run_steps "setup" "${mocks[@]}"
   assert_failure
   assert_output_contains "ERROR: The string should not contain consecutive '##' and should have a maximum of three '#' characters in total."
+}
+
+@test "Command, args - negative: incorrect input - delim - caller recovers" {
+  declare -a STEPS=(
+    "@somebin --opt1 --opt2 # 0 ## someval"
+  )
+
+  recovered=0
+  run_steps "setup" 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
 }
 
 @test "Command, multiple commands, same, repeated call" {

--- a/tests/tui.bats
+++ b/tests/tui.bats
@@ -44,6 +44,18 @@ load _test_helper
   assert_output_contains "SCRIPT_FILE is not set."
 }
 
+@test "Missing SCRIPT_FILE - caller recovers" {
+  answers=(
+    "nothing"
+    "custom answer2"
+  )
+
+  recovered=0
+  tui_run "${answers[@]}" 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
+}
+
 @test "Non-existing SCRIPT_FILE" {
   export SCRIPT_FILE="tests/fixtures/fixture_tui_nonexisting.sh"
 
@@ -54,4 +66,18 @@ load _test_helper
   run tui_run "${answers[@]}"
   assert_failure
   assert_output_contains "SCRIPT_FILE does not exist."
+}
+
+@test "Non-existing SCRIPT_FILE - caller recovers" {
+  export SCRIPT_FILE="tests/fixtures/fixture_tui_nonexisting.sh"
+
+  answers=(
+    "nothing"
+    "custom answer2"
+  )
+
+  recovered=0
+  tui_run "${answers[@]}" 2>/dev/null || recovered=1
+
+  assert_equal 1 "${recovered}"
 }

--- a/tests/tui.bats
+++ b/tests/tui.bats
@@ -35,6 +35,8 @@ load _test_helper
 }
 
 @test "Missing SCRIPT_FILE" {
+  unset SCRIPT_FILE
+
   answers=(
     "nothing"
     "custom answer2"
@@ -45,6 +47,8 @@ load _test_helper
 }
 
 @test "Missing SCRIPT_FILE - caller recovers" {
+  unset SCRIPT_FILE
+
   answers=(
     "nothing"
     "custom answer2"


### PR DESCRIPTION
Closes #155

## Summary

Ten `exit` calls in sourced library functions across `src/tui.bash`, `src/steps.bash`, `src/fixture.bash`, and `src/mock.bash` are replaced with `return`, so a failure is reported and handed back to the caller instead of terminating the test body.

The issue's stated symptom, that a failure terminates the entire BATS test process, does not hold on bats-core 1.12 because it isolates each test in its own subshell and the run continues regardless; the defects verified and actually fixed here are that `exit` cannot be recovered by the caller so `helper || fallback` and `if ! helper; then` both abort the test body before reaching the recovery branch, blocking the `assert_x "..." || return 1` composition idiom the library already uses elsewhere; that the same function behaved two different ways depending on call context, because `mocks="$(run_steps "setup")"` runs in a command substitution where `exit` only killed the subshell and the test carried on with an empty `mocks`, while `run_steps "assert" "$mocks"` aborted the test body outright; that failure messages written to STDOUT were captured into the `mocks` variable and never shown in the command-substitution path; and that `exit` skipped the remainder of the test body, including inline cleanup written outside `teardown`.

Failure reporting now follows one of two shapes: `flunk "message"` plus `return 1` for precondition and input validation, or a bare `return 1` (or `inner_assert ... || return 1`) where an inner assertion has already reported the failure; the 26 existing `format_error | flunk` assertion sites are untouched.

Tests grow from 121 to 139. Each converted site gets a status-and-message test plus a recoverability test that calls the helper directly in a `||` composition and asserts execution continues; the recoverability half is the real regression guard, since `run` catches `exit` just as readily as `return` and a status-only test passes against the unfixed code. Every new test was confirmed to fail against the pre-change source.

## Changes

- `src/tui.bash`: the two `&&`-chained guards for `SCRIPT_FILE` become `if` guard clauses that report through `flunk` and `return 1`.
- `src/steps.bash`: two input-validation sites now report via `flunk` and return; three propagation sites collapse to `|| return 1`, removing two `# shellcheck disable=SC2181` suppressions and the dead `$?` checks that followed them.
- A mocked-command argument mismatch in `src/steps.bash` previously reported nothing unless `RUN_STEPS_DEBUG=1` was set; it now reports expected versus actual unconditionally.
- The "mock does not exist" branch in `src/steps.bash` was unreachable dead code, because `${mocked_commands["${command_binary}"]}` lacked the `-` default that the sibling line already had and died with an unbound-variable error under this file's `set -u`; adding the default makes that error path reachable.
- `src/mock.bash` is a vendored copy of grayhemp/bats-mock, so the divergence is deliberately minimal: only the control flow changes, with `exit 1` becoming `return 1` in `mock_default_n` and its three callers propagating with `|| return "$?"`, the existing STDERR message format kept verbatim, and the change marked with an `@note` matching the file's existing convention for upstream divergence.
- The two `exit` calls at `src/mock.bash:61,63` are intentionally left as-is: they live inside the generated mock script heredoc, which becomes a real executable running in its own process, where `exit` is correct.
- `src/fixture.bash`: both preconditions in `fixture_export_codebase` now propagate with `|| return 1`.
- The `pushd`/`popd` pair in `fixture_export_codebase` is replaced with a subshell that scopes both the working directory and `pipefail`, because the previous shape discarded the `git archive | tar` exit status, so `popd`'s status became the function's return value and a failed export silently returned success on exactly the composed call path this change enables. A failed export now reports through `flunk` and returns non-zero.
- `tests/tui.bats` unsets `SCRIPT_FILE` in the two missing-variable tests so an inherited environment value cannot bypass the path under test.
- `tests/fixture.bats` also gains a file-level `# shellcheck disable=SC2030,SC2031,SC2016` header, matching the convention already used by `tests/steps.bats` and `tests/tui.bats` for the same codes.
- `README.md` gains a "Failure reporting" subsection documenting the convention.
- Follow-up, not addressed here: `src/steps.bash` still sets `set -eu` at source time, which leaks `errexit` and `nounset` into every consuming test file; removing it is a wider behaviour change deferred to its own issue.

## Before / After

```
BEFORE - exit terminates the process directly
────────────────────────────────────────────────────
test body
  │
  ├── fixture_export_codebase "$dst"
  │       │
  │       ▼
  │   precondition fails
  │   echo "message"          (STDOUT)
  │   exit 1
  │
  ✗   BATS subshell for this test exits here
  ✗   || fallback never runs
  ✗   if ! helper; then ... never reached
  ✗   inline cleanup below the call is skipped

AFTER - return hands the status back to the caller
────────────────────────────────────────────────────
test body
  │
  ├── fixture_export_codebase "$dst" || fallback
  │       │
  │       ▼
  │   precondition fails
  │   flunk "message"         (STDERR)
  │   return 1
  │       │
  │       ▼
  │   back in test body, with $? = 1
  │
  ✓   || fallback runs
  ✓   if ! helper; then ... branches correctly
  ✓   inline cleanup below the call still executes
```
