### PR TITLE
[#157] Renamed the string contains assertions to take the haystack first.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   - [Mocking](#mocking) - Command mocking
   - [Step Runner](#step-runner) - Sequential test assertions
   - [Helpers](#helpers) - Utility functions
-  - [Deprecations](#deprecations) - Renamed functions
+  - [Deprecations](#deprecations) - Renamed and reordered functions
 - [Maintenance](#maintenance)
 
 ## Installation
@@ -97,13 +97,21 @@ Use these after running a command with `run`.
 
 #### String assertions
 
-| Function Name         | Description                                        |
-|-----------------------|----------------------------------------------------|
-| `assert_empty`        | Asserts that a string is empty                     |
-| `assert_not_empty`    | Asserts that a string is not empty                 |
-| `assert_equal`        | Asserts that two strings are equal                 |
-| `assert_contains`     | Asserts that a string contains a given substring   |
-| `assert_not_contains` | Asserts that a string does not contain a substring |
+| Function Name                | Description                                        |
+|------------------------------|----------------------------------------------------|
+| `assert_empty`               | Asserts that a string is empty                     |
+| `assert_not_empty`           | Asserts that a string is not empty                 |
+| `assert_equal`               | Asserts that two strings are equal                 |
+| `assert_string_contains`     | Asserts that a string contains a given substring   |
+| `assert_string_not_contains` | Asserts that a string does not contain a substring |
+
+Every `contains` assertion takes the container first and the string to look for second:
+
+```bash
+assert_string_contains "some needle in a haystack" "needle"
+assert_file_contains "${file}" "needle"
+assert_dir_contains_string "${dir}" "needle"
+```
 
 #### File assertions
 
@@ -394,11 +402,21 @@ assert_file_exists "$(file_backup_path "${BATS_TEST_TMPDIR}/.env")"
 
 These names still work, but print a notice on every call and are removed in the next version:
 
-| Deprecated                       | Use instead                   |
-|----------------------------------|-------------------------------|
-| `assert_not_git_repo`            | `assert_git_not_repo`         |
-| `assert_git_file_is_tracked`     | `assert_git_file_tracked`     |
-| `assert_git_file_is_not_tracked` | `assert_git_file_not_tracked` |
+| Deprecated                       | Use instead                    |
+|----------------------------------|--------------------------------|
+| `assert_not_git_repo`            | `assert_git_not_repo`          |
+| `assert_git_file_is_tracked`     | `assert_git_file_tracked`      |
+| `assert_git_file_is_not_tracked` | `assert_git_file_not_tracked`  |
+| `assert_contains`                | `assert_string_contains`       |
+| `assert_not_contains`            | `assert_string_not_contains`   |
+
+`assert_contains` and `assert_not_contains` take the needle first, while their replacements take the haystack first, so a call has to swap its arguments as well as change its name:
+
+```bash
+assert_contains "needle" "some needle in a haystack"
+
+assert_string_contains "some needle in a haystack" "needle"
+```
 
 The notice is written to file descriptor 3, so it shows up in the BATS output without being captured by `run` or by command substitution:
 

--- a/src/assert.command.bash
+++ b/src/assert.command.bash
@@ -41,7 +41,7 @@ assert_output_contains() {
     expected="${1}"
   fi
   # shellcheck disable=SC2154
-  assert_contains "${expected}" "${output-}"
+  assert_string_contains "${output-}" "${expected}"
 }
 
 assert_output_not_contains() {
@@ -52,5 +52,5 @@ assert_output_not_contains() {
     expected="${1}"
   fi
   # shellcheck disable=SC2154
-  assert_not_contains "${expected}" "${output-}"
+  assert_string_not_contains "${output-}" "${expected}"
 }

--- a/src/assert.file.bash
+++ b/src/assert.file.bash
@@ -127,7 +127,7 @@ assert_file_contains() {
 
   local contents
   contents="$(cat "${file}")"
-  assert_contains "${string}" "${contents}"
+  assert_string_contains "${contents}" "${string}"
 }
 
 assert_file_not_contains() {
@@ -138,7 +138,7 @@ assert_file_not_contains() {
 
   local contents
   contents="$(cat "${file}")"
-  assert_not_contains "${string}" "${contents}"
+  assert_string_not_contains "${contents}" "${string}"
 }
 
 assert_dir_contains_string() {

--- a/src/assert.git.bash
+++ b/src/assert.git.bash
@@ -71,7 +71,7 @@ assert_git_clean() {
   assert_git_repo "${dir}" || return 1
 
   message="$(git --work-tree="${dir}" --git-dir="${dir}/.git" status)"
-  assert_contains "nothing to commit" "${message}"
+  assert_string_contains "${message}" "nothing to commit"
 }
 
 assert_git_not_clean() {
@@ -81,7 +81,7 @@ assert_git_not_clean() {
   assert_git_repo "${dir}" || return 1
 
   message="$(git --work-tree="${dir}" --git-dir="${dir}/.git" status)"
-  assert_not_contains "nothing to commit" "${message}"
+  assert_string_not_contains "${message}" "nothing to commit"
 }
 
 ##

--- a/src/assert.string.bash
+++ b/src/assert.string.bash
@@ -20,9 +20,9 @@ assert_not_empty() {
   fi
 }
 
-assert_contains() {
-  local needle="${1}"
-  local haystack="${2}"
+assert_string_contains() {
+  local haystack="${1}"
+  local needle="${2}"
 
   if echo "${haystack}" | $(type -p grep | head -1) -i -F -- "${needle}" >/dev/null; then
     return 0
@@ -31,9 +31,9 @@ assert_contains() {
   fi
 }
 
-assert_not_contains() {
-  local needle="${1}"
-  local haystack="${2}"
+assert_string_not_contains() {
+  local haystack="${1}"
+  local needle="${2}"
 
   if echo "${haystack}" | $(type -p grep | head -1) -i -F -- "${needle}" >/dev/null; then
     format_error "String '${haystack}' contains '${needle}', but should not" | flunk
@@ -57,4 +57,18 @@ random_string() {
   # shellcheck disable=SC2002
   ret=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w "${len}" | head -n 1)
   echo "${ret}"
+}
+
+##
+# Deprecated aliases, removed in the next version.
+##
+
+assert_contains() {
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_contains' will be removed in the next version. Use 'assert_string_contains' instead." >&3
+  assert_string_contains "${2-}" "${1-}"
+}
+
+assert_not_contains() {
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_not_contains' will be removed in the next version. Use 'assert_string_not_contains' instead." >&3
+  assert_string_not_contains "${2-}" "${1-}"
 }

--- a/tests/assert.string.bats
+++ b/tests/assert.string.bats
@@ -8,21 +8,21 @@
 
 load _test_helper
 
-@test "assert_contains" {
-  assert_contains "needle" "some needle in a haystack"
-  assert_contains "n[ee]dle" "some n[ee]dle in a haystack"
+@test "assert_string_contains" {
+  assert_string_contains "some needle in a haystack" "needle"
+  assert_string_contains "some n[ee]dle in a haystack" "n[ee]dle"
 
-  run assert_contains "needle" "some ne edle in a haystack"
+  run assert_string_contains "some ne edle in a haystack" "needle"
   assert_failure
 }
 
-@test "assert_not_contains" {
-  assert_not_contains "otherneedle" "some needle in a haystack"
-  assert_not_contains "othern[ee]dle" "some n[ee]dle in a haystack"
+@test "assert_string_not_contains" {
+  assert_string_not_contains "some needle in a haystack" "otherneedle"
+  assert_string_not_contains "some n[ee]dle in a haystack" "othern[ee]dle"
 
-  run assert_not_contains "needle" "some needle in a haystack"
+  run assert_string_not_contains "some needle in a haystack" "needle"
   assert_failure
-  run assert_not_contains "n[ee]dle" "some n[ee]dle in a haystack"
+  run assert_string_not_contains "some n[ee]dle in a haystack" "n[ee]dle"
   assert_failure
 }
 
@@ -44,5 +44,34 @@ load _test_helper
   assert_not_empty "something"
 
   run assert_not_empty ""
+  assert_failure
+}
+
+##
+# Deprecated aliases.
+#
+# The calls below pass the needle first, so they fail if the alias stops
+# reversing its arguments before forwarding.
+##
+
+@test "assert_contains" {
+  export BATS_HELPERS_DEPRECATION_QUIET=1
+
+  assert_contains "needle" "some needle in a haystack"
+  assert_contains "n[ee]dle" "some n[ee]dle in a haystack"
+
+  run assert_contains "needle" "some ne edle in a haystack"
+  assert_failure
+}
+
+@test "assert_not_contains" {
+  export BATS_HELPERS_DEPRECATION_QUIET=1
+
+  assert_not_contains "otherneedle" "some needle in a haystack"
+  assert_not_contains "othern[ee]dle" "some n[ee]dle in a haystack"
+
+  run assert_not_contains "needle" "some needle in a haystack"
+  assert_failure
+  run assert_not_contains "n[ee]dle" "some n[ee]dle in a haystack"
   assert_failure
 }

--- a/tests/assert.string.bats
+++ b/tests/assert.string.bats
@@ -55,8 +55,6 @@ load _test_helper
 ##
 
 @test "assert_contains" {
-  export BATS_HELPERS_DEPRECATION_QUIET=1
-
   assert_contains "needle" "some needle in a haystack"
   assert_contains "n[ee]dle" "some n[ee]dle in a haystack"
 
@@ -65,8 +63,6 @@ load _test_helper
 }
 
 @test "assert_not_contains" {
-  export BATS_HELPERS_DEPRECATION_QUIET=1
-
   assert_not_contains "otherneedle" "some needle in a haystack"
   assert_not_contains "othern[ee]dle" "some n[ee]dle in a haystack"
 

--- a/tests/deprecation.bats
+++ b/tests/deprecation.bats
@@ -43,6 +43,42 @@ load _test_helper
   assert_file_contains "${notice}" "Deprecated: 'assert_git_file_is_not_tracked' will be removed in the next version. Use 'assert_git_file_not_tracked' instead."
 }
 
+@test "assert_contains" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  assert_contains "needle" "some needle in a haystack" 3>"${notice}"
+
+  assert_file_contains "${notice}" "Deprecated: 'assert_contains' will be removed in the next version. Use 'assert_string_contains' instead."
+}
+
+@test "assert_not_contains" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  assert_not_contains "otherneedle" "some needle in a haystack" 3>"${notice}"
+
+  assert_file_contains "${notice}" "Deprecated: 'assert_not_contains' will be removed in the next version. Use 'assert_string_not_contains' instead."
+}
+
+@test "Assertions calling other assertions emit no notices" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+  fixture_prepare_dir "${BATS_TEST_TMPDIR}/fixture/git_repo"
+  git --work-tree="${BATS_TEST_TMPDIR}/fixture/git_repo" --git-dir="${BATS_TEST_TMPDIR}/fixture/git_repo/.git" init >/dev/null
+  echo "some needle in a haystack" >"${BATS_TEST_TMPDIR}/haystack.txt"
+
+  assert_file_contains "${BATS_TEST_TMPDIR}/haystack.txt" "needle" 3>"${notice}"
+  assert_file_not_contains "${BATS_TEST_TMPDIR}/haystack.txt" "otherneedle" 3>>"${notice}"
+  assert_git_clean "${BATS_TEST_TMPDIR}/fixture/git_repo" 3>>"${notice}"
+  mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/uncommitted_file"
+  assert_git_not_clean "${BATS_TEST_TMPDIR}/fixture/git_repo" 3>>"${notice}"
+
+  run echo "some needle in a haystack"
+  assert_output_contains "needle" 3>>"${notice}"
+  assert_output_not_contains "otherneedle" 3>>"${notice}"
+
+  assert_file_exists "${notice}"
+  assert_empty "$(cat "${notice}")"
+}
+
 @test "Notices are silenced" {
   notice="${BATS_TEST_TMPDIR}/notice.txt"
   export BATS_HELPERS_DEPRECATION_QUIET=1


### PR DESCRIPTION
Closes #157

## Summary

The `contains` assertion family disagreed on argument order: `assert_contains` and `assert_not_contains` took `<needle> <haystack>`, while `assert_file_contains`, `assert_dir_contains_string`, and the rest of the family took the container first. This change renames `assert_contains` to `assert_string_contains` and `assert_not_contains` to `assert_string_not_contains`, both now taking `<haystack> <needle>`, so every `contains` assertion in the library shares the same argument order. The old names remain as deprecated aliases that swap their arguments before forwarding to the renamed functions and print a notice on file descriptor 3 through the existing deprecation mechanism.

Argument order cannot be deprecated the way a name can. Swapping two plain strings produces no error, no warning and no type mismatch, so a consumer who renames a call without also swapping its arguments silently inverts it - and in the negative variants that turns a real assertion into a vacuous one that passes while testing nothing. That is why the order change rides on a rename rather than mutating an existing signature: the old name keeps its old order, and the new name is the only way to get the new one.

## Changes

**Renamed assertions**
- `assert_contains` renamed to `assert_string_contains`, and `assert_not_contains` renamed to `assert_string_not_contains`, in `src/assert.string.bash`; both now take `<haystack> <needle>` instead of `<needle> <haystack>`. The matching implementation is otherwise unchanged.

**Deprecated aliases**
- `assert_contains` and `assert_not_contains` remain in `src/assert.string.bash` as aliases that swap their two arguments and forward to the renamed functions, printing a deprecation notice on file descriptor 3 (silenced by `BATS_HELPERS_DEPRECATION_QUIET`), reusing the library's existing deprecation mechanism.

**Migrated call sites**
- All six first-party callers now use the new names and pass the container first: `assert_output_contains` and `assert_output_not_contains` in `src/assert.command.bash`, `assert_file_contains` and `assert_file_not_contains` in `src/assert.file.bash`, and `assert_git_clean` and `assert_git_not_clean` in `src/assert.git.bash`. Without this the library would emit deprecation notices at consumers for calls they never wrote.

**Tests**
- `tests/assert.string.bats` adds coverage for `assert_string_contains` and `assert_string_not_contains` under the new argument order, and keeps the old-name tests (needle first) in place. Those retained tests are what verifies the aliases still reverse their arguments: they were confirmed to fail when the swap is deliberately removed, including the negative case where a missing swap would otherwise let a vacuous assertion pass.
- `tests/deprecation.bats` adds notice tests for both deprecated aliases, plus a regression test confirming that assertions calling other assertions internally emit no deprecation notice on file descriptor 3. That test was likewise confirmed to fail when an internal call is pointed back at a deprecated name.

**Documentation**
- `README.md` updates the string assertions table with the new names, documents the container-first convention with an example, and adds the two renamed functions to the deprecations table along with an example showing the required argument swap. The swap is documented here because the deprecation notice itself keeps the same wording as every other notice in the library.

## Before / After

```
BEFORE - the string assertions were the odd ones out
┌────────────────────────────────────────────────────────────────────────────┐
│ assert_contains(needle, haystack)              <-- needle first            │
│ assert_not_contains(needle, haystack)          <-- needle first            │
│                                                                            │
│ assert_file_contains(file, string)                 container first         │
│ assert_file_not_contains(file, string)             container first         │
│ assert_dir_contains_string(dir, string)            container first         │
│ assert_dir_not_contains_string(dir, string)        container first         │
└────────────────────────────────────────────────────────────────────────────┘

AFTER - container first everywhere
┌────────────────────────────────────────────────────────────────────────────┐
│ assert_string_contains(haystack, needle)           container first         │
│ assert_string_not_contains(haystack, needle)       container first         │
│                                                                            │
│ assert_file_contains(file, string)                 container first         │
│ assert_file_not_contains(file, string)             container first         │
│ assert_dir_contains_string(dir, string)            container first         │
│ assert_dir_not_contains_string(dir, string)        container first         │
└────────────────────────────────────────────────────────────────────────────┘

The deprecated aliases keep existing call sites working by swapping before forwarding:

    assert_contains("needle", "haystack")
              │
              ▼  print notice on fd 3, swap arguments, forward
    assert_string_contains("haystack", "needle")
```
