### PR TITLE
[#161] Aligned file headers and function documentation across modules.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,55 @@ Failure messages are what a consumer reads when their test breaks, so they follo
 - **State the actual fact, and append an expectation clause only when the fact alone does not convey it.** A positive assertion states the negated fact with no clause (`Directory '${dir}' is not empty`); a negative assertion states the positive fact plus a clause (`Directory '${dir}' is empty, but should not be`). Use the terse `, but should not` after a plain verb and `, but should not be` after a copula when the expectation is simply the negation; name the expectation outright whenever that is clearer (`Regular file '${file}' exists, but should be a symlink`, `Command succeeded, but should have failed`).
 - **Punctuate by message kind**: assertion failures routed through `format_error` take no trailing full stop; validation and runtime errors raised by a direct `flunk` call read as sentences and end with one; `Key: value` summary labels take neither.
 
+### Documentation Style
+File headers and function docblocks follow one house style so the library reads as one project. `src/mock.bash` is exempt from the function docblock rules for the same reason it is exempt from the failure message style: its docblocks are upstream grayhemp/bats-mock text, and restyling them widens the divergence from upstream. Its file header is not upstream text and does follow the rule below.
+
+- **File headers**: every `.bash` file opens with the `@file` shape. `.bats` files use the plain shape without `@file`. A file-level `shellcheck disable` follows the header, separated by a blank comment line.
+
+```bash
+#!/usr/bin/env bash
+##
+# @file
+# Assertions for files and directories.
+#
+```
+
+```bash
+#!/usr/bin/env bats
+#
+# Tests for file and directory assertions.
+#
+```
+
+- **Describe what the file holds**, specifically enough to tell it apart from its siblings. `Assertions for strings.` not `Bats test helpers.`
+- **Test file headers** read `Tests for <subject>.`, with the subject lowercase unless it is an acronym: `Tests for git assertions.`, `Tests for TUI helpers.`
+- **Function docblocks** are `##`-fenced, open with a third-person summary ending in a full stop, and carry only the sections that add something. `Arguments:` whenever the function takes any, `Globals:` whenever it reads or writes one, `Outputs:` when STDOUT is the result, and `Returns:` only where the return semantics differ from the library norm of "zero, or non-zero via `flunk`". Argument entries are numbered `1. name: Description.`
+
+```bash
+##
+# Asserts that a directory contains a string.
+#
+# Arguments:
+#   1. dir: Directory to search.
+#   2. string: String to search for.
+#
+# Globals:
+#   ASSERT_DIR_EXCLUDE: Additional directory names to exclude from the search.
+##
+```
+
+- **Deprecated aliases take no docblock.** The group banner above them and the notice each one prints already name the replacement.
+- **Section banners** inside a long function are three lines at the indent of the code they introduce, with a sentence-case title ending in a full stop:
+
+```bash
+  ##
+  ## Input validation.
+  ##
+```
+
+- **Punctuate comments as sentences.** A comment that is a sentence ends with a full stop; a `Key: value` label takes neither a capital nor a stop.
+- **Coverage markers** pair `# LCOV_EXCL_START` with `# LCOV_EXCL_STOP`. Those are the markers kcov recognises - `LCOV_EXCL_END` is silently ignored, leaving the region open to end of file.
+
 ### Mocking System
 The mocking system creates temporary mock executables that record calls and can return configured outputs/exit codes.
 
@@ -95,6 +144,7 @@ Side effects are Bash code executed when the mock is called, useful for file cre
 - Test files follow BATS naming convention (*.bats)
 - Coverage reports are generated in the `coverage/` directory
 - The library includes comprehensive test coverage for all helper functions
+- Every assertion is tested for both its positive and its negative behaviour, in one `@test` per assertion
 
 ### Assertion Call Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ File headers and function docblocks follow one house style so the library reads 
 # @file
 # Assertions for files and directories.
 #
+# shellcheck disable=SC2119,SC2120
 ```
 
 ```bash

--- a/load.bash
+++ b/load.bash
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 ##
-# Helpers and assertions for BATS testing.
+# @file
+# Central loading point for all helpers and assertions.
 #
-# Central loading point for all the helpers and assertions.
 # @see https://bats-core.readthedocs.io/en/stable/writing-tests.html#bats-load-library-load-system-wide-libraries
 #
 # shellcheck disable=SC1090

--- a/src/assert.base.bash
+++ b/src/assert.base.bash
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
 ##
 # @file
-# Bats test helpers.
+# Failure reporting and error message formatting.
 #
 
+##
+# Fails the test with a message.
+#
+# Arguments:
+#   1. message: Message to print. Optional, read from STDIN when omitted.
+#
+# Outputs:
+#   STDERR: The message, with occurrences of the test temporary directory path
+#           replaced by the variable name so that messages stay comparable
+#           between runs.
+#
+# Returns:
+#   1 always.
+##
 flunk() {
   {
     if [ "$#" -eq 0 ]; then
@@ -15,7 +29,18 @@ flunk() {
   return 1
 }
 
-# Format error message with optional output, if present.
+##
+# Formats an error message with a border and the captured command output.
+#
+# Arguments:
+#   1. message: Message to format.
+#
+# Globals:
+#   output: Output captured by the last 'run' call. Appended when not empty.
+#
+# Outputs:
+#   STDOUT: The formatted message.
+##
 format_error() {
   local message="${1}"
   echo "##################################################"

--- a/src/assert.command.bash
+++ b/src/assert.command.bash
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 ##
 # @file
-# Bats test helpers to run commands.
+# Assertions for commands executed with 'run'.
 #
 
+##
+# Asserts that the last command succeeded.
+#
+# Arguments:
+#   1. output: Exact output to additionally assert on. Optional.
+#
+# Globals:
+#   status: Exit status of the last 'run' call.
+##
 assert_success() {
   # shellcheck disable=SC2154
   if [ "${status-}" -ne 0 ]; then
@@ -13,6 +22,15 @@ assert_success() {
   fi
 }
 
+##
+# Asserts that the last command failed.
+#
+# Arguments:
+#   1. output: Exact output to additionally assert on. Optional.
+#
+# Globals:
+#   status: Exit status of the last 'run' call.
+##
 assert_failure() {
   # shellcheck disable=SC2154
   if [ "${status-}" -eq 0 ]; then
@@ -22,6 +40,15 @@ assert_failure() {
   fi
 }
 
+##
+# Asserts that the output of the last command equals a string.
+#
+# Arguments:
+#   1. expected: Expected output. Optional, read from STDIN when omitted.
+#
+# Globals:
+#   output: Output captured by the last 'run' call.
+##
 assert_output() {
   local expected
   if [ "$#" -eq 0 ]; then
@@ -33,6 +60,15 @@ assert_output() {
   assert_equal "${expected}" "${output}"
 }
 
+##
+# Asserts that the output of the last command contains a string.
+#
+# Arguments:
+#   1. expected: String to search for. Optional, read from STDIN when omitted.
+#
+# Globals:
+#   output: Output captured by the last 'run' call.
+##
 assert_output_contains() {
   local expected
   if [ "$#" -eq 0 ]; then
@@ -44,6 +80,15 @@ assert_output_contains() {
   assert_string_contains "${output-}" "${expected}"
 }
 
+##
+# Asserts that the output of the last command does not contain a string.
+#
+# Arguments:
+#   1. expected: String to search for. Optional, read from STDIN when omitted.
+#
+# Globals:
+#   output: Output captured by the last 'run' call.
+##
 assert_output_not_contains() {
   local expected
   if [ "$#" -eq 0 ]; then

--- a/src/assert.file.bash
+++ b/src/assert.file.bash
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 ##
 # @file
-# Bats test helpers.
+# Assertions for files and directories.
 #
 # shellcheck disable=SC2119,SC2120,SC2044,SC2086
 
+##
+# Asserts that a file exists.
+#
+# Arguments:
+#   1. file: Path to check. May be a glob, in which case the first match is
+#      taken.
+##
 assert_file_exists() {
   local file="${1}"
   local f
@@ -15,13 +22,20 @@ assert_file_exists() {
     else
       format_error "File '${file}' does not exist" | flunk
     fi
-    ## This is all we needed to know, so we can break after the first iteration.
+    # Only the first match decides the outcome.
     break
   done
 
   format_error "File '${file}' does not exist" | flunk
 }
 
+##
+# Asserts that a file does not exist.
+#
+# Arguments:
+#   1. file: Path to check. May be a glob, in which case the first match is
+#      taken.
+##
 assert_file_not_exists() {
   local file="${1}"
   local f
@@ -35,6 +49,12 @@ assert_file_not_exists() {
   done
 }
 
+##
+# Asserts that a directory exists.
+#
+# Arguments:
+#   1. dir: Path to check.
+##
 assert_dir_exists() {
   local dir="${1}"
 
@@ -45,6 +65,12 @@ assert_dir_exists() {
   fi
 }
 
+##
+# Asserts that a directory does not exist.
+#
+# Arguments:
+#   1. dir: Path to check. Optional, defaults to the current directory.
+##
 assert_dir_not_exists() {
   local dir="${1:-$(pwd)}"
 
@@ -55,6 +81,12 @@ assert_dir_not_exists() {
   fi
 }
 
+##
+# Asserts that a directory exists and is empty.
+#
+# Arguments:
+#   1. dir: Path to check. Optional, defaults to the current directory.
+##
 assert_dir_empty() {
   local dir="${1:-$(pwd)}"
   assert_dir_exists "${dir}" || return 1
@@ -66,6 +98,12 @@ assert_dir_empty() {
   fi
 }
 
+##
+# Asserts that a directory exists and is not empty.
+#
+# Arguments:
+#   1. dir: Path to check. Optional, defaults to the current directory.
+##
 assert_dir_not_empty() {
   local dir="${1:-$(pwd)}"
   assert_dir_exists "${dir}" || return 1
@@ -77,6 +115,12 @@ assert_dir_not_empty() {
   fi
 }
 
+##
+# Asserts that a symlink exists.
+#
+# Arguments:
+#   1. file: Path to check.
+##
 assert_symlink_exists() {
   local file="${1}"
 
@@ -89,6 +133,14 @@ assert_symlink_exists() {
   fi
 }
 
+##
+# Asserts that a symlink does not exist.
+#
+# A regular file at the same path satisfies this assertion.
+#
+# Arguments:
+#   1. file: Path to check.
+##
 assert_symlink_not_exists() {
   local file="${1}"
 
@@ -101,6 +153,16 @@ assert_symlink_not_exists() {
   fi
 }
 
+##
+# Asserts that a file has a permission mode.
+#
+# The actual mode is masked with the standard umask before comparison, so the
+# group and other write bits are ignored.
+#
+# Arguments:
+#   1. file: Path to check.
+#   2. perm: Expected three-digit octal mode, such as '644'.
+##
 assert_file_mode() {
   local file="${1}"
   local perm="${2}"
@@ -120,6 +182,13 @@ assert_file_mode() {
   fi
 }
 
+##
+# Asserts that a file exists and contains a string.
+#
+# Arguments:
+#   1. file: File to search.
+#   2. string: String to search for.
+##
 assert_file_contains() {
   local file="${1}"
   local string="${2}"
@@ -130,6 +199,15 @@ assert_file_contains() {
   assert_string_contains "${contents}" "${string}"
 }
 
+##
+# Asserts that a file does not contain a string.
+#
+# A file that does not exist cannot contain the string, so it passes.
+#
+# Arguments:
+#   1. file: File to search.
+#   2. string: String to search for.
+##
 assert_file_not_contains() {
   local file="${1}"
   local string="${2}"
@@ -141,6 +219,19 @@ assert_file_not_contains() {
   assert_string_not_contains "${contents}" "${string}"
 }
 
+##
+# Asserts that a directory exists and contains a string in one of its files.
+#
+# Binary files are skipped. '.git', '.idea', 'vendor' and 'node_modules' are
+# always excluded from the search.
+#
+# Arguments:
+#   1. dir: Directory to search.
+#   2. string: String to search for.
+#
+# Globals:
+#   ASSERT_DIR_EXCLUDE: Additional directory names to exclude from the search.
+##
 assert_dir_contains_string() {
   local dir="${1}"
   local string="${2}"
@@ -161,6 +252,20 @@ assert_dir_contains_string() {
   fi
 }
 
+##
+# Asserts that a directory does not contain a string in any of its files.
+#
+# Binary files are skipped. '.git', '.idea', 'vendor' and 'node_modules' are
+# always excluded from the search. A directory that does not exist cannot
+# contain the string, so it passes.
+#
+# Arguments:
+#   1. dir: Directory to search.
+#   2. string: String to search for.
+#
+# Globals:
+#   ASSERT_DIR_EXCLUDE: Additional directory names to exclude from the search.
+##
 assert_dir_not_contains_string() {
   local dir="${1}"
   local string="${2}"
@@ -181,6 +286,15 @@ assert_dir_not_contains_string() {
   fi
 }
 
+##
+# Asserts that the contents of two text files are equal.
+#
+# Arguments:
+#   1. file1: First file.
+#   2. file2: Second file.
+#   3. ignore_spaces: Set to '1' to ignore blank lines and whitespace changes.
+#      Optional, defaults to '0'.
+##
 assert_files_equal() {
   local file1="${1}"
   local file2="${2}"
@@ -199,6 +313,15 @@ assert_files_equal() {
   fi
 }
 
+##
+# Asserts that the contents of two text files are not equal.
+#
+# Arguments:
+#   1. file1: First file.
+#   2. file2: Second file.
+#   3. ignore_spaces: Set to '1' to ignore blank lines and whitespace changes.
+#      Optional, defaults to '0'.
+##
 assert_files_not_equal() {
   local file1="${1}"
   local file2="${2}"
@@ -217,6 +340,13 @@ assert_files_not_equal() {
   fi
 }
 
+##
+# Asserts that the contents of two binary files are equal.
+#
+# Arguments:
+#   1. file1: First file.
+#   2. file2: Second file.
+##
 assert_binary_files_equal() {
   local file1="${1}"
   local file2="${2}"
@@ -231,6 +361,13 @@ assert_binary_files_equal() {
   fi
 }
 
+##
+# Asserts that the contents of two binary files are not equal.
+#
+# Arguments:
+#   1. file1: First file.
+#   2. file2: Second file.
+##
 assert_binary_files_not_equal() {
   local file1="${1}"
   local file2="${2}"
@@ -245,6 +382,16 @@ assert_binary_files_not_equal() {
   fi
 }
 
+##
+# Asserts that two directories hold the same files with the same contents.
+#
+# Both directories are walked, so a file present in only one of them fails the
+# assertion regardless of which one holds it.
+#
+# Arguments:
+#   1. dir1: First directory.
+#   2. dir2: Second directory.
+##
 assert_dirs_equal() {
   local dir1="${1}"
   local dir2="${2}"

--- a/src/assert.git.bash
+++ b/src/assert.git.bash
@@ -4,6 +4,12 @@
 # Assertions for git repositories.
 #
 
+##
+# Asserts that a directory is a git repository.
+#
+# Arguments:
+#   1. dir: Directory to check. Optional, defaults to the current directory.
+##
 assert_git_repo() {
   local dir="${1:-$(pwd)}"
 
@@ -25,6 +31,12 @@ assert_git_repo() {
   fi
 }
 
+##
+# Asserts that a directory is not a git repository.
+#
+# Arguments:
+#   1. dir: Directory to check. Optional, defaults to the current directory.
+##
 assert_git_not_repo() {
   local dir="${1:-$(pwd)}"
 
@@ -37,6 +49,18 @@ assert_git_not_repo() {
   fi
 }
 
+##
+# Asserts that a file is tracked in a git repository.
+#
+# Arguments:
+#   1. file: File to check.
+#   2. dir: Repository directory. Optional, defaults to the current directory.
+#
+# Returns:
+#   0 if the file is tracked, 1 otherwise. Unlike the other assertions in this
+#   library, this one reports the outcome through the exit status alone and
+#   prints no message.
+##
 assert_git_file_tracked() {
   local file="${1-}"
   local dir="${2:-$(pwd)}"
@@ -49,6 +73,18 @@ assert_git_file_tracked() {
   return $?
 }
 
+##
+# Asserts that a file is not tracked in a git repository.
+#
+# Arguments:
+#   1. file: File to check.
+#   2. dir: Repository directory. Optional, defaults to the current directory.
+#
+# Returns:
+#   0 if the file is not tracked, 1 otherwise. Unlike the other assertions in
+#   this library, this one reports the outcome through the exit status alone and
+#   prints no message.
+##
 assert_git_file_not_tracked() {
   local file="${1-}"
   local dir="${2:-$(pwd)}"
@@ -64,6 +100,12 @@ assert_git_file_not_tracked() {
   fi
 }
 
+##
+# Asserts that a git repository has no uncommitted changes.
+#
+# Arguments:
+#   1. dir: Repository directory. Optional, defaults to the current directory.
+##
 assert_git_clean() {
   local dir="${1:-$(pwd)}"
   local message
@@ -74,6 +116,12 @@ assert_git_clean() {
   assert_string_contains "${message}" "nothing to commit"
 }
 
+##
+# Asserts that a git repository has uncommitted changes.
+#
+# Arguments:
+#   1. dir: Repository directory. Optional, defaults to the current directory.
+##
 assert_git_not_clean() {
   local dir="${1:-$(pwd)}"
   local message
@@ -85,7 +133,7 @@ assert_git_not_clean() {
 }
 
 ##
-# Deprecated aliases, removed in the next version.
+## Deprecated aliases, removed in the next version.
 ##
 
 assert_not_git_repo() {

--- a/src/assert.string.bash
+++ b/src/assert.string.bash
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 ##
 # @file
-# Bats test helpers.
+# Assertions for strings.
 #
 
+##
+# Asserts that a string is empty.
+#
+# Arguments:
+#   1. string: String to check.
+##
 assert_empty() {
   if [ "${1-}" = "" ]; then
     return 0
@@ -12,6 +18,12 @@ assert_empty() {
   fi
 }
 
+##
+# Asserts that a string is not empty.
+#
+# Arguments:
+#   1. string: String to check.
+##
 assert_not_empty() {
   if [ "${1-}" = "" ]; then
     format_error "String '${1}' is empty, but should not be" | flunk
@@ -20,6 +32,15 @@ assert_not_empty() {
   fi
 }
 
+##
+# Asserts that a string contains a substring.
+#
+# The match is case-insensitive and treats the needle as a literal string.
+#
+# Arguments:
+#   1. haystack: String to search.
+#   2. needle: Substring to search for.
+##
 assert_string_contains() {
   local haystack="${1}"
   local needle="${2}"
@@ -31,6 +52,15 @@ assert_string_contains() {
   fi
 }
 
+##
+# Asserts that a string does not contain a substring.
+#
+# The match is case-insensitive and treats the needle as a literal string.
+#
+# Arguments:
+#   1. haystack: String to search.
+#   2. needle: Substring to search for.
+##
 assert_string_not_contains() {
   local haystack="${1}"
   local needle="${2}"
@@ -42,6 +72,13 @@ assert_string_not_contains() {
   fi
 }
 
+##
+# Asserts that two strings are equal.
+#
+# Arguments:
+#   1. expected: Expected string.
+#   2. actual: Actual string.
+##
 assert_equal() {
   if [ "${1-}" != "${2-}" ]; then
     {
@@ -51,6 +88,15 @@ assert_equal() {
   fi
 }
 
+##
+# Generates a random alphanumeric string.
+#
+# Arguments:
+#   1. length: Number of characters to generate. Optional, defaults to 8.
+#
+# Outputs:
+#   STDOUT: The generated string.
+##
 random_string() {
   local len="${1:-8}"
   local ret
@@ -60,7 +106,7 @@ random_string() {
 }
 
 ##
-# Deprecated aliases, removed in the next version.
+## Deprecated aliases, removed in the next version.
 ##
 
 assert_contains() {

--- a/src/dataprovider.bash
+++ b/src/dataprovider.bash
@@ -1,24 +1,23 @@
 #!/usr/bin/env bash
-#
-# A Bats helper library providing data providers support.
+##
+# @file
+# Data provider to run a function over multiple test cases.
 #
 
 ##
-# Run multiple test cases for a given function (aka Data Provider).
+# Runs multiple test cases for a given function (aka data provider).
 #
 # Arguments:
-#   1. func_name: The name of the function to be tested.
-#   2. args_per_row: (Optional) The number of arguments in each row of the TEST_CASES array, defaults to 1.
+#   1. func_name: Name of the function to be tested.
+#   2. args_per_row: Number of arguments in each row of the TEST_CASES array.
+#      Optional, defaults to 1.
 #
-# Global Variables:
-#   TEST_CASES: An array containing test cases with their expected values.
+# Globals:
+#   TEST_CASES: Array of test cases, each row ending with its expected value.
 #
 # Examples:
-#   To run a function `test_func` with TEST_CASES containing two arguments per row,
-#   you can call dataprovider_run like so:
-#     dataprovider_run "test_func" 2
+#   dataprovider_run "test_func" 2
 ##
-
 dataprovider_run() {
   local func_name="${1}"
   local args_per_row="${2:-1}"
@@ -103,7 +102,7 @@ dataprovider_run() {
   ##
 
   if [ "${error_count}" -ne 0 ]; then
-    failed_sets=${failed_sets%, } # Remove trailing comma
+    failed_sets=${failed_sets%, } # Remove the trailing comma.
     echo
     echo "Failed sets (0-based): ${failed_sets}"
     flunk "Total failed test sets: ${error_count}"

--- a/src/dataprovider.bash
+++ b/src/dataprovider.bash
@@ -9,14 +9,17 @@
 #
 # Arguments:
 #   1. func_name: Name of the function to be tested.
-#   2. args_per_row: Number of arguments in each row of the TEST_CASES array.
-#      Optional, defaults to 1.
+#   2. args_per_row: Number of elements in each row of the TEST_CASES array,
+#      counting the trailing expected value. Optional, defaults to 1. The
+#      function under test receives one argument fewer.
 #
 # Globals:
 #   TEST_CASES: Array of test cases, each row ending with its expected value.
 #
 # Examples:
-#   dataprovider_run "test_func" 2
+#   Two inputs and one expected value per row:
+#     declare -a TEST_CASES=(1 2 3)
+#     dataprovider_run "add_numbers" 3
 ##
 dataprovider_run() {
   local func_name="${1}"

--- a/src/file.bash
+++ b/src/file.bash
@@ -4,12 +4,23 @@
 # Utilities for working with files.
 #
 
+##
+# Creates a file and any missing parent directories.
+#
+# Arguments:
+#   1. file: Path to create.
+##
 mktouch() {
   local file="${1}"
   mkdir -p "$(dirname "${file}")" && touch "${file}"
 }
 
-# Trim the last line of the file.
+##
+# Removes the last line of a file in place.
+#
+# Arguments:
+#   1. file: File to trim.
+##
 trim_file() {
   local sed_opts
 
@@ -23,6 +34,18 @@ trim_file() {
   sed "${sed_opts[@]}" "${1}"
 }
 
+##
+# Evaluates an expression with the variables from the '.env' file in scope.
+#
+# The variables are visible only for the duration of the call: the caller's
+# environment is captured beforehand and restored afterwards.
+#
+# Arguments:
+#   1. expression: Expression to evaluate.
+#
+# Outputs:
+#   STDOUT: The evaluated expression.
+##
 read_env() {
   local t
   # shellcheck disable=SC1090,SC1091
@@ -32,13 +55,24 @@ read_env() {
   eval echo "$@"
 }
 
-# Resolve the backup location of a file.
+##
+# Resolves the backup location of a file.
 #
-# Backups are stored under BATS_HELPERS_BACKUP_DIR, which defaults to a
-# directory within the per-test temporary directory so that BATS removes them
-# with the rest of the test sandbox. The source path is mirrored below the root
-# so that backups of different files do not collide. Paths with a parent
-# directory reference are rejected, as they resolve outside of that root.
+# The source path is mirrored below the backup root so that backups of
+# different files do not collide. Paths with a parent directory reference are
+# rejected, as they resolve outside of that root.
+#
+# Arguments:
+#   1. file: File whose backup path to resolve.
+#
+# Globals:
+#   BATS_HELPERS_BACKUP_DIR: Backup root. Defaults to a directory within the
+#     per-test temporary directory, so that BATS removes the backups with the
+#     rest of the test sandbox.
+#
+# Outputs:
+#   STDOUT: The backup path.
+##
 file_backup_path() {
   local file="${1}"
 
@@ -59,6 +93,14 @@ file_backup_path() {
   echo "${root%/}/${file#/}"
 }
 
+##
+# Appends a variable assignment to a file, backing the file up first.
+#
+# Arguments:
+#   1. file: File to append to.
+#   2. name: Variable name.
+#   3. value: Variable value.
+##
 add_var_to_file() {
   local file="${1}"
   local name="${2}"
@@ -78,6 +120,12 @@ add_var_to_file() {
   echo "${name}=${value}" >>"${file}"
 }
 
+##
+# Restores a file from the backup taken by 'add_var_to_file'.
+#
+# Arguments:
+#   1. file: File to restore.
+##
 restore_file() {
   local file="${1}"
 

--- a/src/file.bash
+++ b/src/file.bash
@@ -35,10 +35,11 @@ trim_file() {
 }
 
 ##
-# Evaluates an expression with the variables from the '.env' file in scope.
+# Evaluates an expression with the variables from the './.env' file in scope.
 #
-# The variables are visible only for the duration of the call: the caller's
-# environment is captured beforehand and restored afterwards.
+# Variables that were already exported are restored to their previous values
+# once the expression has been evaluated. Variables that './.env' introduces
+# stay exported.
 #
 # Arguments:
 #   1. expression: Expression to evaluate.
@@ -58,9 +59,10 @@ read_env() {
 ##
 # Resolves the backup location of a file.
 #
-# The source path is mirrored below the backup root so that backups of
-# different files do not collide. Paths with a parent directory reference are
-# rejected, as they resolve outside of that root.
+# The source path is mirrored below the backup root, so files in different
+# directories keep separate backups. A leading slash is stripped, so relative
+# and absolute paths to the same location share one backup. Paths with a parent
+# directory reference are rejected, as they resolve outside of that root.
 #
 # Arguments:
 #   1. file: File whose backup path to resolve.

--- a/src/fixture.bash
+++ b/src/fixture.bash
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
-#
-# A Bats helper library for working with fixtures.
+##
+# @file
+# Utilities for preparing test fixtures.
 #
 
+##
+# Exports the codebase at the latest commit to a destination directory.
 #
-# Export codebase source code at the latest commit to the destination directory.
+# Arguments:
+#   1. dst: Destination directory. Required.
+#   2. src: Repository to export. Optional, defaults to the current directory.
 #
+# Globals:
+#   BATS_FIXTURE_EXPORT_CODEBASE_ENABLED: Set to '1' to enable the export.
+#     Anything else makes this function a no-op.
+##
 fixture_export_codebase() {
   if [ "${BATS_FIXTURE_EXPORT_CODEBASE_ENABLED-}" != "1" ]; then
     return
@@ -32,9 +41,12 @@ fixture_export_codebase() {
   fi
 }
 
+##
+# Creates an empty directory for a fixture, removing any existing content.
 #
-# Prepare a directory for a fixture.
-#
+# Arguments:
+#   1. dir: Directory to prepare. Optional, defaults to the current directory.
+##
 fixture_prepare_dir() {
   local dir="${1:-"$(pwd)"}"
   rm -Rf "${dir}" >/dev/null

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
+##
+# @file
+# Command mocking.
 #
-# A Bats helper library providing mocking functionality.
+# The function docblocks below are upstream text and are exempt from this
+# repository's docblock style, so that the diff against upstream stays narrow.
+# Local changes are marked with @note comments.
+#
 # @see https://github.com/grayhemp/bats-mock
 #
-# This file was modified - look for @note comments.
 # shellcheck disable=SC1090,SC2061
 
 # Creates a mock program

--- a/src/steps.bash
+++ b/src/steps.bash
@@ -1,73 +1,49 @@
 #!/usr/bin/env bash
+##
+# @file
+# Step runner for sequences of mocked command and output assertions.
+#
 
-################################################################################
-# Setup and process a sequence of string and mocked command assertions.
+##
+# Sets up and processes a sequence of string and mocked command assertions.
 #
-# Global variables:
-# - STEPS: An array holding the steps to be processed.
-# - RUN_STEPS_DEBUG: Set to '1' to enable debug output.
+# Steps that mock commands need two calls: the 'setup' phase creates the mocks,
+# and the 'assert' phase checks how they were called. Steps that only assert on
+# output need the 'assert' phase alone.
 #
-# Parameters:
-# 1. Phase: Either "setup" or "assert". Defaults to "assert".
-# 2. Mocked Commands (optional for 'setup', required for 'assert' phase):
-#    An array holding the mocked command details.
+#   declare -a STEPS=( ... )
+#   mocks="$(run_steps "setup")"
+#   # ... code to be tested ...
+#   run_steps "assert" "${mocks}"
 #
-# Return:
-#  The mocked commands array for the 'setup' phase.
+# Each step takes one of three forms:
 #
+#   @<command> [<args>] # <status> [ # <output> [ # <side_effect> ]]
+#     Mocks <command>. The status may be omitted and the output given in its
+#     place. The side effect is Bash code run when the mock is called. A command
+#     may be mocked by several steps; every call goes through the same mock.
+#     Literal '#' characters in <args> are escaped as '\#'.
 #
-# Usage:
-# When used with commands, this function needs to be called twice, once for
-# the 'setup' phase and once for the 'assert' phase. The 'setup' phase will mock
-# the commands and the 'assert' phase will assert the commands.
-# When used with strings, just call it once for the 'assert' phase.
+#   <substring>
+#     Asserts that the output contains <substring>.
 #
-# STEPS=(...)
-# mocks="$(run_steps "setup")" # $mocks will hold created mocks
-# # ... code to be tested ...
-# run_steps "assert" "$mocks"
+#   - <substring>
+#     Asserts that the output does not contain <substring>.
 #
-# Every step is a string that can be one of the following:
-# @<command> [<args>] # <mock_status> [ # <mock_output> [ # <mock_side_effect> ]]
-#   Mock the command <command> with the given status, optional output, and optional side effect.
-#   Status can be omitted and <mock_output> can be used instead.
-#   Side effect is Bash code that will be executed when the mock is called.
-#   Different commands can be mocked multiple times.
-#   Call to the same command will be using the same mock.
-#   If <args> contains literal '#' characters (e.g., in URLs like https://example.com#anchor),
-#   escape them as '\#' to prevent them from being treated as delimiters.
+# See README.md for worked examples.
 #
-# <substring>
-#   Check that the output contains the given substring.
+# Arguments:
+#   1. phase: Either 'setup' or 'assert'. Optional, defaults to 'assert'.
+#   2. mocked_commands: Mocks returned by the 'setup' phase. Required for the
+#      'assert' phase.
 #
-# - <substring>
-#   Ensure the output does NOT contain the specified substring.
-#   Starts with '- ' (minus followed by space).
+# Globals:
+#   STEPS: Array of steps to process.
+#   RUN_STEPS_DEBUG: Set to '1' to enable debug output.
 #
-# Example:
-# declare -a STEPS=(
-#   # Mock `drush` binary with an exit status of 1 and not output.
-#   "@drush -y status --field=drupal-version # 1"
-#   # Mock `drush` binary with an exit status of 0 and output "success".
-#   "@drush -y status --fields=bootstrap # success"
-#   # Mock `drush` binary with an exit status of 1 and output "failure".
-#   "@drush -y status --fields=bootstrap # 1 # failure"
-#   # Mock `drush` binary with side effect that creates a file.
-#   "@drush cache-rebuild # 0 # Cache rebuilt # touch /tmp/cache-cleared"
-#   # Mock command with URL containing hash fragment (escaped as \#).
-#   "@curl -fsSL https://example.com\#anchor -o file.php # 0"
-#   "@git clone https://github.com/user/repo.git\#stable # 0 # Cloning repo"
-#   # Assert presence of the partial string in the output "Hello world"
-#   "Hello world"
-#   # Assert absence of the partial string in the output "Goodbye world"
-#   "- Goodbye world"
-# )
-#
-# mocks="$(run_steps "setup")" # $mocks will hold created mocks
-# # ... code to be tested ...
-# run_steps "assert" "$mocks" # Assertions will be processed.
-#
-################################################################################
+# Outputs:
+#   STDOUT: The created mocks, in the 'setup' phase only.
+##
 run_steps() {
   local PHASE_SETUP="setup"
   local PHASE_ASSERT="assert"
@@ -87,7 +63,7 @@ run_steps() {
   steps_debug "Total steps : ${#STEPS[@]}"
   steps_debug
 
-  # Create associative array for mocked commands
+  # Create associative array for mocked commands.
   if [[ -n ${mocked_commands_var} ]]; then
     local line
     while IFS= read -r line; do
@@ -105,20 +81,20 @@ run_steps() {
 
     steps_debug "STEP START: '${item}'"
 
-    #########################################################################
-    #                                COMMAND                                #
-    #########################################################################
+    ##
+    ## Command.
+    ##
     if [[ ${item} == "@"* ]]; then
       steps_debug "Type: command"
       steps_debug
 
-      #------------------------------------------------------------------------
-      # Parsing the command, status, and optional output.
-      #------------------------------------------------------------------------
+      ##
+      ## Parsing the command, status, and optional output.
+      ##
 
       steps_debug_sub "PARSE: STARTED"
 
-      # Replace escaped hashes with a placeholder before parsing
+      # Replace escaped hashes with a placeholder before parsing.
       local ESCAPED_HASH_PLACEHOLDER="__ESCAPED_HASH__"
       local item_with_placeholders="${item//\\#/${ESCAPED_HASH_PLACEHOLDER}}"
 
@@ -143,7 +119,7 @@ run_steps() {
       local mock_output="${command_parts[2]-}"
       local mock_side_effect="${command_parts[3]-}"
 
-      # Restore escaped hashes in all parsed components
+      # Restore escaped hashes in all parsed components.
       command_args="${command_args//${ESCAPED_HASH_PLACEHOLDER}/#}"
       mock_status="${mock_status//${ESCAPED_HASH_PLACEHOLDER}/#}"
       mock_output="${mock_output//${ESCAPED_HASH_PLACEHOLDER}/#}"
@@ -163,9 +139,9 @@ run_steps() {
       steps_debug_sub "       output      : '${mock_output}'"
       steps_debug_sub "       side_effect : '${mock_side_effect}'"
 
-      #------------------------------------------------------------------------
-      # Processing the command.
-      #------------------------------------------------------------------------
+      ##
+      ## Processing the command.
+      ##
 
       # Track the index of the command call per binary.
       command_index=${command_indexes[${command_binary}]:-1}
@@ -197,7 +173,7 @@ run_steps() {
 
         steps_debug_sub "SETUP: Setup mock for binary '${command_binary}' complete."
       else
-        # Check if mock for the binary exists in the assert phase
+        # Check if mock for the binary exists in the assert phase.
         if [[ -z ${mocked_commands["${command_binary}"]-} ]]; then
           flunk "ERROR: Mock for the binary '${command_binary}' does not exist."
           return 1
@@ -217,7 +193,7 @@ run_steps() {
         fi
         steps_debug_sub "        actual args : ${mock_args_actual}"
 
-        # Use wildcard-aware assertion
+        # Use wildcard-aware assertion.
         if ! mock_assert_call_args "${mock}" "${command_args}" "${command_index}"; then
           flunk "ERROR: Mocked command '${command_binary}' was called with arguments '${mock_args_actual}', but '${command_args}' was expected."
           return 1
@@ -227,18 +203,18 @@ run_steps() {
       command_indexes["${command_binary}"]=$((command_index + 1))
       steps_debug "Updated command index for '${command_binary}' to '${command_indexes[${command_binary}]}'"
 
-    #########################################################################
-    #                            STRING ABSENT                              #
-    #########################################################################
+    ##
+    ## String absent.
+    ##
     elif [[ ${item} == "-"* ]]; then
       steps_debug "Type: string absent"
 
       if [[ ${phase} == "${PHASE_ASSERT}" ]]; then
         assert_output_not_contains "${item:2}" || return 1 # Skip '-' and a space.
       fi
-    #########################################################################
-    #                            STRING PRESENT                             #
-    #########################################################################
+    ##
+    ## String present.
+    ##
     else
       steps_debug "Type: string present"
 
@@ -263,34 +239,34 @@ run_steps() {
 }
 
 ##
-# Print a debug message for a step.
+# Prints a debug message for a step.
 #
-# Parameters:
-# 1. Message. Optional.
+# Arguments:
+#   1. message: Message to print. Optional.
 ##
 steps_debug() {
   steps_debug_write "  > " "${1-}"
 }
 
 ##
-# Print a debug message for a sub-step.
+# Prints a debug message for a sub-step.
 #
-# Parameters:
-# 1. Message. Optional.
+# Arguments:
+#   1. message: Message to print. Optional.
 ##
 steps_debug_sub() {
   steps_debug_write "  >   " "${1-}"
 }
 
 ##
-# Print a debug message to the file descriptor 3, shown by `bats --tap`.
+# Prints a debug message to file descriptor 3, shown by 'bats --tap'.
 #
-# Global variables:
-# - RUN_STEPS_DEBUG: Set to '1' to enable debug output.
+# Arguments:
+#   1. prefix: Prefix to print before the message.
+#   2. message: Message to print.
 #
-# Parameters:
-# 1. Prefix.
-# 2. Message.
+# Globals:
+#   RUN_STEPS_DEBUG: Set to '1' to enable debug output.
 ##
 steps_debug_write() {
   if [ "${RUN_STEPS_DEBUG-}" = "1" ]; then

--- a/src/steps.bash
+++ b/src/steps.bash
@@ -20,9 +20,10 @@
 #
 #   @<command> [<args>] # <status> [ # <output> [ # <side_effect> ]]
 #     Mocks <command>. The status may be omitted and the output given in its
-#     place. The side effect is Bash code run when the mock is called. A command
-#     may be mocked by several steps; every call goes through the same mock.
-#     Literal '#' characters in <args> are escaped as '\#'.
+#     place, unless that output is all digits, which parses as a status. The
+#     side effect is Bash code run when the mock is called. A command may be
+#     mocked by several steps; every call goes through the same mock. Literal
+#     '#' characters in <args> are escaped as '\#'.
 #
 #   <substring>
 #     Asserts that the output contains <substring>.

--- a/src/tui.bash
+++ b/src/tui.bash
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
-#
-# A Bats helper library for working with Terminal User Interface (TUI).
+##
+# @file
+# Helpers for testing Terminal User Interface (TUI) scripts.
 #
 
+##
+# Runs a TUI script, feeding it a list of answers on STDIN.
+#
+# Each answer is submitted followed by a newline. The literal answer 'nothing'
+# submits an empty line, so a prompt can be left at its default.
+#
+# Arguments:
+#   @. answers: Answers to submit, in the order the script prompts for them.
+#
+# Globals:
+#   SCRIPT_FILE: Path to the script to run, relative to the current directory.
+##
 tui_run() {
   if [ -z "${SCRIPT_FILE-}" ]; then
     flunk "SCRIPT_FILE is not set."

--- a/src/tui.bash
+++ b/src/tui.bash
@@ -11,7 +11,8 @@
 # submits an empty line, so a prompt can be left at its default.
 #
 # Arguments:
-#   @. answers: Answers to submit, in the order the script prompts for them.
+#   1. answers: Answers to submit, one per argument, in the order the script
+#      prompts for them.
 #
 # Globals:
 #   SCRIPT_FILE: Path to the script to run, relative to the current directory.

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 ##
 # @file
-# Bats test helpers.
+# Common setup for the library's own tests.
 #
 
 # Load library.
@@ -16,5 +16,5 @@ setup() {
   if [ "${BATS_VERBOSE_RUN-}" = "1" ]; then
     echo "BATS_TEST_TMPDIR: ${BATS_TEST_TMPDIR}" >&3
   fi
-  # LCOV_EXCL_END
+  # LCOV_EXCL_STOP
 }

--- a/tests/assert.base.bats
+++ b/tests/assert.base.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Tests for Bats helpers.
+# Tests for base assertion helpers.
 #
 # shellcheck disable=SC2129,SC2016
 

--- a/tests/assert.command.bats
+++ b/tests/assert.command.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Tests for Bats helpers.
+# Tests for command assertions.
 #
 # shellcheck disable=SC2129
 

--- a/tests/assert.file.bats
+++ b/tests/assert.file.bats
@@ -1,8 +1,6 @@
 #!/usr/bin/env bats
 #
-# Tests for Bats helpers.
-#
-# Each assertion tests positive and negative behaviour.
+# Tests for file and directory assertions.
 #
 # shellcheck disable=SC2129,SC2030,SC2031
 

--- a/tests/assert.git.bats
+++ b/tests/assert.git.bats
@@ -1,8 +1,6 @@
 #!/usr/bin/env bats
 #
-# Tests for Bats helpers.
-#
-# Each assertion tests positive and negative behaviour.
+# Tests for git assertions.
 #
 # shellcheck disable=SC2129
 

--- a/tests/assert.string.bats
+++ b/tests/assert.string.bats
@@ -1,8 +1,6 @@
 #!/usr/bin/env bats
 #
-# Tests for Bats helpers.
-#
-# Each assertion tests positive and negative behaviour.
+# Tests for string assertions.
 #
 # shellcheck disable=SC2129
 

--- a/tests/dataprovider.bats
+++ b/tests/dataprovider.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# BATS tests for dataprovider runner.
+# Tests for the data provider runner.
 #
 # shellcheck disable=SC2034
 

--- a/tests/fixture.bats
+++ b/tests/fixture.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# BATS tests for Fixture helpers.
+# Tests for fixture helpers.
 #
 # shellcheck disable=SC2030,SC2031,SC2016
 

--- a/tests/fixtures/mock_script.sh
+++ b/tests/fixtures/mock_script.sh
@@ -6,3 +6,4 @@ set -e
 curl -L -s -o /dev/null -w "%{http_code}" example.com
 
 curl example.com
+# LCOV_EXCL_STOP

--- a/tests/fixtures/tui_script.sh
+++ b/tests/fixtures/tui_script.sh
@@ -31,3 +31,4 @@ answer2="$(ask "Answer2" "default answer2")"
 
 echo "${answer1}"
 echo "${answer2}"
+# LCOV_EXCL_STOP

--- a/tests/mock.bats
+++ b/tests/mock.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Tests for mock.
+# Tests for mocking helpers.
 #
 # shellcheck disable=SC2129
 

--- a/tests/steps.bats
+++ b/tests/steps.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Tests for steps helper.
+# Tests for the step runner.
 #
 # shellcheck disable=SC2034,SC2030,SC2031,SC2016
 

--- a/tests/tui.bats
+++ b/tests/tui.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# BATS tests for TUI helpers.
+# Tests for TUI helpers.
 #
 # shellcheck disable=SC2030,SC2031
 


### PR DESCRIPTION
Closes #161

## Summary

This is a documentation-consistency pass across `src/` and `tests/`. It settles one file-header shape, one function-docblock style, one section-banner form and one comment-punctuation rule, and records each in `CLAUDE.md` so the convention holds for the next contributor. The change is comment- and documentation-only: no executable line in the library changes behaviour.

## Changes

- File headers: every `.bash` file now opens with the `##` / `# @file` / description / `#` shape; `.bats` files keep the plain `#` / description / `#` shape, already uniform across all 12 of them. This replaces five competing header shapes, including three files that all carried the identical uninformative description `Bats test helpers.`, and `src/steps.bash`, which had no file header at all.
- Function docblocks: added to roughly 46 previously undocumented first-party functions. The five assertion modules documented only 2 of about 42 functions before this change, so the best-documented module in the library was the vendored one. Docblocks are `##`-fenced with a third-person summary and carry `Arguments:`, `Globals:`, `Outputs:` and `Returns:` sections only where they add something, so the handful of genuinely surprising contracts stand out instead of being buried in boilerplate. Examples of what this surfaces: `assert_file_exists` glob-expands its argument, `assert_dir_contains_string` honours the caller-supplied `ASSERT_DIR_EXCLUDE` array, `assert_git_file_tracked` reports through exit status alone rather than calling `flunk`, and `assert_file_mode` masks the actual mode with the standard umask before comparing.
- `src/mock.bash` function docblocks were deliberately left as upstream grayhemp/bats-mock text, per the issue's own recommendation, since restyling them would widen the divergence from upstream for no functional gain. Only its file header was restyled, because the `@see` link and shellcheck disable there are already local additions. `CLAUDE.md` records this exemption alongside the existing one for the same file under Failure Message Style.
- Section banners: `src/steps.bash` used 80-column `####` rules while `src/dataprovider.bash` used a light three-line form. Both now use the light form, removing about nine lines of decoration from the library's most complex function while keeping its navigation.
- The `run_steps` banner docblock duplicated the Step Runner section of `README.md` in a worked example. It now keeps the contract - parameters, globals, return, the three step forms and the escaping rule - and drops the duplicated worked example, pointing at `README.md` instead.
- Test file headers: twelve `.bats` files used seven different phrasings, varying in prefix (`Tests for` vs `BATS tests for`) and in capitalisation. All now read `Tests for <subject>.` The stray line `# Each assertion tests positive and negative behaviour.`, which appeared in three of the five assertion test files, moved to `CLAUDE.md`, where the suite's other test conventions already live.
- Coverage markers: `tests/_test_helper.bash` closed its `LCOV_EXCL_START` region with `LCOV_EXCL_END`, which kcov does not recognise - the installed binary ships only `LCOV_EXCL_START`, `LCOV_EXCL_STOP` and `LCOV_EXCL_LINE` - so the exclusion region ran to the end of the file instead of closing. It now uses `LCOV_EXCL_STOP`. Both fixture scripts named in the issue (`tests/fixtures/fixture.sh` and `tests/fixtures/fixture_tui.sh`, now `tests/fixtures/mock_script.sh` and `tests/fixtures/tui_script.sh`) opened a region they never closed, and now close it explicitly.
- Docblock accuracy: two docblocks written during this pass overclaimed what the code guarantees and were narrowed. `read_env` does not restore the caller's whole environment - `export -p` captures only exported variables, so variables that `.env` introduces stay exported after the call. `file_backup_path` does not fully prevent collisions - it strips a single leading slash, so a relative and an absolute path to the same location resolve to one backup.

## Before / After

```
 BEFORE                                          AFTER
 ┌──────────────────────────────────────┐        ┌──────────────────────────────────────┐
 │ File headers: 5 competing shapes      │        │ File headers: 1 shape per file type   │
 │  - ## / @file / desc / #              │  ───▶  │  .bash → ## / @file / desc / #        │
 │  - # / desc / #                       │        │  .bats → # / desc / #                 │
 │  - prose + @see + fork notice         │        │                                        │
 │  - no header at all (steps.bash)      │        │                                        │
 ├──────────────────────────────────────┤        ├──────────────────────────────────────┤
 │ Assertion docblocks:    2 of ~42       │  ───▶  │ Assertion docblocks:   ~46 documented  │
 │ (vendored mock.bash was the best-      │        │ (surprising contracts now visible:    │
 │  documented module in the library)    │        │  glob expansion, umask masking, ...)  │
 ├──────────────────────────────────────┤        ├──────────────────────────────────────┤
 │ Section banners: 80-col ####          │  ───▶  │ Section banners: one light            │
 │ rules vs. a light 3-line form         │        │ ## / Title. / ## form everywhere      │
 ├──────────────────────────────────────┤        ├──────────────────────────────────────┤
 │ Test headers: 7 phrasings across      │  ───▶  │ Test headers: "Tests for <x>."        │
 │ 12 .bats files                        │        │ on all 12 .bats files                 │
 ├──────────────────────────────────────┤        ├──────────────────────────────────────┤
 │ Coverage marker: # LCOV_EXCL_END       │  ───▶  │ Coverage marker: # LCOV_EXCL_STOP      │
 │ (kcov ignores it; region never closes)│        │ (region closes exactly where intended)│
 └──────────────────────────────────────┘        └──────────────────────────────────────┘
```
