### PR TITLE
[#172] Renamed eight helpers to subject-first order and fixed 'string_random'.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,14 @@ export BATS_LIB_PATH="${BATS_TEST_DIRNAME}/../node_modules"
 bats_load_library bats-helpers
 ```
 
+### Function Naming
+Bash has no namespaces: every sourced function lands in one global scope shared with the consumer's own helpers, with bats-assert and bats-file, and with every binary on `PATH`. The prefix is the namespace, so a helper is named `<subject>_<verb>` after the module that owns it - `steps_run`, `mock_setup`, `file_trim`, `fixture_prepare_dir`, `string_random`. This matches how bats-core namespaces `bats_*` and bats-support namespaces `batslib_*`.
+
+Two exceptions:
+
+- **The `assert_*` family** keeps the verb first, because there the verb is already the namespace and it matches bats-assert and bats-file exactly. Shape: `assert_<subject>_<predicate>`, e.g. `assert_file_not_exists`. An assertion a module owns still takes the module's prefix: `mock_assert_call_args`.
+- **`flunk` and `format_error`** are bare verbs, mirroring bats-support's `fail`.
+
 ### Assertion Functions
 All assertion functions follow the pattern of checking conditions and calling `flunk()` with formatted error messages on failure.
 
@@ -151,6 +159,6 @@ Side effects are Bash code executed when the mock is called, useful for file cre
 
 Both shapes below work for a positive case, so the split is settled here rather than left to each new test.
 
-- **Call the helper bare for a positive case**: `run_steps "assert" "${mocks[@]}"`. The helper's `flunk` returns non-zero, which fails the test under BATS errexit and reports the specific reason against the calling line. The `run` wrapper needs a follow-up `assert_success`, and omitting it discards the result without failing anything.
-- **Wrap the call for a negative case**: `run run_steps "assert" "${mocks[@]}"` followed by `assert_failure`. The bare form would abort the test at the `flunk` before reaching the assertion.
+- **Call the helper bare for a positive case**: `steps_run "assert" "${mocks[@]}"`. The helper's `flunk` returns non-zero, which fails the test under BATS errexit and reports the specific reason against the calling line. The `run` wrapper needs a follow-up `assert_success`, and omitting it discards the result without failing anything.
+- **Wrap the call for a negative case**: `run steps_run "assert" "${mocks[@]}"` followed by `assert_failure`. The bare form would abort the test at the `flunk` before reaching the assertion.
 - **Declare test data arrays with `declare -a`**: `declare -a STEPS=( ... )`, `declare -a TEST_CASES=( ... )`, `declare -a answers=( ... )`. Helpers read these arrays through BASH dynamic scoping, so the declaration marks the array as an input to the call that follows it.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ tests.
 
 | Function               | Description                                | Arguments                        | Returns   |
 |------------------------|--------------------------------------------|----------------------------------|-----------|
-| `setup_mock`           | Setup mock support. Call from `setup()`    | None                             | None      |
+| `mock_setup`           | Setup mock support. Call from `setup()`    | None                             | None      |
 | `mock_create`          | Creates a mock program that can be tracked | None                             | Mock path |
 | `mock_command`         | Mock provided command                      | `command_name`                   | Mock path |
 | `mock_set_output`      | Sets the output of the mock                | `mock`, `output`, `[call_index]` | None      |
@@ -220,7 +220,7 @@ tests.
 
 ```bash
 setup() {
-  setup_mock
+  mock_setup
 }
 
 # Example to test the notify.sh script that uses curl to send a notification to external system.
@@ -264,7 +264,7 @@ assertions. It helps to make maintenance of complex tests easier.
 Consider this example:
 
 ```bash
-# Declare STEPS as a global variable, as `run_steps` needs to be called
+# Declare STEPS as a global variable, as `steps_run` needs to be called
 # twice and it does not store the steps internally.
 declare -a STEPS=(
   # Mock command with exit status only (status 1 = failure, no output).
@@ -295,13 +295,13 @@ declare -a STEPS=(
 )
 
 # Setup phase: creates mocks and returns references to them.
-mocks="$(run_steps "setup")"
+mocks="$(steps_run "setup")"
 
 # Run the code under test.
 run ./my-script.sh
 
 # Assert phase: verifies mocks were called correctly and output assertions pass.
-run_steps "assert" "$mocks"
+steps_run "assert" "$mocks"
 ```
 
 #### Step types
@@ -353,17 +353,17 @@ Starts with `- ` (minus followed by a space).
 
 | Function Name             | Description                                                                   |
 |---------------------------|-------------------------------------------------------------------------------|
-| `add_var_to_file`         | Adds a variable assignment to a file and creates a backup                     |
-| `restore_file`            | Restores a file from its backup created by add_var_to_file                    |
+| `file_add_var`            | Adds a variable assignment to a file and creates a backup                     |
+| `file_restore`            | Restores a file from its backup created by file_add_var                       |
 | `file_backup_path`        | Returns the sandbox path of a file's backup                                   |
-| `read_env`                | Reads .env file and evaluates variable expressions in that context            |
+| `file_read_env`           | Reads .env file and evaluates variable expressions in that context            |
 | `format_error`            | Formats error messages with decorative borders and includes command output    |
 | `flunk`                   | Causes a test to fail with an optional error message                          |
-| `mktouch`                 | Creates a file and any necessary parent directories                           |
+| `file_mktouch`            | Creates a file and any necessary parent directories                           |
 | `fixture_export_codebase` | Export codebase source code at the latest commit to the destination directory |
 | `fixture_prepare_dir`     | Prepares a directory for fixture use by removing existing content             |
-| `random_string`           | Generates a random alphanumeric string of specified length                    |
-| `trim_file`               | Removes the last line from a file                                             |
+| `string_random`           | Generates a random alphanumeric string of specified length                    |
+| `file_trim`               | Removes the last line from a file                                             |
 | `tui_run`                 | Runs a TUI script with predefined answers, simulating user input              |
 
 #### Failure reporting
@@ -384,7 +384,7 @@ A bare call still fails the test at that point, because BATS runs tests with `er
 
 #### File backups
 
-`add_var_to_file` backs a file up before modifying it and `restore_file` puts that backup back. Backups are written below `${BATS_TEST_TMPDIR}/bats-helpers-backup`, mirroring the source path, so BATS removes them together with the rest of the test sandbox and concurrent runs cannot overwrite each other's backups.
+`file_add_var` backs a file up before modifying it and `file_restore` puts that backup back. Backups are written below `${BATS_TEST_TMPDIR}/bats-helpers-backup`, mirroring the source path, so BATS removes them together with the rest of the test sandbox and concurrent runs cannot overwrite each other's backups.
 
 Set `BATS_HELPERS_BACKUP_DIR` to store them elsewhere. Only the default location carries the guarantees above - a directory outside `${BATS_TEST_TMPDIR}` is not removed by BATS and is shared with concurrent runs:
 
@@ -409,6 +409,16 @@ These names still work, but print a notice on every call and are removed in the 
 | `assert_git_file_is_not_tracked` | `assert_git_file_not_tracked`  |
 | `assert_contains`                | `assert_string_contains`       |
 | `assert_not_contains`            | `assert_string_not_contains`   |
+| `run_steps`                      | `steps_run`                    |
+| `setup_mock`                     | `mock_setup`                   |
+| `mktouch`                        | `file_mktouch`                 |
+| `trim_file`                      | `file_trim`                    |
+| `read_env`                       | `file_read_env`                |
+| `add_var_to_file`                | `file_add_var`                 |
+| `restore_file`                   | `file_restore`                 |
+| `random_string`                  | `string_random`                |
+
+The eight names below the assertion aliases were renamed to put the subject first, so every helper in a module shares one prefix - `steps_*`, `mock_*`, `file_*`, `string_*` - matching how bats-core namespaces `bats_*` and bats-support namespaces `batslib_*`. Only the name changed: arguments, output and return semantics are identical, so a call is updated by swapping the name alone.
 
 `assert_contains` and `assert_not_contains` take the needle first, while their replacements take the haystack first, so a call has to swap its arguments as well as change its name:
 

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ These names still work, but print a notice on every call and are removed in the 
 | `restore_file`                   | `file_restore`                 |
 | `random_string`                  | `string_random`                |
 
-The eight names below the assertion aliases were renamed to put the subject first, so every helper in a module shares one prefix - `steps_*`, `mock_*`, `file_*`, `string_*` - matching how bats-core namespaces `bats_*` and bats-support namespaces `batslib_*`. Only the name changed: arguments, output and return semantics are identical, so a call is updated by swapping the name alone.
+The eight names below the assertion aliases were renamed to put the subject first, so every helper in a module shares one prefix - `steps_*`, `mock_*`, `file_*`, `string_*` - matching how bats-core namespaces `bats_*` and bats-support namespaces `batslib_*`. The replacement keeps the arguments, the standard output and the return semantics, so a call is updated by swapping the name alone. The deprecated alias additionally writes its notice to file descriptor 3.
 
 `assert_contains` and `assert_not_contains` take the needle first, while their replacements take the haystack first, so a call has to swap its arguments as well as change its name:
 

--- a/src/assert.string.bash
+++ b/src/assert.string.bash
@@ -103,9 +103,17 @@ string_random() {
   local ret=''
   local i
 
-  # Built from Bash's own generator rather than a '/dev/urandom' pipeline: a
-  # pipeline leaks its tools' STDERR into the value that Bats' 'run' returns,
-  # and leaves a reader spinning on the device when the writer exits first.
+  if ! [[ ${len} =~ ^[0-9]+$ ]]; then
+    flunk "Length must be a non-negative integer."
+    return 1
+  fi
+
+  # Base 10 is explicit so that a zero-padded length is not read as octal.
+  len=$((10#${len}))
+
+  # A '/dev/urandom' pipeline is not usable here: its tools' STDERR reaches the
+  # caller, where Bats' 'run' merges it into the returned value, and its reader
+  # can outlive the writer and hang.
   for ((i = 0; i < len; i++)); do
     ret="${ret}${alphabet:RANDOM%${#alphabet}:1}"
   done

--- a/src/assert.string.bash
+++ b/src/assert.string.bash
@@ -100,8 +100,12 @@ assert_equal() {
 string_random() {
   local len="${1:-8}"
   local ret
-  # shellcheck disable=SC2002
-  ret=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w "${len}" | head -n 1)
+
+  # 'tr' reads the device directly and 'head' counts bytes, so neither a
+  # broken-pipe warning nor a locale complaint can reach the caller's STDERR,
+  # where Bats' 'run' would merge it into the returned string.
+  ret="$(LC_ALL=C tr -dc 'a-zA-Z0-9' </dev/urandom 2>/dev/null | head -c "${len}")"
+
   echo "${ret}"
 }
 

--- a/src/assert.string.bash
+++ b/src/assert.string.bash
@@ -97,7 +97,7 @@ assert_equal() {
 # Outputs:
 #   STDOUT: The generated string.
 ##
-random_string() {
+string_random() {
   local len="${1:-8}"
   local ret
   # shellcheck disable=SC2002
@@ -117,4 +117,9 @@ assert_contains() {
 assert_not_contains() {
   [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_not_contains' will be removed in the next version. Use 'assert_string_not_contains' instead." >&3
   assert_string_not_contains "${2-}" "${1-}"
+}
+
+random_string() {
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'random_string' will be removed in the next version. Use 'string_random' instead." >&3
+  string_random "$@"
 }

--- a/src/assert.string.bash
+++ b/src/assert.string.bash
@@ -99,12 +99,16 @@ assert_equal() {
 ##
 string_random() {
   local len="${1:-8}"
-  local ret
+  local alphabet='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+  local ret=''
+  local i
 
-  # 'tr' reads the device directly and 'head' counts bytes, so neither a
-  # broken-pipe warning nor a locale complaint can reach the caller's STDERR,
-  # where Bats' 'run' would merge it into the returned string.
-  ret="$(LC_ALL=C tr -dc 'a-zA-Z0-9' </dev/urandom 2>/dev/null | head -c "${len}")"
+  # Built from Bash's own generator rather than a '/dev/urandom' pipeline: a
+  # pipeline leaks its tools' STDERR into the value that Bats' 'run' returns,
+  # and leaves a reader spinning on the device when the writer exits first.
+  for ((i = 0; i < len; i++)); do
+    ret="${ret}${alphabet:RANDOM%${#alphabet}:1}"
+  done
 
   echo "${ret}"
 }

--- a/src/file.bash
+++ b/src/file.bash
@@ -10,7 +10,7 @@
 # Arguments:
 #   1. file: Path to create.
 ##
-mktouch() {
+file_mktouch() {
   local file="${1}"
   mkdir -p "$(dirname "${file}")" && touch "${file}"
 }
@@ -21,7 +21,7 @@ mktouch() {
 # Arguments:
 #   1. file: File to trim.
 ##
-trim_file() {
+file_trim() {
   local sed_opts
 
   if [ "$(uname)" = "Darwin" ]; then
@@ -47,7 +47,7 @@ trim_file() {
 # Outputs:
 #   STDOUT: The evaluated expression.
 ##
-read_env() {
+file_read_env() {
   local t
   # shellcheck disable=SC1090,SC1091
   [ -f "./.env" ] && t=$(mktemp) && export -p >"${t}" && set -a && . "./.env" && set +a && . "${t}" && rm "${t}" && unset t
@@ -103,7 +103,7 @@ file_backup_path() {
 #   2. name: Variable name.
 #   3. value: Variable value.
 ##
-add_var_to_file() {
+file_add_var() {
   local file="${1}"
   local name="${2}"
   local value="${3}"
@@ -123,12 +123,12 @@ add_var_to_file() {
 }
 
 ##
-# Restores a file from the backup taken by 'add_var_to_file'.
+# Restores a file from the backup taken by 'file_add_var'.
 #
 # Arguments:
 #   1. file: File to restore.
 ##
-restore_file() {
+file_restore() {
   local file="${1}"
 
   local backup
@@ -140,4 +140,33 @@ restore_file() {
   fi
 
   cp -f "${backup}" "${file}"
+}
+
+##
+## Deprecated aliases, removed in the next version.
+##
+
+mktouch() {
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'mktouch' will be removed in the next version. Use 'file_mktouch' instead." >&3
+  file_mktouch "$@"
+}
+
+trim_file() {
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'trim_file' will be removed in the next version. Use 'file_trim' instead." >&3
+  file_trim "$@"
+}
+
+read_env() {
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'read_env' will be removed in the next version. Use 'file_read_env' instead." >&3
+  file_read_env "$@"
+}
+
+add_var_to_file() {
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'add_var_to_file' will be removed in the next version. Use 'file_add_var' instead." >&3
+  file_add_var "$@"
+}
+
+restore_file() {
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'restore_file' will be removed in the next version. Use 'file_restore' instead." >&3
+  file_restore "$@"
 }

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -253,7 +253,7 @@ mock_default_n() {
 
 # Setup mock support.
 # Call this function from your test's setup() method.
-setup_mock() {
+mock_setup() {
   # Command and functions mocking support.
   # @see https://github.com/grayhemp/bats-mock
   #
@@ -291,4 +291,13 @@ mock_command() {
   local mock_file="${mock##*/}"
   ln -sf "${mock_path}/${mock_file}" "${mock_path}/${mocked_command}"
   echo "${mock}"
+}
+
+##
+## Deprecated aliases, removed in the next version.
+##
+
+setup_mock() {
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'setup_mock' will be removed in the next version. Use 'mock_setup' instead." >&3
+  mock_setup "$@"
 }

--- a/src/steps.bash
+++ b/src/steps.bash
@@ -12,9 +12,9 @@
 # output need the 'assert' phase alone.
 #
 #   declare -a STEPS=( ... )
-#   mocks="$(run_steps "setup")"
+#   mocks="$(steps_run "setup")"
 #   # ... code to be tested ...
-#   run_steps "assert" "${mocks}"
+#   steps_run "assert" "${mocks}"
 #
 # Each step takes one of three forms:
 #
@@ -45,7 +45,7 @@
 # Outputs:
 #   STDOUT: The created mocks, in the 'setup' phase only.
 ##
-run_steps() {
+steps_run() {
   local PHASE_SETUP="setup"
   local PHASE_ASSERT="assert"
 
@@ -273,4 +273,13 @@ steps_debug_write() {
   if [ "${RUN_STEPS_DEBUG-}" = "1" ]; then
     echo "${1}${2}" >&3
   fi
+}
+
+##
+## Deprecated aliases, removed in the next version.
+##
+
+run_steps() {
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'run_steps' will be removed in the next version. Use 'steps_run' instead." >&3
+  steps_run "$@"
 }

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -9,7 +9,7 @@ load '../load.bash'
 
 setup() {
   # Setup command mocking.
-  setup_mock
+  mock_setup
 
   # Print debug information if "--verbose-run" is passed.
   # LCOV_EXCL_START

--- a/tests/assert.file.bats
+++ b/tests/assert.file.bats
@@ -9,10 +9,10 @@ load _test_helper
 @test "assert_file_exists" {
   assert_file_exists "${BATS_TEST_FILENAME}"
 
-  mktouch "${BATS_TEST_TMPDIR}/file1.txt"
-  mktouch "${BATS_TEST_TMPDIR}/file2.txt"
-  mktouch "${BATS_TEST_TMPDIR}/file3.md"
-  mktouch "${BATS_TEST_TMPDIR}/a.b.c.d.doc"
+  file_mktouch "${BATS_TEST_TMPDIR}/file1.txt"
+  file_mktouch "${BATS_TEST_TMPDIR}/file2.txt"
+  file_mktouch "${BATS_TEST_TMPDIR}/file3.md"
+  file_mktouch "${BATS_TEST_TMPDIR}/a.b.c.d.doc"
 
   assert_file_exists "${BATS_TEST_TMPDIR}/file1.txt"
   assert_file_exists "${BATS_TEST_TMPDIR}/file2.txt"
@@ -35,9 +35,9 @@ load _test_helper
 @test "assert_file_not_exists" {
   assert_file_not_exists "some_file.txt"
 
-  mktouch "${BATS_TEST_TMPDIR}/file1.txt"
-  mktouch "${BATS_TEST_TMPDIR}/file2.txt"
-  mktouch "${BATS_TEST_TMPDIR}/file3.md"
+  file_mktouch "${BATS_TEST_TMPDIR}/file1.txt"
+  file_mktouch "${BATS_TEST_TMPDIR}/file2.txt"
+  file_mktouch "${BATS_TEST_TMPDIR}/file3.md"
 
   assert_file_not_exists "${BATS_TEST_TMPDIR}/otherfile1.txt"
   assert_file_not_exists "${BATS_TEST_TMPDIR}/otherfile*"

--- a/tests/assert.git.bats
+++ b/tests/assert.git.bats
@@ -54,7 +54,7 @@ load _test_helper
   assert_output_contains "not a git repository"
   assert_output_not_contains "nothing to commit"
 
-  mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/uncommitted_file"
+  file_mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/uncommitted_file"
   run assert_git_clean "${BATS_TEST_TMPDIR}/fixture/git_repo"
   assert_failure
 
@@ -62,7 +62,7 @@ load _test_helper
   git --work-tree="${BATS_TEST_TMPDIR}/fixture/git_repo" --git-dir="${BATS_TEST_TMPDIR}/fixture/git_repo/.git" add -A >/dev/null
   git --work-tree="${BATS_TEST_TMPDIR}/fixture/git_repo" --git-dir="${BATS_TEST_TMPDIR}/fixture/git_repo/.git" commit -m "First commit" >/dev/null
   assert_git_clean "${BATS_TEST_TMPDIR}/fixture/git_repo"
-  mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/other_uncommitted_file"
+  file_mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/other_uncommitted_file"
   run assert_git_clean "${BATS_TEST_TMPDIR}/fixture/git_repo"
   assert_failure
 }
@@ -80,7 +80,7 @@ load _test_helper
   run assert_git_not_clean "${BATS_TEST_TMPDIR}/fixture/git_repo"
   assert_failure
 
-  mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/uncommitted_file"
+  file_mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/uncommitted_file"
   assert_git_not_clean "${BATS_TEST_TMPDIR}/fixture/git_repo"
 
   # Now, commit first file and create another, but do not add.
@@ -88,7 +88,7 @@ load _test_helper
   git --work-tree="${BATS_TEST_TMPDIR}/fixture/git_repo" --git-dir="${BATS_TEST_TMPDIR}/fixture/git_repo/.git" commit -m "First commit" >/dev/null
   run assert_git_not_clean "${BATS_TEST_TMPDIR}/fixture/git_repo"
   assert_failure
-  mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/other_uncommitted_file"
+  file_mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/other_uncommitted_file"
   assert_git_not_clean "${BATS_TEST_TMPDIR}/fixture/git_repo"
 }
 

--- a/tests/assert.string.bats
+++ b/tests/assert.string.bats
@@ -49,12 +49,21 @@ load _test_helper
   run string_random
   assert_success
   assert_equal 8 "${#output}"
-  assert_string_not_contains "${output}" " "
+  assert_empty "${output//[a-zA-Z0-9]/}"
 
   run string_random 16
   assert_success
   assert_equal 16 "${#output}"
-  assert_string_not_contains "${output}" " "
+  assert_empty "${output//[a-zA-Z0-9]/}"
+
+  # A zero-padded length would be read as octal by the arithmetic loop.
+  run string_random 08
+  assert_success
+  assert_equal 8 "${#output}"
+
+  run string_random "abc"
+  assert_failure
+  assert_output_contains "Length must be a non-negative integer."
 }
 
 ##

--- a/tests/assert.string.bats
+++ b/tests/assert.string.bats
@@ -45,6 +45,16 @@ load _test_helper
   assert_failure
 }
 
+@test "string_random" {
+  run string_random
+  assert_success
+  assert_equal 8 "${#output}"
+
+  run string_random 16
+  assert_success
+  assert_equal 16 "${#output}"
+}
+
 ##
 # Deprecated aliases.
 #

--- a/tests/assert.string.bats
+++ b/tests/assert.string.bats
@@ -49,10 +49,12 @@ load _test_helper
   run string_random
   assert_success
   assert_equal 8 "${#output}"
+  assert_string_not_contains "${output}" " "
 
   run string_random 16
   assert_success
   assert_equal 16 "${#output}"
+  assert_string_not_contains "${output}" " "
 }
 
 ##

--- a/tests/deprecation.bats
+++ b/tests/deprecation.bats
@@ -66,6 +66,7 @@ load _test_helper
 
   assert_success
   assert_equal 5 "${#output}"
+  assert_string_not_contains "${output}" " "
   assert_file_contains "${notice}" "Deprecated: 'random_string' will be removed in the next version. Use 'string_random' instead."
 }
 

--- a/tests/deprecation.bats
+++ b/tests/deprecation.bats
@@ -5,7 +5,7 @@
 # Each test asserts that the old name still works and still warns. File
 # descriptor 3 is redirected per call so the notice can be asserted on.
 #
-# shellcheck disable=SC2129
+# shellcheck disable=SC2034,SC2129
 
 load _test_helper
 

--- a/tests/deprecation.bats
+++ b/tests/deprecation.bats
@@ -66,7 +66,7 @@ load _test_helper
 
   assert_success
   assert_equal 5 "${#output}"
-  assert_string_not_contains "${output}" " "
+  assert_empty "${output//[a-zA-Z0-9]/}"
   assert_file_contains "${notice}" "Deprecated: 'random_string' will be removed in the next version. Use 'string_random' instead."
 }
 
@@ -119,6 +119,7 @@ load _test_helper
   # shellcheck disable=SC2016
   run read_env '$VAR1' 3>"${notice}"
 
+  assert_success
   assert_output_contains "val1"
   assert_file_contains "${notice}" "Deprecated: 'read_env' will be removed in the next version. Use 'file_read_env' instead."
 

--- a/tests/deprecation.bats
+++ b/tests/deprecation.bats
@@ -59,6 +59,86 @@ load _test_helper
   assert_file_contains "${notice}" "Deprecated: 'assert_not_contains' will be removed in the next version. Use 'assert_string_not_contains' instead."
 }
 
+@test "random_string" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  run random_string 5 3>"${notice}"
+
+  assert_success
+  assert_equal 5 "${#output}"
+  assert_file_contains "${notice}" "Deprecated: 'random_string' will be removed in the next version. Use 'string_random' instead."
+}
+
+@test "run_steps" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+  declare -a STEPS=(
+    "Some Substring"
+  )
+
+  run echo "Some Substring"
+  run_steps "assert" 3>"${notice}"
+
+  assert_file_contains "${notice}" "Deprecated: 'run_steps' will be removed in the next version. Use 'steps_run' instead."
+}
+
+@test "setup_mock" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  setup_mock 3>"${notice}"
+
+  assert_dir_exists "${BATS_MOCK_TMPDIR}"
+  assert_file_contains "${notice}" "Deprecated: 'setup_mock' will be removed in the next version. Use 'mock_setup' instead."
+}
+
+@test "mktouch" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  mktouch "${BATS_TEST_TMPDIR}/dir1/dir2/file.txt" 3>"${notice}"
+
+  assert_file_exists "${BATS_TEST_TMPDIR}/dir1/dir2/file.txt"
+  assert_file_contains "${notice}" "Deprecated: 'mktouch' will be removed in the next version. Use 'file_mktouch' instead."
+}
+
+@test "trim_file" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+  echo "line1" >>"${BATS_TEST_TMPDIR}/file.txt"
+  echo "line2" >>"${BATS_TEST_TMPDIR}/file.txt"
+
+  trim_file "${BATS_TEST_TMPDIR}/file.txt" 3>"${notice}"
+
+  assert_file_not_contains "${BATS_TEST_TMPDIR}/file.txt" "line2"
+  assert_file_contains "${notice}" "Deprecated: 'trim_file' will be removed in the next version. Use 'file_trim' instead."
+}
+
+@test "read_env" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+  pushd "${BATS_TEST_TMPDIR}"
+  echo "VAR1=val1" >>.env
+
+  # shellcheck disable=SC2016
+  run read_env '$VAR1' 3>"${notice}"
+
+  assert_output_contains "val1"
+  assert_file_contains "${notice}" "Deprecated: 'read_env' will be removed in the next version. Use 'file_read_env' instead."
+
+  popd
+}
+
+@test "add_var_to_file and restore_file" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+  echo "line1" >>"${BATS_TEST_TMPDIR}/.env"
+
+  add_var_to_file "${BATS_TEST_TMPDIR}/.env" "VAR" "value" 3>"${notice}"
+
+  assert_file_contains "${BATS_TEST_TMPDIR}/.env" "VAR=value"
+  assert_file_contains "${notice}" "Deprecated: 'add_var_to_file' will be removed in the next version. Use 'file_add_var' instead."
+
+  restore_file "${BATS_TEST_TMPDIR}/.env" 3>>"${notice}"
+
+  assert_file_not_contains "${BATS_TEST_TMPDIR}/.env" "VAR=value"
+  assert_file_contains "${notice}" "Deprecated: 'restore_file' will be removed in the next version. Use 'file_restore' instead."
+}
+
 @test "Assertions calling other assertions emit no notices" {
   notice="${BATS_TEST_TMPDIR}/notice.txt"
   fixture_prepare_dir "${BATS_TEST_TMPDIR}/fixture/git_repo"
@@ -68,7 +148,7 @@ load _test_helper
   assert_file_contains "${BATS_TEST_TMPDIR}/haystack.txt" "needle" 3>"${notice}"
   assert_file_not_contains "${BATS_TEST_TMPDIR}/haystack.txt" "otherneedle" 3>>"${notice}"
   assert_git_clean "${BATS_TEST_TMPDIR}/fixture/git_repo" 3>>"${notice}"
-  mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/uncommitted_file"
+  file_mktouch "${BATS_TEST_TMPDIR}/fixture/git_repo/uncommitted_file"
   assert_git_not_clean "${BATS_TEST_TMPDIR}/fixture/git_repo" 3>>"${notice}"
 
   run echo "some needle in a haystack"

--- a/tests/file.bats
+++ b/tests/file.bats
@@ -6,31 +6,31 @@
 
 load _test_helper
 
-@test "mktouch" {
+@test "file_mktouch" {
   assert_file_not_exists "${BATS_TEST_TMPDIR}/dir1/dir2/dir3/file.txt"
-  mktouch "${BATS_TEST_TMPDIR}/dir1/dir2/dir3/file.txt"
+  file_mktouch "${BATS_TEST_TMPDIR}/dir1/dir2/dir3/file.txt"
   assert_file_exists "${BATS_TEST_TMPDIR}/dir1/dir2/dir3/file.txt"
 }
 
-@test "trim_file" {
+@test "file_trim" {
   echo "line1" >>"${BATS_TEST_TMPDIR}/file.txt"
   echo "line2" >>"${BATS_TEST_TMPDIR}/file.txt"
   echo "line3" >>"${BATS_TEST_TMPDIR}/file.txt"
 
-  trim_file "${BATS_TEST_TMPDIR}/file.txt"
+  file_trim "${BATS_TEST_TMPDIR}/file.txt"
 
   assert_file_contains "${BATS_TEST_TMPDIR}/file.txt" "line1"
   assert_file_contains "${BATS_TEST_TMPDIR}/file.txt" "line2"
   assert_file_not_contains "${BATS_TEST_TMPDIR}/file.txt" "line3"
 
-  trim_file "${BATS_TEST_TMPDIR}/file.txt"
+  file_trim "${BATS_TEST_TMPDIR}/file.txt"
 
   assert_file_contains "${BATS_TEST_TMPDIR}/file.txt" "line1"
   assert_file_not_contains "${BATS_TEST_TMPDIR}/file.txt" "line2"
   assert_file_not_contains "${BATS_TEST_TMPDIR}/file.txt" "line3"
 }
 
-@test "read_env" {
+@test "file_read_env" {
   pushd "${BATS_TEST_TMPDIR}"
 
   assert_file_not_exists ".env"
@@ -38,10 +38,10 @@ load _test_helper
   echo "VAR1=val1" >>.env
   echo "VAR2=val2" >>.env
   # shellcheck disable=SC2016
-  run read_env '$VAR1'
+  run file_read_env '$VAR1'
   assert_output_contains "val1"
   # shellcheck disable=SC2016
-  run read_env '$VAR2'
+  run file_read_env '$VAR2'
   assert_output_contains "val2"
 
   popd
@@ -95,13 +95,13 @@ load _test_helper
   assert_failure
 }
 
-@test "add_var_to_file and restore_file" {
+@test "file_add_var and file_restore" {
   local backup="${BATS_TEST_TMPDIR}/bats-helpers-backup/${BATS_TEST_TMPDIR#/}/.env"
 
   echo "line1" >>"${BATS_TEST_TMPDIR}/.env"
   echo "line2" >>"${BATS_TEST_TMPDIR}/.env"
 
-  add_var_to_file "${BATS_TEST_TMPDIR}/.env" "VAR" "value"
+  file_add_var "${BATS_TEST_TMPDIR}/.env" "VAR" "value"
 
   assert_file_exists "${BATS_TEST_TMPDIR}/.env"
   assert_file_contains "${BATS_TEST_TMPDIR}/.env" "line1"
@@ -113,7 +113,7 @@ load _test_helper
   assert_file_contains "${backup}" "line2"
   assert_file_not_contains "${backup}" "VAR=value"
 
-  restore_file "${BATS_TEST_TMPDIR}/.env"
+  file_restore "${BATS_TEST_TMPDIR}/.env"
 
   assert_file_exists "${BATS_TEST_TMPDIR}/.env"
   assert_file_contains "${BATS_TEST_TMPDIR}/.env" "line1"
@@ -121,37 +121,37 @@ load _test_helper
   assert_file_not_contains "${BATS_TEST_TMPDIR}/.env" "VAR=value"
 }
 
-@test "add_var_to_file and restore_file in a custom directory" {
+@test "file_add_var and file_restore in a custom directory" {
   export BATS_HELPERS_BACKUP_DIR="${BATS_TEST_TMPDIR}/custom"
 
   echo "line1" >>"${BATS_TEST_TMPDIR}/.env"
 
-  add_var_to_file "${BATS_TEST_TMPDIR}/.env" "VAR" "value"
+  file_add_var "${BATS_TEST_TMPDIR}/.env" "VAR" "value"
 
   assert_file_exists "${BATS_HELPERS_BACKUP_DIR}/${BATS_TEST_TMPDIR#/}/.env"
   assert_file_not_exists "${BATS_TEST_TMPDIR}/bats-helpers-backup/${BATS_TEST_TMPDIR#/}/.env"
 
-  restore_file "${BATS_TEST_TMPDIR}/.env"
+  file_restore "${BATS_TEST_TMPDIR}/.env"
 
   assert_file_not_contains "${BATS_TEST_TMPDIR}/.env" "VAR=value"
 }
 
-@test "add_var_to_file preserves the value verbatim" {
+@test "file_add_var preserves the value verbatim" {
   echo "line1" >>"${BATS_TEST_TMPDIR}/.env"
 
-  add_var_to_file "${BATS_TEST_TMPDIR}/.env" "VAR" "*"
+  file_add_var "${BATS_TEST_TMPDIR}/.env" "VAR" "*"
 
   assert_file_contains "${BATS_TEST_TMPDIR}/.env" "VAR=*"
 }
 
-@test "add_var_to_file backs up files independently" {
+@test "file_add_var backs up files independently" {
   echo "first" >>"${BATS_TEST_TMPDIR}/first.env"
   echo "second" >>"${BATS_TEST_TMPDIR}/second.env"
 
-  add_var_to_file "${BATS_TEST_TMPDIR}/first.env" "VAR" "1"
-  add_var_to_file "${BATS_TEST_TMPDIR}/second.env" "VAR" "2"
+  file_add_var "${BATS_TEST_TMPDIR}/first.env" "VAR" "1"
+  file_add_var "${BATS_TEST_TMPDIR}/second.env" "VAR" "2"
 
-  restore_file "${BATS_TEST_TMPDIR}/first.env"
+  file_restore "${BATS_TEST_TMPDIR}/first.env"
 
   assert_file_contains "${BATS_TEST_TMPDIR}/first.env" "first"
   assert_file_not_contains "${BATS_TEST_TMPDIR}/first.env" "VAR=1"
@@ -162,17 +162,17 @@ load _test_helper
 
 # The file assertions glob their argument, so a path with spaces is read back
 # with "cat" instead.
-@test "add_var_to_file and restore_file with spaces in the path" {
+@test "file_add_var and file_restore with spaces in the path" {
   mkdir -p "${BATS_TEST_TMPDIR}/dir with spaces"
   echo "line1" >>"${BATS_TEST_TMPDIR}/dir with spaces/.env"
 
-  add_var_to_file "${BATS_TEST_TMPDIR}/dir with spaces/.env" "VAR" "value"
+  file_add_var "${BATS_TEST_TMPDIR}/dir with spaces/.env" "VAR" "value"
 
   run cat "${BATS_TEST_TMPDIR}/dir with spaces/.env"
   assert_success
   assert_output_contains "VAR=value"
 
-  restore_file "${BATS_TEST_TMPDIR}/dir with spaces/.env"
+  file_restore "${BATS_TEST_TMPDIR}/dir with spaces/.env"
 
   run cat "${BATS_TEST_TMPDIR}/dir with spaces/.env"
   assert_success
@@ -180,18 +180,18 @@ load _test_helper
   assert_output_not_contains "VAR=value"
 }
 
-@test "add_var_to_file for a missing file" {
-  run add_var_to_file "${BATS_TEST_TMPDIR}/missing.env" "VAR" "value"
+@test "file_add_var for a missing file" {
+  run file_add_var "${BATS_TEST_TMPDIR}/missing.env" "VAR" "value"
   assert_failure
   assert_output_contains "does not exist"
 
   assert_file_not_exists "${BATS_TEST_TMPDIR}/missing.env"
 }
 
-@test "restore_file without a backup" {
+@test "file_restore without a backup" {
   echo "line1" >>"${BATS_TEST_TMPDIR}/.env"
 
-  run restore_file "${BATS_TEST_TMPDIR}/.env"
+  run file_restore "${BATS_TEST_TMPDIR}/.env"
   assert_failure
   assert_output_contains "Backup for file"
 

--- a/tests/steps.bats
+++ b/tests/steps.bats
@@ -13,21 +13,21 @@ load _test_helper
 
   # Shorthand.
   run echo "Some Substring"
-  run_steps
+  steps_run
 
   # Full.
-  run_steps "setup"
+  steps_run "setup"
   run echo "Some Substring"
-  run_steps "assert"
+  steps_run "assert"
 
   # Full with mocks
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run echo "Some Substring"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Negative.
   run echo "Some other"
-  run run_steps "assert"
+  run steps_run "assert"
   assert_failure
 }
 
@@ -39,7 +39,7 @@ load _test_helper
   run echo "Some other"
 
   recovered=0
-  run_steps "assert" 2>/dev/null || recovered=1
+  steps_run "assert" 2>/dev/null || recovered=1
 
   assert_equal 1 "${recovered}"
 }
@@ -51,21 +51,21 @@ load _test_helper
 
   # Shorthand.
   run echo "Some other"
-  run_steps
+  steps_run
 
   # Full.
-  run_steps "setup"
+  steps_run "setup"
   run echo "Some other"
-  run_steps "assert"
+  steps_run "assert"
 
   # Full with mocks
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run echo "Some other"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Negative.
   run echo "Some Substring"
-  run run_steps "assert"
+  run steps_run "assert"
   assert_failure
 }
 
@@ -77,7 +77,7 @@ load _test_helper
   run echo "Some Substring"
 
   recovered=0
-  run_steps "assert" 2>/dev/null || recovered=1
+  steps_run "assert" 2>/dev/null || recovered=1
 
   assert_equal 1 "${recovered}"
 }
@@ -87,9 +87,9 @@ load _test_helper
     "@somebin # 0 # someval"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   somebin
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Direct command execution, args" {
@@ -97,9 +97,9 @@ load _test_helper
     "@somebin --opt1 --opt2 # 0 # someval"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   somebin --opt1 --opt2
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Wrapped execution through Bats' 'run'" {
@@ -107,10 +107,10 @@ load _test_helper
     "@somebin # 0 # someval"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin
   assert_output_contains "someval"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, args" {
@@ -118,10 +118,10 @@ load _test_helper
     "@somebin --opt1 --opt2 # 0 # someval"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1 --opt2
   assert_output_contains "someval"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, args - negative: wrong args" {
@@ -129,11 +129,11 @@ load _test_helper
     "@somebin --opt1 --opt2 # 0 # someval"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1 --opt2 --opt3
   assert_output_contains "someval"
 
-  run run_steps "assert" "${mocks[@]}"
+  run steps_run "assert" "${mocks[@]}"
   assert_failure
   assert_output_contains "ERROR: Mocked command 'somebin' was called with arguments '--opt1 --opt2 --opt3', but '--opt1 --opt2' was expected."
 }
@@ -143,11 +143,11 @@ load _test_helper
     "@somebin --opt1 --opt2 # 0 # someval"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1 --opt2 --opt3
 
   recovered=0
-  run_steps "assert" "${mocks[@]}" 2>/dev/null || recovered=1
+  steps_run "assert" "${mocks[@]}" 2>/dev/null || recovered=1
 
   assert_equal 1 "${recovered}"
 }
@@ -157,7 +157,7 @@ load _test_helper
     "@somebin --opt1 --opt2 # 0 # someval"
   )
 
-  run run_steps "assert" "otherbin=/some/mock/path"
+  run steps_run "assert" "otherbin=/some/mock/path"
   assert_failure
   assert_output_contains "ERROR: Mock for the binary 'somebin' does not exist."
 }
@@ -168,7 +168,7 @@ load _test_helper
   )
 
   recovered=0
-  run_steps "assert" "otherbin=/some/mock/path" 2>/dev/null || recovered=1
+  steps_run "assert" "otherbin=/some/mock/path" 2>/dev/null || recovered=1
 
   assert_equal 1 "${recovered}"
 }
@@ -178,10 +178,10 @@ load _test_helper
     "@somebin --opt1 --opt2"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1 --opt2
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, args, output, no exit code" {
@@ -189,11 +189,11 @@ load _test_helper
     "@somebin --opt1 --opt2 # someval with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1 --opt2
   assert_output_contains "someval with spaces"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, args, error exit code" {
@@ -201,12 +201,12 @@ load _test_helper
     "@somebin --opt1 --opt2 # 1 # someval with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1 --opt2
   assert_failure
   assert_output_contains "someval with spaces"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, args - negative: incorrect input - delim" {
@@ -214,7 +214,7 @@ load _test_helper
     "@somebin --opt1 --opt2 # 0 ## someval"
   )
 
-  run run_steps "setup" "${mocks[@]}"
+  run steps_run "setup" "${mocks[@]}"
   assert_failure
   assert_output_contains "ERROR: The string should not contain consecutive '##' and should have a maximum of three '#' characters in total."
 }
@@ -225,7 +225,7 @@ load _test_helper
   )
 
   recovered=0
-  run_steps "setup" 2>/dev/null || recovered=1
+  steps_run "setup" 2>/dev/null || recovered=1
 
   assert_equal 1 "${recovered}"
 }
@@ -236,7 +236,7 @@ load _test_helper
     "@somebin --opt1 --opt2 # 0 # someval2 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run somebin --opt1 --opt2
   assert_output_contains "someval1 with spaces"
@@ -245,7 +245,7 @@ load _test_helper
   assert_output_not_contains "someval1 with spaces"
   assert_output_contains "someval2 with spaces"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, multiple commands, same, combined execution" {
@@ -254,13 +254,13 @@ load _test_helper
     "@somebin --opt1 --opt2 # 0 # someval2 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run bash -c "somebin --opt1 --opt2; somebin --opt1 --opt2"
   assert_output_contains "someval1 with spaces"
   assert_output_contains "someval2 with spaces"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, multiple commands, same, combined execution, and" {
@@ -269,13 +269,13 @@ load _test_helper
     "@somebin --opt1 --opt2 # 0 # someval2 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run bash -c "somebin --opt1 --opt2 && somebin --opt1 --opt2"
   assert_output_contains "someval1 with spaces"
   assert_output_contains "someval2 with spaces"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, multiple commands, different" {
@@ -284,14 +284,14 @@ load _test_helper
     "@otherbin --opt1 --opt2 # 0 # someval2 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run somebin --opt1 --opt2
   assert_success
   run otherbin --opt1 --opt2
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, multiple commands, different - negative: incorrect arguments" {
@@ -300,13 +300,13 @@ load _test_helper
     "@otherbin --opt1 --opt2 # 0 # someval2 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt3 --opt4
   assert_success
   run otherbin --opt1 --opt2
   assert_success
 
-  run run_steps "assert" "${mocks[@]}"
+  run steps_run "assert" "${mocks[@]}"
   assert_failure
 }
 
@@ -317,7 +317,7 @@ load _test_helper
     "@otherbin --opt3 --opt4 # 0 # someval3 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run somebin --opt1 --opt2
   assert_output_contains "someval1 with spaces"
@@ -332,7 +332,7 @@ load _test_helper
   assert_output_not_contains "someval2 with spaces"
   assert_output_contains "someval3 with spaces"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, multiple commands, different, repeated call - negative" {
@@ -342,7 +342,7 @@ load _test_helper
     "@otherbin --opt3 --opt4 # 0 # someval3 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run somebin --opt1 --opt2
   assert_output_contains "someval1 with spaces"
@@ -354,7 +354,7 @@ load _test_helper
   assert_output_not_contains "someval3 with spaces"
 
   # Asserting missing call to the 'otherbin'.
-  run run_steps "assert" "${mocks[@]}"
+  run steps_run "assert" "${mocks[@]}"
   assert_failure
 }
 
@@ -368,7 +368,7 @@ load _test_helper
     "@otherbin --opt33 --opt43 # 0 # someval6 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run somebin --opt11 --opt21
   run somebin --opt11 --opt22
@@ -377,7 +377,7 @@ load _test_helper
   run otherbin --opt32 --opt42
   run otherbin --opt33 --opt43
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, multiple commands, different, repeated call, order - negative" {
@@ -390,7 +390,7 @@ load _test_helper
     "@otherbin --opt33 --opt43 # 0 # someval6 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run somebin --opt11 --opt21
   run somebin --opt13 --opt23
@@ -399,7 +399,7 @@ load _test_helper
   run otherbin --opt31 --opt41
   run otherbin --opt33 --opt43
 
-  run run_steps "assert" "${mocks[@]}"
+  run steps_run "assert" "${mocks[@]}"
   assert_failure
 }
 
@@ -419,11 +419,11 @@ load _test_helper
     "- absent someval5 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run bash -c "somebin --opt1 --opt2; somebin --opt1 --opt2; somebin --opt1 --opt2 --opt3; otherbin --opt1 --opt2 --opt3; otherbin --opt1 --opt2 --opt3"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, multiple commands, different, combined, repeated call, order, shorthand" {
@@ -442,11 +442,11 @@ load _test_helper
     "- absent someval5 with spaces"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run bash -c "somebin --opt1 --opt2; somebin --opt1 --opt2; somebin --opt1 --opt2 --opt3; otherbin --opt1 --opt2 --opt3; otherbin --opt1 --opt2 --opt3"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command, multi-line argument" {
@@ -460,14 +460,14 @@ load _test_helper
     # 0 # multi-line arg"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1 \
     --opt2 \
     --opt3 \
     "{" \
     "test": 1 \
     "}"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command with side effect - basic file creation" {
@@ -475,12 +475,12 @@ load _test_helper
     '@somebin --opt1 # 0 # success # touch ${BATS_TEST_TMPDIR}/side_effect_file'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1
   assert_output_contains "success"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify side effect was executed
   assert_file_exists "${BATS_TEST_TMPDIR}/side_effect_file"
@@ -491,14 +491,14 @@ load _test_helper
     "@somebin --opt1 # 0 # success # export TEST_SIDE_EFFECT=executed"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   # Side effects are executed in the mock's context, not the test context
   run somebin --opt1
   assert_output_contains "success"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Command with side effect - echo to file" {
@@ -506,12 +506,12 @@ load _test_helper
     "@somebin --opt1 # 0 # success # echo 'side effect executed' > \${BATS_TEST_TMPDIR}/side_effect_output"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1
   assert_output_contains "success"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify side effect output
   assert_file_exists "${BATS_TEST_TMPDIR}/side_effect_output"
@@ -524,12 +524,12 @@ load _test_helper
     "@somebin --opt1 # 0 # success # touch \${BATS_TEST_TMPDIR}/file1; echo 'data' > \${BATS_TEST_TMPDIR}/file2"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1
   assert_output_contains "success"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify both side effects were executed
   assert_file_exists "${BATS_TEST_TMPDIR}/file1"
@@ -543,12 +543,12 @@ load _test_helper
     "@somebin --opt1 # 1 # error message # echo 'error logged' > \${BATS_TEST_TMPDIR}/error_log"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1
   assert_output_contains "error message"
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify side effect was executed even with failure status
   assert_file_exists "${BATS_TEST_TMPDIR}/error_log"
@@ -561,11 +561,11 @@ load _test_helper
     '@somebin --opt1 # 0 # # touch ${BATS_TEST_TMPDIR}/no_output_side_effect'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify side effect was executed
   assert_file_exists "${BATS_TEST_TMPDIR}/no_output_side_effect"
@@ -576,12 +576,12 @@ load _test_helper
     '@somebin --opt1 # success output # # touch ${BATS_TEST_TMPDIR}/shorthand_side_effect'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin --opt1
   assert_output_contains "success output"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify side effect was executed
   assert_file_exists "${BATS_TEST_TMPDIR}/shorthand_side_effect"
@@ -593,7 +593,7 @@ load _test_helper
     "@cmd2 # 0 # output2 # echo 'cmd2 executed' > \${BATS_TEST_TMPDIR}/cmd2_file"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run cmd1
   assert_output_contains "output1"
@@ -603,7 +603,7 @@ load _test_helper
   assert_output_contains "output2"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify both side effects were executed
   assert_file_exists "${BATS_TEST_TMPDIR}/cmd1_file"
@@ -618,7 +618,7 @@ load _test_helper
     '@somebin # 0 # call2 # touch ${BATS_TEST_TMPDIR}/call2_file'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run somebin
   assert_output_contains "call1"
@@ -628,7 +628,7 @@ load _test_helper
   assert_output_contains "call2"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify both side effects were executed
   assert_file_exists "${BATS_TEST_TMPDIR}/call1_file"
@@ -640,7 +640,7 @@ load _test_helper
     "@somebin # 0 # output # side effect # extra"
   )
 
-  run run_steps "setup"
+  run steps_run "setup"
   assert_failure
   assert_output_contains "ERROR: The string should not contain consecutive '##' and should have a maximum of three '#' characters in total."
 }
@@ -650,7 +650,7 @@ load _test_helper
     "@somebin # 0 ## output # side effect"
   )
 
-  run run_steps "setup"
+  run steps_run "setup"
   assert_failure
   assert_output_contains "ERROR: The string should not contain consecutive '##' and should have a maximum of three '#' characters in total."
 }
@@ -662,7 +662,7 @@ load _test_helper
     "@somebin * # 0 # wildcard output 3"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   # Test with different arguments - all should work
   run somebin --opt1 --opt2
@@ -677,7 +677,7 @@ load _test_helper
   assert_output_contains "wildcard output 3"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Wildcard command - multiple calls with different args" {
@@ -686,7 +686,7 @@ load _test_helper
     "@git * # 0 # git output 2"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run git status
   assert_output_contains "git output 1"
@@ -696,7 +696,7 @@ load _test_helper
   assert_output_contains "git output 2"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Wildcard command - with side effects" {
@@ -704,13 +704,13 @@ load _test_helper
     '@somebin * # 0 # wildcard success # touch ${BATS_TEST_TMPDIR}/wildcard_file'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run somebin any args here
   assert_output_contains "wildcard success"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify side effect was executed
   assert_file_exists "${BATS_TEST_TMPDIR}/wildcard_file"
@@ -721,13 +721,13 @@ load _test_helper
     "@somebin * # 1 # wildcard error"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run somebin any args
   assert_output_contains "wildcard error"
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Mixed exact and wildcard commands" {
@@ -737,7 +737,7 @@ load _test_helper
     "@npm * # 1 # npm error"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   # This should match the exact command
   run git status
@@ -754,7 +754,7 @@ load _test_helper
   assert_output_contains "npm error"
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Wildcard command - shorthand syntax" {
@@ -762,13 +762,13 @@ load _test_helper
     "@somebin * # wildcard shorthand output"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run somebin any arguments
   assert_output_contains "wildcard shorthand output"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Escaped hash - URL with fragment in command arguments" {
@@ -776,11 +776,11 @@ load _test_helper
     "@curl -fsSL https://example.com\#anchor -o file.php # 0"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run curl -fsSL "https://example.com#anchor" -o file.php
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Escaped hash - Git URL with branch fragment" {
@@ -788,12 +788,12 @@ load _test_helper
     "@git clone https://github.com/user/repo.git\#stable # 0 # Cloning repo"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run git clone "https://github.com/user/repo.git#stable"
   assert_output_contains "Cloning repo"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Escaped hash - multiple escaped hashes in arguments" {
@@ -801,11 +801,11 @@ load _test_helper
     "@somebin --url1=https://a.com\#tag1 --url2=https://b.com\#tag2 # 0"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin "--url1=https://a.com#tag1" "--url2=https://b.com#tag2"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Escaped hash - in output" {
@@ -813,12 +813,12 @@ load _test_helper
     "@somebin # 0 # Output with \# hash"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin
   assert_output_contains "Output with # hash"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Escaped hash - in side effect" {
@@ -826,12 +826,12 @@ load _test_helper
     '@somebin # 0 # success # echo "Comment \# starts here" > ${BATS_TEST_TMPDIR}/escaped_hash'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin
   assert_output_contains "success"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify side effect contains unescaped hash
   assert_file_exists "${BATS_TEST_TMPDIR}/escaped_hash"
@@ -844,12 +844,12 @@ load _test_helper
     "@curl -fsSL https://example.com/install?key=123\#section -o installer.php # 0 # Downloaded"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run curl -fsSL "https://example.com/install?key=123#section" -o installer.php
   assert_output_contains "Downloaded"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Escaped hash - mix of escaped and delimiter hashes" {
@@ -857,12 +857,12 @@ load _test_helper
     "@php installer.php --uri=https://github.com/repo.git\#stable # 0 # Success \# done"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run php installer.php "--uri=https://github.com/repo.git#stable"
   assert_output_contains "Success # done"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Escaped hash - all three parts with escaped hashes" {
@@ -870,12 +870,12 @@ load _test_helper
     '@somebin --url=https://site.com\#tag # 0 # Message with \# hash # echo "Comment \# here" > ${BATS_TEST_TMPDIR}/all_escaped'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run somebin "--url=https://site.com#tag"
   assert_output_contains "Message with # hash"
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # Verify side effect
   assert_file_exists "${BATS_TEST_TMPDIR}/all_escaped"
@@ -891,7 +891,7 @@ load _test_helper
     "Downloading installer to installer.php"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run bash -c "curl -fsSL https://www.vortextemplate.com/install?1234567890 -o installer.php && \
                php installer.php --no-interaction --uri=https://github.com/drevops/vortex.git#stable && \
@@ -900,7 +900,7 @@ load _test_helper
 
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 
 @test "Debug output" {
@@ -912,9 +912,9 @@ load _test_helper
     "Some Substring"
   )
 
-  mocks="$(run_steps "setup" 3>"${debug}")"
+  mocks="$(steps_run "setup" 3>"${debug}")"
   run curl example.com
-  run_steps "assert" "${mocks[@]}" 3>>"${debug}"
+  steps_run "assert" "${mocks[@]}" 3>>"${debug}"
 
   assert_file_contains "${debug}" "  > Phase       : setup"
   assert_file_contains "${debug}" "  > Phase       : assert"
@@ -933,20 +933,20 @@ load _test_helper
   )
 
   run echo "Some Substring"
-  run_steps "assert" 3>"${debug}"
+  steps_run "assert" 3>"${debug}"
 
   assert_empty "$(cat "${debug}")"
 }
 
 @test "Missing STEPS" {
-  run run_steps "assert"
+  run steps_run "assert"
   assert_failure
   assert_output_contains "STEPS array is empty."
 }
 
 @test "Missing STEPS - caller recovers" {
   recovered=0
-  run_steps "assert" 2>/dev/null || recovered=1
+  steps_run "assert" 2>/dev/null || recovered=1
 
   assert_equal 1 "${recovered}"
 }
@@ -957,10 +957,10 @@ load _test_helper
     "@curl example.org # 0"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run curl example.com
 
-  run run_steps "assert" "${mocks[@]}"
+  run steps_run "assert" "${mocks[@]}"
   assert_failure
   assert_output_contains "Mocked command 'curl' was expected to be called at least 2 time(s), but was called fewer times."
 }
@@ -971,11 +971,11 @@ load _test_helper
     "@curl example.org # 0"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run curl example.com
 
   recovered=0
-  run_steps "assert" "${mocks[@]}" 2>/dev/null || recovered=1
+  steps_run "assert" "${mocks[@]}" 2>/dev/null || recovered=1
 
   assert_equal 1 "${recovered}"
 }


### PR DESCRIPTION
Closes #172

## Summary

The public surface mixed two naming orders. Most helpers were already subject-first (`mock_create`, `fixture_prepare_dir`, `steps_debug`), but eight were verb-first, and three modules carried both orders at once, so no rule let a consumer guess a name. This renames those eight to subject-first, so every helper in a module shares one prefix, matching how bats-core namespaces `bats_*` and bats-support namespaces `batslib_*`.

Every old name survives as a deprecated alias that writes a notice to file descriptor 3 and forwards to its replacement, so nothing breaks for existing consumers. Each alias is written out in full next to the group it belongs to; there is deliberately no shared deprecation helper, matching the five aliases already in the library.

Writing the first test for `string_random` also uncovered a real bug in it, fixed here.

## Changes

### Renames

| Current | Was |
|---|---|
| `steps_run` | `run_steps` |
| `mock_setup` | `setup_mock` |
| `file_mktouch` | `mktouch` |
| `file_trim` | `trim_file` |
| `file_read_env` | `read_env` |
| `file_add_var` | `add_var_to_file` |
| `file_restore` | `restore_file` |
| `string_random` | `random_string` |

The `assert_*` family is untouched: there the verb is already the namespace, and the shape matches bats-assert and bats-file exactly. `flunk` and `format_error` stay bare verbs, mirroring bats-support's `fail`.

Converging on subject-first cost eight renames. Converging on verb-first would have cost roughly twenty-two, including a rewrite of the entire vendored `mock_*` surface, widening the divergence from grayhemp/bats-mock that the vendored copy exists to minimise.

### `string_random` bug fix

`string_random` had no test before this branch, and the first one failed on every macOS runner: the call returned 52 characters when asked for 8. Its implementation piped `cat /dev/urandom` through `tr`, `fold` and `head`. Command substitution captures standard output only, so a broken-pipe warning or a locale complaint from any stage escaped to the function's standard error, where Bats' `run` merges it into `$output` and the caller receives the error text instead of a random string.

It is now built from Bash's own generator over an explicit alphabet, with no subprocess at all, so there is no stream that can leak into the return value and no reader left waiting on a device. This trades `/dev/urandom` for Bash's PRNG; the function generates test fixture strings and never claimed cryptographic randomness.

The length argument is now validated as a non-negative decimal and normalised with `10#`, so a zero-padded length such as `08` is not read as octal.

### Call sites, tests and docs

- Every call site across `src/` and `tests/` moved to the new names.
- Eight alias tests added to `tests/deprecation.bats`, one per renamed helper, each asserting that the old name still works and still warns.
- First direct tests for `string_random`, covering the character class, a zero-padded length and a non-numeric length.
- `tests/deprecation.bats` gained `SC2034` on its file-level shellcheck directive, since `STEPS` reaches `steps_run` through Bash dynamic scoping and is invisible to static analysis, matching `tests/steps.bats`.
- README Helpers and Deprecations tables updated; the Deprecations section now notes that the replacement keeps the arguments, standard output and return semantics, while the alias additionally writes its notice to file descriptor 3.
- `CLAUDE.md` gained a Function Naming section recording the rule and its two exceptions, so the convention does not drift back.

### Not included

`RUN_STEPS_DEBUG` still carries the old function's name. Globals have no alias mechanism, so renaming one is a different compatibility question, and the library's globals are already inconsistent among themselves - `BATS_HELPERS_BACKUP_DIR` and `BATS_FIXTURE_EXPORT_CODEBASE_ENABLED` are prefixed, while `STEPS`, `TEST_CASES`, `SCRIPT_FILE` and `ASSERT_DIR_EXCLUDE` are not. That belongs in its own pass.

## Before / After

```
BEFORE - two orders, three modules carrying both
┌──────────────────┬──────────────────────────────────────────────┐
│ steps.bash       │ run_steps          ◀── verb-first            │
│                  │ steps_debug                                  │
│                  │ steps_debug_sub                              │
│                  │ steps_debug_write                            │
├──────────────────┼──────────────────────────────────────────────┤
│ mock.bash        │ setup_mock         ◀── verb-first            │
│                  │ mock_create                                  │
│                  │ mock_set_*  mock_get_*  mock_command  …       │
├──────────────────┼──────────────────────────────────────────────┤
│ file.bash        │ mktouch            ◀── verb-first            │
│                  │ trim_file          ◀── verb-first            │
│                  │ read_env           ◀── verb-first            │
│                  │ add_var_to_file    ◀── verb-first            │
│                  │ restore_file       ◀── verb-first            │
│                  │ file_backup_path                             │
├──────────────────┼──────────────────────────────────────────────┤
│ assert.string    │ random_string      ◀── verb-first            │
└──────────────────┴──────────────────────────────────────────────┘
   grep '^mock_' finds part of a module. No rule predicts a name.

AFTER - one prefix per module, old names aliased
┌──────────────────┬──────────────────────────────────────────────┐
│ steps.bash       │ steps_run  steps_debug  steps_debug_sub  …   │
├──────────────────┼──────────────────────────────────────────────┤
│ mock.bash        │ mock_setup  mock_create  mock_set_*  …       │
├──────────────────┼──────────────────────────────────────────────┤
│ file.bash        │ file_mktouch  file_trim  file_read_env       │
│                  │ file_add_var  file_restore  file_backup_path │
├──────────────────┼──────────────────────────────────────────────┤
│ assert.string    │ string_random                                │
└──────────────────┴──────────────────────────────────────────────┘
   grep '^file_' finds the whole module. The prefix is the namespace.

   old name ──▶ notice on fd 3 ──▶ replacement
   (removed in the next version; silenced by BATS_HELPERS_DEPRECATION_QUIET)
```

```
string_random - what the caller received

BEFORE   cat /dev/urandom │ tr │ fold │ head
                           └────────┬────────┘
                    stdout ─────────┴──────────▶ captured by $( )
                    stderr ────────────────────▶ leaks to caller
                                                 └─▶ Bats 'run' merges it
                                                     into $output
         asked for 8 characters, received 52 on macOS

AFTER    Bash $RANDOM over an explicit alphabet
                    stdout ────────────────────▶ the value
                    (no subprocess, no stream to leak, nothing to hang)
         asked for 8 characters, received 8 everywhere
```
