### PR TITLE
Reconciled the documentation with the code and added contributor and security docs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,5 @@
 /.gitignore           export-ignore
 /.npmignore           export-ignore
 /CLAUDE.md            export-ignore
-/lint.sh              export-ignore
 /renovate.json        export-ignore
 /tests                export-ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+Thank you for considering a contribution to BATS helpers.
+
+## Reporting an issue
+
+Search the [existing issues](https://github.com/drevops/bats-helpers/issues) before opening a new one. A report is most useful when it names the BATS version and the operating system, and includes a minimal test that reproduces the behaviour.
+
+## Local setup
+
+Requires [Node.js](https://nodejs.org). `bats-core` is installed alongside the other dependencies:
+
+```shell
+npm install
+```
+
+Linting additionally requires [shellcheck](https://www.shellcheck.net) and [shfmt](https://github.com/mvdan/sh).
+
+## Running the tests
+
+```shell
+npm run test
+```
+
+Pass any other flag, or a single file, to `bats` directly:
+
+```shell
+./node_modules/.bin/bats tests/assert.base.bats
+./node_modules/.bin/bats --verbose-run tests/
+./node_modules/.bin/bats --timing tests/
+```
+
+`--verbose-run` prints each test's `BATS_TEST_TMPDIR`, which is where the fixtures for that test are built.
+
+Coverage is measured with [kcov](https://github.com/SimonKagstrom/kcov) in CI and uploaded to [Codecov](https://codecov.io/gh/drevops/bats-helpers). CI runs the suite on Ubuntu and macOS, against both the current and the lowest supported `bats-core`.
+
+## Linting
+
+```shell
+npm run lint
+```
+
+`npm run lint-fix` applies the `shfmt` formatting in place. It does not fix `shellcheck` findings.
+
+## Coding standards
+
+[`CLAUDE.md`](CLAUDE.md) holds the conventions this library is written to: how helpers are named, how failure messages are worded, and how file headers and function docblocks are laid out. Read it before adding a helper.
+
+Two rules that are easy to miss:
+
+- A helper is named `<subject>_<verb>` after the module that owns it, because Bash has no namespaces and the prefix is the namespace. The `assert_*` family is the exception and keeps the verb first.
+- Every assertion is tested for both its positive and its negative behaviour, in one `@test` per assertion.
+
+## Releasing
+
+```shell
+npm version minor
+git push
+npm publish
+```
+
+The `Draft release notes` workflow runs on pushes to `main` and on tag pushes, and assembles the GitHub release draft from the merged pull request titles.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://bats-helpers.drevops.com" rel="noopener">
- <img width=200px height=200px src="https://placehold.jp/000000/ffffff/200x200.png?text=BATS%20helpers&css=%7B%22border-radius%22%3A%22%20100px%22%7D" alt="Project logo"></a>
+ <img width=200px height=200px src="https://placehold.jp/000000/ffffff/200x200.png?text=BATS%20helpers&css=%7B%22border-radius%22%3A%22%20100px%22%7D" alt="BATS helpers logo"></a>
 </p>
 
 <h1 align="center">BATS helpers</h1>
@@ -23,18 +23,29 @@
 
 ## Table of Contents
 
-- [Installation](#installation)
-- [Usage](#usage)
+- [Features](#-features)
+- [Installation](#-installation)
+- [Usage](#-usage)
   - [Load library](#load-library)
   - [Assertions](#assertions) - Command run, String, File, Git
-  - [Data Provider](#data-provider) - Parameterized tests
+  - [Data provider](#data-provider) - Parameterized tests
   - [Mocking](#mocking) - Command mocking
-  - [Step Runner](#step-runner) - Sequential test assertions
+  - [Step runner](#step-runner) - Sequential test assertions
   - [Helpers](#helpers) - Utility functions
   - [Deprecations](#deprecations) - Renamed and reordered functions
-- [Maintenance](#maintenance)
+- [Acknowledgments](#-acknowledgments)
+- [Contributing](#-contributing)
 
-## Installation
+## ✨ Features
+
+- Assertions for command output, strings, files, directories and git repositories.
+- Command mocking with per-call output, exit status and side effects.
+- Step runner for sequences of mocked calls and output assertions.
+- Data provider for running one function over many test cases.
+- Fixture and file utilities for building and restoring test sandboxes.
+- TUI helper for driving interactive scripts with scripted answers.
+
+## 📦 Installation
 
 Requires [bats-core](https://github.com/bats-core/bats-core) `1.10` or newer.
 
@@ -48,12 +59,10 @@ This will also install `bats-core`.
 
 ### From source
 
-1. Click `Code` -> `Download ZIP` in
-   the [GitHub UI](https://github.com/drevops/bats-helpers).
-2. Extract files to a desired location. Usually, next to where `bats-core` is
-   located.
+1. Click `Code` -> `Download ZIP` in the [GitHub UI](https://github.com/drevops/bats-helpers).
+2. Extract files to a desired location. Usually, next to where `bats-core` is located.
 
-## Usage
+## 🚀 Usage
 
 ### Load library
 
@@ -105,6 +114,8 @@ Use these after running a command with `run`.
 | `assert_string_contains`     | Asserts that a string contains a given substring   |
 | `assert_string_not_contains` | Asserts that a string does not contain a substring |
 
+`assert_string_contains` and `assert_string_not_contains` match case-insensitively and treat the needle as a literal string. So do the assertions built on them: `assert_output_contains`, `assert_output_not_contains`, `assert_file_contains` and `assert_file_not_contains`.
+
 Every `contains` assertion takes the container first and the string to look for second:
 
 ```bash
@@ -136,6 +147,13 @@ assert_dir_contains_string "${dir}" "needle"
 | `assert_symlink_exists`          | Asserts that a symbolic link exists                    |
 | `assert_symlink_not_exists`      | Asserts that a symbolic link does not exist            |
 
+`assert_dir_contains_string` and `assert_dir_not_contains_string` search recursively, skip binary files, and always exclude `.git`, `.idea`, `vendor` and `node_modules`. Unlike the string and file assertions, they match case-sensitively and read the string as a `grep` basic regular expression. Set `ASSERT_DIR_EXCLUDE` to an array of additional directory names to exclude:
+
+```bash
+declare -a ASSERT_DIR_EXCLUDE=("build" "dist")
+assert_dir_contains_string "${dir}" "needle"
+```
+
 #### Git assertions
 
 | Function Name                 | Description                                      |
@@ -147,16 +165,16 @@ assert_dir_contains_string "${dir}" "needle"
 | `assert_git_file_tracked`     | Checks if a file is tracked in git               |
 | `assert_git_file_not_tracked` | Checks if a file is not tracked in git           |
 
-### Data Provider
+`assert_git_file_tracked` and `assert_git_file_not_tracked` report through the exit status alone and print no message.
+
+### Data provider
 
 Run multiple test cases for a given function (aka "data provider").
 
 Arguments:
 
 1. `func_name`: The name of the function to be tested.
-2. `args_per_row`: (Optional) The number of arguments in each row of the
-   `TEST_CASES` array, defaults to `1`. Last argument is always the expected
-   value.
+2. `args_per_row`: (Optional) The number of arguments in each row of the `TEST_CASES` array, defaults to `1`. Last argument is always the expected value.
 
 Global Variables:
 
@@ -164,8 +182,7 @@ Global Variables:
 
 **Examples:**
 
-To run a function `add_numbers` with `TEST_CASES` containing three arguments per
-row, you can call `dataprovider_run` like so:
+To run a function `add_numbers` with `TEST_CASES` containing three arguments per row, you can call `dataprovider_run` like so:
 
 ```bash
 # Function to test.
@@ -175,7 +192,7 @@ add_numbers() {
 
 @test "Test add_numbers" {
   # Numbers: first two are inputs, last is expected output.
-  TEST_CASES=(
+  declare -a TEST_CASES=(
     1 2 3
     4 5 9
   )
@@ -189,12 +206,10 @@ This Bats helper library provides command mocking functionality for BATS.
 
 It allows to mock commands and check how they were called.
 
-This is a very powerful feature that allows to test complex scenarios as unit
-tests.
+This is a very powerful feature that allows to test complex scenarios as unit tests.
 
 > [!NOTE]
-> To run multiple mock assertions in a more convenient way, check out
-> the [Step Runner](#step-runner) helper.
+> To run multiple mock assertions in a more convenient way, check out the [Step runner](#step-runner) helper.
 
 #### Setup functions
 
@@ -209,12 +224,13 @@ tests.
 
 #### Assertion functions
 
-| Function             | Description                                | Arguments                          | Returns          |
-|----------------------|--------------------------------------------|------------------------------------|------------------|
-| `mock_get_call_args` | Returns arguments the mock was called with | `mock`, `[call_index]`             | Arguments string |
-| `mock_get_call_num`  | Returns number of times mock was called    | `mock`                             | Call count       |
-| `mock_get_call_user` | Returns user the mock was called with      | `mock`, `[call_index]`             | User name        |
-| `mock_get_call_env`  | Returns env variable value from mock call  | `mock`, `var_name`, `[call_index]` | Variable value   |
+| Function                | Description                                                                    | Arguments                               | Returns          |
+|-------------------------|--------------------------------------------------------------------------------|-----------------------------------------|------------------|
+| `mock_get_call_args`    | Returns arguments the mock was called with                                     | `mock`, `[call_index]`                  | Arguments string |
+| `mock_get_call_num`     | Returns number of times mock was called                                        | `mock`                                  | Call count       |
+| `mock_get_call_user`    | Returns user the mock was called with                                          | `mock`, `[call_index]`                  | User name        |
+| `mock_get_call_env`     | Returns env variable value from mock call                                      | `mock`, `var_name`, `[call_index]`      | Variable value   |
+| `mock_assert_call_args` | Checks the arguments the mock was called with, where `*` matches any arguments | `mock`, `expected_args`, `[call_index]` | `0` when matched |
 
 #### Example
 
@@ -223,14 +239,14 @@ setup() {
   mock_setup
 }
 
-# Example to test the notify.sh script that uses curl to send a notification to external system.
+# Test notify.sh, which uses curl to notify an external system.
 @test "Notify" {
   app_id="9876543210"
 
   # Mock curl command.
   mock_curl="$(mock_command "curl")"
 
-  # Setup mock responses for curl call with specific arguments in notify.sh.
+  # Setup mock responses for the curl calls made by notify.sh.
   mock_set_output "${mock_curl}" "12345678910-1234567890-${app_id}-12345" 1
   mock_set_output "${mock_curl}" "201" 2
 
@@ -238,28 +254,24 @@ setup() {
   assert_success
 
   # Single line mock assertion example.
-  assert_equal "-s -X GET https://api.example.com/v2/applications.json" "$(mock_get_call_args "${mock_curl}" 1)"
+  assert_equal "-s -X GET https://api.example.com/v2/applications.json" \
+    "$(mock_get_call_args "${mock_curl}" 1)"
+
   # Multi-line mock assertion example.
-  assert_equal '-X POST https://api.example.com/v2/applications/9876543210/deployments.json -d {
-  "deployment": {
-    "description": "example description",
+  url="https://api.example.com/v2/applications/${app_id}/deployments.json"
+  assert_equal "-X POST ${url} -d {
+  \"deployment\": {
+    \"description\": \"example description\",
   }
-}' "$(mock_get_call_args "${mock_curl}" 2)"
+}" "$(mock_get_call_args "${mock_curl}" 2)"
 }
 ```
 
-### Step Runner
+### Step runner
 
-When working with mocks, you would have to setup a mock for each command call
-with the expected argument numbers, return value, possible output and an index
-of the call. Then, you would run the code to be tested and run assertions for
-each of the
-mocked commands. For large scripts maintaining both parts becomes a tedious
-task.
+When working with mocks, you would have to setup a mock for each command call with the expected argument numbers, return value, possible output and an index of the call. Then, you would run the code to be tested and run assertions for each of the mocked commands. For large scripts maintaining both parts becomes a tedious task.
 
-The Step Runner allows to setup and process a sequence of string and mocked
-command
-assertions. It helps to make maintenance of complex tests easier.
+The step runner allows to setup and process a sequence of string and mocked command assertions. It helps to make maintenance of complex tests easier.
 
 Consider this example:
 
@@ -278,12 +290,12 @@ declare -a STEPS=(
 
   # Mock command with exit status, output, AND side effect.
   # Side effect creates a file when the mock is called.
-  "@drush cache-rebuild # 0 # Cache rebuilt # touch /tmp/cache-cleared"
+  "@drush cache-rebuild # 0 # Rebuilt # touch ${BATS_TEST_TMPDIR}/done"
 
   # Mock command with wildcard (*) - accepts any arguments.
   "@git * # 0 # Git operation successful"
 
-  # Mock command with escaped hash (\#) in URL - use \# for literal # in arguments.
+  # Escaped hash: use \# for a literal # in arguments.
   "@curl https://example.com/page\#anchor # 0 # Response body"
 
   # Assert that the output contains the substring "Hello world".
@@ -301,7 +313,7 @@ mocks="$(steps_run "setup")"
 run ./my-script.sh
 
 # Assert phase: verifies mocks were called correctly and output assertions pass.
-steps_run "assert" "$mocks"
+steps_run "assert" "${mocks}"
 ```
 
 #### Step types
@@ -336,6 +348,8 @@ Mock a command with the given status, optional output, and optional side effect.
   - Use `${BATS_TEST_TMPDIR}` for temporary files
   - Each invocation of the same command can have different side effects
 
+A step may contain at most three `#` characters and no consecutive `##`. Escape a literal `#` in the arguments as `\#`.
+
 ##### Substring presence
 
 `<substring>`
@@ -346,25 +360,38 @@ Assert that the output contains the given substring.
 
 `- <substring>`
 
-Assert that the output does not contain the specified substring.
-Starts with `- ` (minus followed by a space).
+Assert that the output does not contain the specified substring. Starts with `- ` (minus followed by a space).
+
+##### Debugging
+
+Set `RUN_STEPS_DEBUG` to `1` to print the parsing and matching decisions of every step to file descriptor 3:
+
+```bash
+export RUN_STEPS_DEBUG=1
+```
 
 ### Helpers
 
 | Function Name             | Description                                                                   |
 |---------------------------|-------------------------------------------------------------------------------|
-| `file_add_var`            | Adds a variable assignment to a file and creates a backup                     |
-| `file_restore`            | Restores a file from its backup created by file_add_var                       |
-| `file_backup_path`        | Returns the sandbox path of a file's backup                                   |
-| `file_read_env`           | Reads .env file and evaluates variable expressions in that context            |
-| `format_error`            | Formats error messages with decorative borders and includes command output    |
-| `flunk`                   | Causes a test to fail with an optional error message                          |
-| `file_mktouch`            | Creates a file and any necessary parent directories                           |
-| `fixture_export_codebase` | Export codebase source code at the latest commit to the destination directory |
-| `fixture_prepare_dir`     | Prepares a directory for fixture use by removing existing content             |
-| `string_random`           | Generates a random alphanumeric string of specified length                    |
-| `file_trim`               | Removes the last line from a file                                             |
-| `tui_run`                 | Runs a TUI script with predefined answers, simulating user input              |
+| `file_mktouch`            | Creates a file and any missing parent directories                             |
+| `file_trim`               | Removes the last line of a file in place                                      |
+| `file_read_env`           | Evaluates an expression with the variables from the `./.env` file in scope    |
+| `file_backup_path`        | Resolves the backup location of a file                                        |
+| `file_add_var`            | Appends a variable assignment to a file, backing the file up first            |
+| `file_restore`            | Restores a file from the backup taken by `file_add_var`                       |
+| `fixture_prepare_dir`     | Creates an empty directory for a fixture, removing any existing content       |
+| `fixture_export_codebase` | Exports the codebase at the latest commit to a destination directory          |
+| `string_random`           | Generates a random alphanumeric string, 8 characters long by default          |
+| `tui_run`                 | Runs the script named by `SCRIPT_FILE`, feeding it a list of answers on STDIN |
+| `flunk`                   | Fails the test with a message                                                 |
+| `format_error`            | Formats an error message with a border and the captured command output        |
+
+`fixture_export_codebase` is a no-op unless `BATS_FIXTURE_EXPORT_CODEBASE_ENABLED` is set to `1`, so an expensive export can be enabled per suite rather than per call:
+
+```bash
+export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+```
 
 #### Failure reporting
 
@@ -372,7 +399,8 @@ Helpers report a failure by writing a message to STDERR and returning a non-zero
 
 ```bash
 # Recover from a failure and carry on.
-fixture_export_codebase "${build_dir}" || echo "Export failed - continuing with an empty codebase."
+fixture_export_codebase "${build_dir}" \
+  || echo "Export failed - continuing without a codebase."
 
 # Capture the status and the message.
 run tui_run "${answers[@]}"
@@ -402,23 +430,23 @@ assert_file_exists "$(file_backup_path "${BATS_TEST_TMPDIR}/.env")"
 
 These names still work, but print a notice on every call and are removed in the next version:
 
-| Deprecated                       | Use instead                    |
-|----------------------------------|--------------------------------|
-| `assert_not_git_repo`            | `assert_git_not_repo`          |
-| `assert_git_file_is_tracked`     | `assert_git_file_tracked`      |
-| `assert_git_file_is_not_tracked` | `assert_git_file_not_tracked`  |
-| `assert_contains`                | `assert_string_contains`       |
-| `assert_not_contains`            | `assert_string_not_contains`   |
-| `run_steps`                      | `steps_run`                    |
-| `setup_mock`                     | `mock_setup`                   |
-| `mktouch`                        | `file_mktouch`                 |
-| `trim_file`                      | `file_trim`                    |
-| `read_env`                       | `file_read_env`                |
-| `add_var_to_file`                | `file_add_var`                 |
-| `restore_file`                   | `file_restore`                 |
-| `random_string`                  | `string_random`                |
+| Deprecated                       | Use instead                   |
+|----------------------------------|-------------------------------|
+| `assert_not_git_repo`            | `assert_git_not_repo`         |
+| `assert_git_file_is_tracked`     | `assert_git_file_tracked`     |
+| `assert_git_file_is_not_tracked` | `assert_git_file_not_tracked` |
+| `assert_contains`                | `assert_string_contains`      |
+| `assert_not_contains`            | `assert_string_not_contains`  |
+| `run_steps`                      | `steps_run`                   |
+| `setup_mock`                     | `mock_setup`                  |
+| `mktouch`                        | `file_mktouch`                |
+| `trim_file`                      | `file_trim`                   |
+| `read_env`                       | `file_read_env`               |
+| `add_var_to_file`                | `file_add_var`                |
+| `restore_file`                   | `file_restore`                |
+| `random_string`                  | `string_random`               |
 
-The eight names below the assertion aliases were renamed to put the subject first, so every helper in a module shares one prefix - `steps_*`, `mock_*`, `file_*`, `string_*` - matching how bats-core namespaces `bats_*` and bats-support namespaces `batslib_*`. The replacement keeps the arguments, the standard output and the return semantics, so a call is updated by swapping the name alone. The deprecated alias additionally writes its notice to file descriptor 3.
+Every helper in a module shares one prefix - `steps_*`, `mock_*`, `file_*`, `string_*` - matching how bats-core namespaces `bats_*` and bats-support namespaces `batslib_*`. Apart from the two below, each replacement keeps the arguments, the standard output and the return semantics, so a call is updated by swapping the name alone.
 
 `assert_contains` and `assert_not_contains` take the needle first, while their replacements take the haystack first, so a call has to swap its arguments as well as change its name:
 
@@ -440,28 +468,13 @@ Set `BATS_HELPERS_DEPRECATION_QUIET` to any non-empty value to silence every not
 export BATS_HELPERS_DEPRECATION_QUIET=1
 ```
 
-## Acknowledgments
+## 🙏 Acknowledgments
 
-The mocking functionality is based on
-the [bats-mock](https://github.com/grayhemp/bats-mock) project.
-A special thank you to the contributors for their original work.
+The mocking functionality is based on the [bats-mock](https://github.com/grayhemp/bats-mock) project. A special thank you to the contributors for their original work.
 
-## Maintenance
+## 🤝 Contributing
 
-    npm install
-
-    npm run lint
-
-    npm run test
-
-### Publishing
-
-    npm version minor
-
-    git push
-
-    npm publish
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for local development setup, the linting and testing commands, and the release procedure.
 
 ---
-_This repository was created using the [Scaffold](https://getscaffold.dev/)
-project template_
+_This repository was created using the [Scaffold](https://getscaffold.dev/) project template_

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are released for the latest published version of `@drevops/bats-helpers`. Older versions are not patched.
+
+## Reporting a vulnerability
+
+Report a vulnerability privately through [GitHub security advisories](https://github.com/drevops/bats-helpers/security/advisories/new), or by email to alex@drevops.com if you cannot use GitHub.
+
+Please do not open a public issue for a vulnerability.
+
+Include the affected version, the platform, and the steps to reproduce. You can expect an acknowledgement within seven days, and an assessment of the report once it has been reproduced.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@drevops/bats-helpers",
     "version": "1.6.0",
     "description": "Helpers and assertions for BATS testing.",
-    "license": "GPL-2.0-or-later",
+    "license": "GPL-3.0-or-later",
     "homepage": "https://github.com/drevops/bats-helpers",
     "author": {
         "name": "Alex Skrypnyk",

--- a/src/assert.file.bash
+++ b/src/assert.file.bash
@@ -144,9 +144,7 @@ assert_symlink_exists() {
 assert_symlink_not_exists() {
   local file="${1}"
 
-  if [ ! -h "${file}" ] && [ -f "${file}" ]; then
-    return 0
-  elif [ ! -h "${file}" ]; then
+  if [ ! -h "${file}" ]; then
     return 0
   else
     format_error "Symlink '${file}' exists, but should not" | flunk

--- a/src/dataprovider.bash
+++ b/src/dataprovider.bash
@@ -34,7 +34,6 @@ dataprovider_run() {
     return
   fi
 
-  # Verify that func_name is a valid function that can be called.
   if ! type -t "${func_name}" | grep -q 'function'; then
     flunk "Function '${func_name}' is not a valid function."
     return
@@ -47,25 +46,21 @@ dataprovider_run() {
     return
   fi
 
-  # Check that TEST_CASES is not empty.
   if [ -z "${TEST_CASES+x}" ]; then
     flunk "TEST_CASES array is empty."
     return
   fi
 
-  # Ensure args_per_row is less than or equal to the total number of elements in TEST_CASES.
   if [ "${args_per_row}" -gt ${#TEST_CASES[@]} ]; then
     flunk "Number of arguments per test case is greater than the total elements in TEST_CASES."
     return
   fi
 
-  # Ensure that TEST_CASES has a multiple of args_per_row elements.
   if [ "$((${#TEST_CASES[@]} % args_per_row))" -ne 0 ]; then
     flunk "Total elements in TEST_CASES must be a multiple of ${args_per_row}."
     return
   fi
 
-  # Ensure that the last argument in each row (i.e., "expected" value) is not empty.
   local i
   local data_set_idx
   for ((i = args_per_row - 1, data_set_idx = 0; i < ${#TEST_CASES[@]}; i += args_per_row, data_set_idx++)); do

--- a/src/steps.bash
+++ b/src/steps.bash
@@ -174,7 +174,6 @@ steps_run() {
 
         steps_debug_sub "SETUP: Setup mock for binary '${command_binary}' complete."
       else
-        # Check if mock for the binary exists in the assert phase.
         if [[ -z ${mocked_commands["${command_binary}"]-} ]]; then
           flunk "ERROR: Mock for the binary '${command_binary}' does not exist."
           return 1


### PR DESCRIPTION
## Summary

This change polishes the repository for open-source readiness without altering any runtime behaviour. It removes a redundant conditional branch and several comments that only restated the `flunk` call directly beneath them, corrects the `package.json` licence declaration to match the GPL-3.0 text in `LICENSE`, and drops a `.gitattributes` entry for a `lint.sh` file that does not exist in the repository. The larger part of the work reconciles `README.md` against the current source - documenting behaviour that previously had no written record, fixing an example that contradicted its own advice, and adding a Features section - then routes contributor-facing setup and release instructions out of the README into a new `CONTRIBUTING.md`, and adds a `SECURITY.md` with a private vulnerability-reporting policy.

## Changes

### Source hygiene

- Collapsed a redundant branch in `assert_symlink_not_exists` (`src/assert.file.bash`): `[ ! -h "${file}" ] && [ -f "${file}" ]` is fully subsumed by the following `elif [ ! -h "${file}" ]`, so both branches returned `0` under the same condition. Folded into a single `if [ ! -h "${file}" ]`, with no change in behaviour.
- Removed comments in `src/dataprovider.bash` and `src/steps.bash` that restated the `flunk` message on the line directly beneath them. The `dataprovider_run` validation block now reads as a uniform stack of guard clauses, with the one comment that explains a decision retained.

### Licence and packaging metadata

- Changed `license` in `package.json` from `GPL-2.0-or-later` to `GPL-3.0-or-later` to match the full GPL-3.0 text already in `LICENSE`, which has been unchanged since the initial commit.
- Removed the `.gitattributes` `export-ignore` entry for `lint.sh`, which does not exist in this repository.

### README reconciliation

- Documented `mock_assert_call_args`, which had no entry in the mocking table.
- Documented the `BATS_FIXTURE_EXPORT_CODEBASE_ENABLED`, `ASSERT_DIR_EXCLUDE` and `RUN_STEPS_DEBUG` globals, none of which appeared anywhere in the README. The first matters most: `fixture_export_codebase` is a silent no-op without it.
- Recorded that `assert_string_contains` and everything built on it (`assert_output_contains`, `assert_file_contains`, and their `not_contains` counterparts) match case-insensitively and treat the needle as a literal string (`grep -i -F`), while `assert_dir_contains_string` matches case-sensitively and reads the needle as a `grep` basic regular expression (`grep -rI`). This distinction was verified against the running library rather than inferred from the source.
- Rewrote the Helpers table from the source docblocks, replacing paraphrases that had drifted, and grouped it by owning module.
- Fixed a step-runner example that wrote to `/tmp` while the surrounding text recommends `${BATS_TEST_TMPDIR}`.
- Aligned the `steps_run "assert"` example with the quoting used in the source docblock, and the data provider example with the `declare -a` convention the library's own tests follow.
- Removed a duplicated sentence and past-tense phrasing from the Deprecations section.
- Added a Features section, documented the `#`-count constraint on step definitions, and noted that the `assert_git_file_*` assertions report through the exit status alone.
- Reformatted every embedded code example to 80 columns, so none of them scroll horizontally on GitHub.

### Contributor and security docs

- Moved the `Maintenance` and `Publishing` sections out of `README.md` into a new `CONTRIBUTING.md` covering local setup, running the tests, linting, coding standards and the release procedure. `README.md` now carries a short pointer in their place.
- Added `SECURITY.md` with a private vulnerability-reporting policy, directing reports to GitHub security advisories with email as a fallback.

All 165 BATS tests pass, unchanged in count from before this work.

## Known issues found but deliberately not fixed here

`assert_file_exists` prints its failure banner twice for a missing non-glob path. In `src/assert.file.bash`, the `else` branch calls `format_error | flunk` but does not return, so control falls through to the identical call after the loop. Fixing it changes the assertion's output, which is outside the scope of a documentation and hygiene pass, so it is recorded here rather than changed.

## Before / After

Documentation structure and audience routing:

```
BEFORE                                 AFTER
┌──────────────────────────┐           ┌──────────────────────────┐
│ README.md                │           │ README.md                │
│   - Installation         │           │   - Features (new)       │
│   - Usage                │           │   - Installation         │
│   - Deprecations         │           │   - Usage                │
│   - Acknowledgments      │           │   - Deprecations         │
│   - Maintenance          │           │   - Acknowledgments      │
│   - Publishing           │           │   - Contributing         │
└──────────────────────────┘           └──────────────────────────┘
                                       ┌──────────────────────────┐
                                       │ CONTRIBUTING.md (new)    │
                                       │   - Local setup          │
                                       │   - Running the tests    │
                                       │   - Linting              │
                                       │   - Coding standards     │
                                       │   - Releasing            │
                                       └──────────────────────────┘
                                       ┌──────────────────────────┐
                                       │ SECURITY.md (new)        │
                                       │   - Supported versions   │
                                       │   - Reporting a vuln.    │
                                       └──────────────────────────┘
```

Declared licence and packaging metadata:

```
BEFORE                                 AFTER

package.json    GPL-2.0-or-later  ─┐   package.json    GPL-3.0-or-later  ─┐
                                   ├── mismatch                           ├── agree
LICENSE         GPL-3.0 text      ─┘   LICENSE         GPL-3.0 text      ─┘

.gitattributes  export-ignore          .gitattributes  entry removed
                /lint.sh
                (no such file)
```

Redundant branch in `assert_symlink_not_exists`:

```
BEFORE                                 AFTER

if [ ! -h "${file}" ] \                if [ ! -h "${file}" ]; then
   && [ -f "${file}" ]; then             return 0
  return 0                             else
elif [ ! -h "${file}" ]; then            format_error "..." | flunk
  return 0                             fi
else
  format_error "..." | flunk
fi

two branches, same condition,          one branch, same result for
same result                            every input
```
