### PR TITLE
Fixed the file existence assertions reporting a failure more than once.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,10 @@ Two rules that are easy to miss:
 
 ```shell
 npm version minor
-git push
+git push --follow-tags
 npm publish
 ```
+
+`npm version` creates an annotated tag that a plain `git push` leaves behind, so `--follow-tags` is what gets the tag to GitHub.
 
 The `Draft release notes` workflow runs on pushes to `main` and on tag pushes, and assembles the GitHub release draft from the merged pull request titles.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ assert_dir_contains_string "${dir}" "needle"
 | `assert_symlink_exists`          | Asserts that a symbolic link exists                    |
 | `assert_symlink_not_exists`      | Asserts that a symbolic link does not exist            |
 
+`assert_file_exists` and `assert_file_not_exists` accept a glob. Only the first match decides the outcome, and the failure is reported once however many paths the glob expands to:
+
+```bash
+assert_file_exists "${dir}/*.txt"
+assert_file_not_exists "${dir}/*.rtf"
+```
+
 `assert_dir_contains_string` and `assert_dir_not_contains_string` search recursively, skip binary files, and always exclude `.git`, `.idea`, `vendor` and `node_modules`. Unlike the string and file assertions, they match case-sensitively and read the string as a `grep` basic regular expression. Set `ASSERT_DIR_EXCLUDE` to an array of additional directory names to exclude:
 
 ```bash

--- a/src/assert.file.bash
+++ b/src/assert.file.bash
@@ -19,9 +19,8 @@ assert_file_exists() {
   for f in ${file}; do
     if [ -e "${f}" ]; then
       return 0
-    else
-      format_error "File '${file}' does not exist" | flunk
     fi
+
     # Only the first match decides the outcome.
     break
   done
@@ -43,10 +42,14 @@ assert_file_not_exists() {
   for f in ${file}; do
     if [ -e "${f}" ]; then
       format_error "File '${file}' exists, but should not" | flunk
-    else
-      return 0
+      return 1
     fi
+
+    # Only the first match decides the outcome.
+    break
   done
+
+  return 0
 }
 
 ##

--- a/tests/assert.file.bats
+++ b/tests/assert.file.bats
@@ -56,6 +56,26 @@ load _test_helper
   assert_failure
 }
 
+@test "assert_file_exists reports a failure once" {
+  run assert_file_exists "${BATS_TEST_TMPDIR}/missing.txt"
+  assert_failure
+
+  banner_count="$(echo "${output}" | grep -c "BEGIN ERROR MESSAGE" || true)"
+  assert_equal "1" "${banner_count}"
+}
+
+@test "assert_file_not_exists reports a failure once for a glob" {
+  file_mktouch "${BATS_TEST_TMPDIR}/file1.txt"
+  file_mktouch "${BATS_TEST_TMPDIR}/file2.txt"
+  file_mktouch "${BATS_TEST_TMPDIR}/file3.txt"
+
+  run assert_file_not_exists "${BATS_TEST_TMPDIR}/*.txt"
+  assert_failure
+
+  banner_count="$(echo "${output}" | grep -c "BEGIN ERROR MESSAGE" || true)"
+  assert_equal "1" "${banner_count}"
+}
+
 @test "assert_dir_exists" {
   assert_dir_exists "${BATS_TEST_DIRNAME}"
 


### PR DESCRIPTION
## Summary

`assert_file_exists` and `assert_file_not_exists` both printed their failure banner more than once on a single failed assertion, and `assert_file_not_exists` printed a separate banner per glob match instead of stopping at the first one, contradicting its own docblock. Both functions are now structurally symmetric: the loop alone decides the outcome and stops at the first match, with exactly one `format_error ... | flunk` call site per function.

## Changes

- **`src/assert.file.bash`**: `assert_file_exists` no longer calls `format_error ... | flunk` inside the loop's `else` branch and then falls through to an identical call after the loop; the loop now only returns on a match or breaks, and the single `format_error ... | flunk` call lives after the loop. `assert_file_not_exists` now returns immediately after its `format_error ... | flunk` call instead of continuing to iterate every glob match, and breaks after the first entry otherwise.
- **`tests/assert.file.bats`**: added two regression tests that count the `BEGIN ERROR MESSAGE` banners in the output and assert the count is exactly 1, for a missing path and for a glob matching three files. Both were confirmed to fail against the pre-fix code, reporting 2 and 3 banners respectively, so they genuinely pin the behaviour rather than just passing alongside it.
- **`README.md`**: documented that `assert_file_exists` and `assert_file_not_exists` accept a glob, that only the first match decides the outcome, and that the failure is reported once regardless of how many paths the glob expands to.
- **`CONTRIBUTING.md`**: the release procedure's `git push` is now `git push --follow-tags`, so the annotated tag that `npm version` creates actually reaches GitHub and the `Draft release notes` workflow can see it.

`assert_file_not_exists` also contradicted its own docblock, which states that a glob takes the first match. It iterated every match instead. The fix makes that statement true.

Full suite: 167 tests passing, up from 165 - the two new regression tests above.

## Measured behaviour

| Call | Banners before | Banners after |
|---|---|---|
| `assert_file_exists` on a missing path | 2 | 1 |
| `assert_file_exists` on an unmatched glob | 2 | 1 |
| `assert_file_not_exists` on a glob matching three files | 3 | 1 |

## Before / After

`assert_file_exists` on a missing path:

```
Before                              After
+-------------------------+         +-------------------------+
| BEGIN ERROR MESSAGE     |         | BEGIN ERROR MESSAGE     |
| File does not exist     |         | File does not exist     |
| END ERROR MESSAGE       |         | END ERROR MESSAGE       |
+-------------------------+         +-------------------------+
| BEGIN ERROR MESSAGE     |         (nothing further)
| File does not exist     |
| END ERROR MESSAGE       |
+-------------------------+
     2 banners printed                   1 banner printed
```

`assert_file_not_exists` on a glob matching three files:

```
Before                              After
+-------------------------+         +-------------------------+
| BEGIN ERROR MESSAGE     |         | BEGIN ERROR MESSAGE     |
| File exists (match 1)   |         | File exists (match 1)   |
| END ERROR MESSAGE       |         | END ERROR MESSAGE       |
+-------------------------+         +-------------------------+
| BEGIN ERROR MESSAGE     |         (returns on the first match)
| File exists (match 2)   |
| END ERROR MESSAGE       |
+-------------------------+
| BEGIN ERROR MESSAGE     |
| File exists (match 3)   |
| END ERROR MESSAGE       |
+-------------------------+
     3 banners printed                   1 banner printed
```
