### PR TITLE
[#176] Anchored the mock directory to the per-test BATS sandbox.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ This is a very powerful feature that allows to test complex scenarios as unit te
 
 `mock_setup` writes the mocks to `${BATS_TEST_TMPDIR}/bats-mock-tmp` and puts that directory first on `PATH`, so BATS removes the mocks together with the rest of the test sandbox and concurrent runs cannot delete each other's mocks.
 
-Set `BATS_MOCK_TMPDIR` to store them elsewhere; the mocks are written to a `bats-mock-tmp` directory below it. Only the default location carries the guarantees above - a directory outside `${BATS_TEST_TMPDIR}` is not removed by BATS and is shared with concurrent runs:
+Set `BATS_MOCK_TMPDIR` to store them elsewhere; the mocks are written to a `bats-mock-tmp` directory below it. The guarantees above come from staying within the test sandbox - a directory outside `${BATS_TEST_TMPDIR}` is not removed by BATS and is shared with concurrent runs:
 
 ```bash
 export BATS_MOCK_TMPDIR="${BATS_TEST_TMPDIR}/mocks"

--- a/README.md
+++ b/README.md
@@ -239,6 +239,16 @@ This is a very powerful feature that allows to test complex scenarios as unit te
 | `mock_get_call_env`     | Returns env variable value from mock call                                      | `mock`, `var_name`, `[call_index]`      | Variable value   |
 | `mock_assert_call_args` | Checks the arguments the mock was called with, where `*` matches any arguments | `mock`, `expected_args`, `[call_index]` | `0` when matched |
 
+#### Mock sandbox
+
+`mock_setup` writes the mocks to `${BATS_TEST_TMPDIR}/bats-mock-tmp` and puts that directory first on `PATH`, so BATS removes the mocks together with the rest of the test sandbox and concurrent runs cannot delete each other's mocks.
+
+Set `BATS_MOCK_TMPDIR` to store them elsewhere; the mocks are written to a `bats-mock-tmp` directory below it. Only the default location carries the guarantees above - a directory outside `${BATS_TEST_TMPDIR}` is not removed by BATS and is shared with concurrent runs:
+
+```bash
+export BATS_MOCK_TMPDIR="${BATS_TEST_TMPDIR}/mocks"
+```
+
 #### Example
 
 ```bash

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -294,8 +294,8 @@ mock_prepare_tmp() {
   local dir
   dir="$(mock_resolve_tmp)" || return 1
 
-  rm -rf "${dir}/bats-mock-tmp" >/dev/null
-  mkdir -p "${dir}/bats-mock-tmp"
+  rm -rf "${dir}/bats-mock-tmp" >/dev/null || return 1
+  mkdir -p "${dir}/bats-mock-tmp" || return 1
 
   echo "${dir}/bats-mock-tmp"
 }

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -13,16 +13,17 @@
 
 # Creates a mock program
 # Globals:
-#   BATS_TMPDIR
 #   BATS_MOCK_TMPDIR
+#   BATS_TEST_TMPDIR
 # Outputs:
 #   STDOUT: Path to the mock
 mock_create() {
   local index
 
-  # @note: Modification to the original file: allow to provide custom temp
-  # directory. BATS_TMPDIR below was changed to BATS_MOCK_TMPDIR.
-  BATS_MOCK_TMPDIR="${BATS_MOCK_TMPDIR:-$BATS_TMPDIR}"
+  # @note: Modification to the original file: the directory is resolved by
+  # mock_resolve_tmp(), which allows a custom location and defaults to the
+  # per-test one. BATS_TMPDIR below was changed to BATS_MOCK_TMPDIR.
+  BATS_MOCK_TMPDIR="$(mock_resolve_tmp)" || return 1
 
   index="$(find "${BATS_MOCK_TMPDIR}" -name bats-mock.$$.* | wc -l | tr -d ' ')"
   local mock
@@ -259,7 +260,7 @@ mock_setup() {
   #
   # Prepare directory with mock binaries, get it's path, and export it so that
   # bats-mock could use it internally.
-  BATS_MOCK_TMPDIR="$(mock_prepare_tmp)"
+  BATS_MOCK_TMPDIR="$(mock_prepare_tmp)" || return 1
   export "BATS_MOCK_TMPDIR"
   # Set the path to temp mocked binaries directory as the first location in
   # PATH to lookup in mock directories first. This change lives only for the
@@ -268,14 +269,35 @@ mock_setup() {
   PATH="${BATS_MOCK_TMPDIR}:${PATH}"
 }
 
+# Resolves the directory that mocks are stored in.
+# Globals:
+#   BATS_MOCK_TMPDIR
+#   BATS_TEST_TMPDIR
+# Returns:
+#   1: If neither of the globals is set
+# Outputs:
+#   STDOUT: Path to the directory
+#   STDERR: Corresponding error message
+mock_resolve_tmp() {
+  local dir="${BATS_MOCK_TMPDIR:-${BATS_TEST_TMPDIR-}}"
+
+  if [ -z "${dir}" ]; then
+    echo "Unable to resolve the mock directory: BATS_TEST_TMPDIR is not set. Set BATS_MOCK_TMPDIR to a writable directory" >&2
+    return 1
+  fi
+
+  echo "${dir%/}"
+}
+
 # Prepare temporary mock directory.
 mock_prepare_tmp() {
-  # @note: Modification to the original file: allow to provide custom temp
-  # directory. BATS_TMPDIR below was changed to BATS_MOCK_TMPDIR.
-  BATS_MOCK_TMPDIR="${BATS_MOCK_TMPDIR:-$BATS_TMPDIR}"
-  rm -rf "${BATS_MOCK_TMPDIR}/bats-mock-tmp" >/dev/null
-  mkdir -p "${BATS_MOCK_TMPDIR}/bats-mock-tmp"
-  echo "${BATS_MOCK_TMPDIR}/bats-mock-tmp"
+  local dir
+  dir="$(mock_resolve_tmp)" || return 1
+
+  rm -rf "${dir}/bats-mock-tmp" >/dev/null
+  mkdir -p "${dir}/bats-mock-tmp"
+
+  echo "${dir}/bats-mock-tmp"
 }
 
 # Mock provided command.

--- a/tests/mock.bats
+++ b/tests/mock.bats
@@ -121,7 +121,31 @@ load _test_helper
   assert_equal 1 "${recovered}"
 }
 
-@test "Mock: BATS_MOCK_TMPDIR with spaces" {
+@test "Mock: default temporary directory" {
+  assert_equal "${BATS_TEST_TMPDIR}/bats-mock-tmp" "${BATS_MOCK_TMPDIR}"
+
+  mock_curl=$(mock_command "curl")
+
+  assert_equal "${BATS_MOCK_TMPDIR}" "$(dirname "${mock_curl}")"
+  assert_symlink_exists "${BATS_MOCK_TMPDIR}/curl"
+}
+
+@test "Mock: custom temporary directory" {
+  export BATS_MOCK_TMPDIR="${BATS_TEST_TMPDIR}/custom"
+
+  run mock_prepare_tmp
+  assert_success
+  assert_output "${BATS_TEST_TMPDIR}/custom/bats-mock-tmp"
+
+  # A trailing slash does not produce a double separator.
+  export BATS_MOCK_TMPDIR="${BATS_TEST_TMPDIR}/custom/"
+
+  run mock_prepare_tmp
+  assert_success
+  assert_output "${BATS_TEST_TMPDIR}/custom/bats-mock-tmp"
+}
+
+@test "Mock: custom temporary directory with spaces" {
   export BATS_MOCK_TMPDIR="${BATS_TEST_TMPDIR}/bats mock with spaces"
   mkdir -p "${BATS_MOCK_TMPDIR}"
   mock_curl=$(mock_command "curl")
@@ -129,6 +153,30 @@ load _test_helper
   PATH="${BATS_MOCK_TMPDIR}":${PATH} run curl example.com
 
   assert_success
+}
+
+@test "Mock: temporary directory without a sandbox" {
+  local original="${BATS_TEST_TMPDIR}"
+
+  BATS_MOCK_TMPDIR=""
+  BATS_TEST_TMPDIR=""
+  run mock_prepare_tmp
+  BATS_TEST_TMPDIR="${original}"
+
+  assert_failure
+  assert_output_contains "Set BATS_MOCK_TMPDIR to a writable directory"
+}
+
+@test "Mock: create without a sandbox" {
+  local original="${BATS_TEST_TMPDIR}"
+
+  BATS_MOCK_TMPDIR=""
+  BATS_TEST_TMPDIR=""
+  run mock_create
+  BATS_TEST_TMPDIR="${original}"
+
+  assert_failure
+  assert_output_contains "Set BATS_MOCK_TMPDIR to a writable directory"
 }
 
 @test "Mock: call environment" {

--- a/tests/mock.bats
+++ b/tests/mock.bats
@@ -155,6 +155,14 @@ load _test_helper
   assert_success
 }
 
+@test "Mock: temporary directory that cannot be created" {
+  touch "${BATS_TEST_TMPDIR}/regular_file"
+  export BATS_MOCK_TMPDIR="${BATS_TEST_TMPDIR}/regular_file/custom"
+
+  run mock_prepare_tmp
+  assert_failure
+}
+
 @test "Mock: temporary directory without a sandbox" {
   local original="${BATS_TEST_TMPDIR}"
 

--- a/tests/mock.bats
+++ b/tests/mock.bats
@@ -2,7 +2,7 @@
 #
 # Tests for mocking helpers.
 #
-# shellcheck disable=SC2129
+# shellcheck disable=SC2129,SC2030,SC2031
 
 load _test_helper
 


### PR DESCRIPTION
Closes #176

## Summary

`mock_setup` anchored the mock directory on `BATS_TMPDIR`, which bats-core sets to `${TMPDIR:-/tmp}` - one path shared by every BATS process on the machine - and `mock_prepare_tmp` ran `rm -rf` on that directory in every `setup()`, so two concurrent BATS runs deleted each other's mocks mid-test and failed with scattered errors that pointed at the mock plumbing rather than at the collision. `src/mock.bash` now resolves the mock root through a single `mock_resolve_tmp()` helper that prefers `BATS_MOCK_TMPDIR` when set and otherwise falls back to the per-test `BATS_TEST_TMPDIR`, and `mock_prepare_tmp`/`mock_setup` propagate failure instead of continuing with an unusable directory.

Verified by running the collision itself: the full suite passes 172/172; two concurrent runs of `tests/mock.bats tests/steps.bats` both exit 0 (82 tests each); two concurrent runs deliberately pointed at one shared directory via `BATS_MOCK_TMPDIR` both fail with 45 failures each, reproducing the symptoms reported in the issue.

## Changes

- `src/mock.bash`: added `mock_resolve_tmp()`, which resolves the mock root once - `BATS_MOCK_TMPDIR` when set, otherwise the per-test `BATS_TEST_TMPDIR` - stripping a trailing slash and failing with an explicit message when neither is available. `mock_create()` and `mock_prepare_tmp()` both call it instead of each carrying its own copy of the `BATS_TMPDIR` fallback, which is how the two drifted apart.
- `src/mock.bash`: `mock_prepare_tmp()` and `mock_setup()` propagate failure (`|| return 1`) rather than continuing with an unusable directory. Without it, `mock_setup` would prepend an empty entry to `PATH`, which puts the working directory on `PATH`.
- `tests/mock.bats`: added coverage for the default per-test directory (the regression guard - it confirms both the mock file and the command symlink land inside `BATS_TEST_TMPDIR`), a custom `BATS_MOCK_TMPDIR` including trailing-slash handling, a directory that cannot be created, and the two unresolvable-sandbox paths through `mock_prepare_tmp` and `mock_create`. The existing spaces test is named `Mock: custom temporary directory with spaces` to sit with them.
- `tests/mock.bats`: the file-level directive is now `# shellcheck disable=SC2129,SC2030,SC2031`. The new tests reassign `BATS_MOCK_TMPDIR` and `BATS_TEST_TMPDIR` inside `@test` blocks, which shellcheck reads as subshell modifications that might be lost, while that locality is exactly what makes each test independent. `tests/file.bats` and `tests/assert.file.bats` already carry the same directive for the same reason.
- `README.md`: added a `#### Mock sandbox` subsection under Mocking, covering the default location and the `BATS_MOCK_TMPDIR` override.

## Notes for review

The issue suggested anchoring on `BATS_RUN_TMPDIR`. `BATS_TEST_TMPDIR` is used instead because `mock_command` creates a symlink named after the mocked command - a fixed name such as `curl` - so two parallel tests within a single run would still claim the same path in a per-run directory. A per-test directory isolates that symlink too, which also covers `bats --jobs`. It matches the `BATS_HELPERS_BACKUP_DIR` precedent in `src/file.bash`, which defaults to `${BATS_TEST_TMPDIR}/bats-helpers-backup`.

`src/mock.bash` is a vendored copy of grayhemp/bats-mock and is kept close to upstream. `mock_create` is upstream code, so its local change keeps an `@note` marker. `mock_setup`, `mock_prepare_tmp` and `mock_command` have no upstream counterpart, so they carry no such marker.

The `rm -rf` in `mock_prepare_tmp` is kept. With the default root it runs against a directory that does not exist yet, and with an explicit `BATS_MOCK_TMPDIR` pointing somewhere persistent it still guarantees each `mock_setup` starts from an empty mock directory.

## Before / After

```
Before - one directory shared by every BATS process on the machine
──────────────────────────────────────────────────────────────────

   run A, every setup()  ─┐
                          ├─►  ${TMPDIR:-/tmp}/bats-mock-tmp
   run B, every setup()  ─┘     one directory, machine-wide,
                                rm -rf'd on every setup()

   Whichever run loses the race finds its mocks deleted mid-test.


After - one directory inside each test's own sandbox
────────────────────────────────────────────────────

   run A, test N  ─►  <BATS_TEST_TMPDIR of run A, test N>/bats-mock-tmp
   run B, test M  ─►  <BATS_TEST_TMPDIR of run B, test M>/bats-mock-tmp

   BATS creates each sandbox and removes it afterwards, so no run -
   and no parallel test within a run - can reach another's mocks.
```
