### PR TITLE
[#180] Added standard error assertions and raised the 'bats-core' minimum to 1.13.

### DIFF
--- a/.github/workflows/test-shell.yml
+++ b/.github/workflows/test-shell.yml
@@ -19,7 +19,7 @@ on:
 env:
   BATS_LIB_PATH: "./node_modules"
   # Oldest supported version, kept in sync with the "bats" range in package.json.
-  BATS_VERSION_LOWEST: "1.10.0"
+  BATS_VERSION_LOWEST: "1.13.0"
 
 jobs:
   test-shell:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 ## 📦 Installation
 
-Requires [bats-core](https://github.com/bats-core/bats-core) `1.10` or newer, and Bash `4.0` or newer. macOS ships Bash `3.2`, so install a current one with `brew install bash`.
+Requires [bats-core](https://github.com/bats-core/bats-core) `1.13` or newer, and Bash `4.0` or newer. macOS ships Bash `3.2`, so install a current one with `brew install bash`.
 
 ### NPM
 
@@ -150,7 +150,7 @@ Error: config file not found
 ----------------------------------------
 ```
 
-`run --separate-stderr` sets `$stderr` for the remainder of the test and no later `run` clears it, so a plain `run` after one leaves the previous value in place. Pass `--separate-stderr` to every `run` whose STDERR is asserted on.
+A capture lives only until the next `run`: a plain one clears `$stderr`, so the assertions always read the most recent `run --separate-stderr`. Pass the option to the `run` whose STDERR is being asserted on, and assert directly after it.
 
 #### String assertions
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - [Installation](#-installation)
 - [Usage](#-usage)
   - [Load library](#load-library)
-  - [Assertions](#assertions) - Command run, String, File, Git
+  - [Assertions](#assertions) - Command run, Standard error, String, File, Git
   - [Data provider](#data-provider) - Parameterized tests
   - [Mocking](#mocking) - Command mocking
   - [Step runner](#step-runner) - Sequential test assertions
@@ -39,7 +39,7 @@
 
 ## ✨ Features
 
-- Assertions for command output, strings, files, directories and git repositories.
+- Assertions for command output, standard error, strings, files, directories and git repositories.
 - Command mocking with per-call output, exit status and side effects.
 - Step runner for sequences of mocked calls and output assertions.
 - Data provider for running one function over many test cases.
@@ -104,6 +104,53 @@ Use these after running a command with `run`.
 | `assert_output`              | Asserts that a command outputs an exact string      |
 | `assert_output_contains`     | Checks if output contains a specific string         |
 | `assert_output_not_contains` | Checks if output does not contain a specific string |
+
+#### Standard error assertions
+
+| Function Name                | Description                                                 |
+|------------------------------|-------------------------------------------------------------|
+| `assert_stderr`              | Asserts that a command writes an exact string to STDERR     |
+| `assert_stderr_contains`     | Checks if STDERR contains a specific string                 |
+| `assert_stderr_not_contains` | Checks if STDERR does not contain a specific string         |
+| `assert_stderr_empty`        | Asserts that a command wrote nothing to STDERR              |
+| `assert_stderr_captured`     | Asserts that STDERR was captured separately from the output |
+
+`run` merges STDERR into `$output`, so on its own it cannot tell which stream a message went to. Pass `--separate-stderr` to capture the two apart: `$output` then holds STDOUT alone, and the assertions above read the captured STDERR.
+
+```bash
+bats_require_minimum_version 1.5.0
+
+@test "the script warns without polluting stdout" {
+  run --separate-stderr ./script.sh
+
+  assert_success
+  assert_output "the result"
+  assert_stderr_contains "Warning:"
+}
+```
+
+`bats_require_minimum_version 1.5.0` is what bats-core asks for before `run` accepts flags; without it every flagged call prints a `BW02` warning.
+
+Each of these assertions fails when `--separate-stderr` is missing, instead of comparing against a value that was never captured:
+
+```text
+Stderr was not captured. Run the command with 'run --separate-stderr'.
+```
+
+The check matters most for `assert_stderr_empty`, which would otherwise pass for a command that did write to STDERR - the stream having simply never been captured. Use `assert_stderr_captured` to make the same check on its own.
+
+Once captured, STDERR is appended to every failure report, so a command that failed shows why rather than only that it did:
+
+```text
+Command failed with exit status 3
+
+----------------------------------------
+stderr:
+Error: config file not found
+----------------------------------------
+```
+
+`run --separate-stderr` sets `$stderr` for the remainder of the test and no later `run` clears it, so a plain `run` after one leaves the previous value in place. Pass `--separate-stderr` to every `run` whose STDERR is asserted on.
 
 #### String assertions
 
@@ -411,7 +458,7 @@ export BATS_HELPERS_STEPS_DEBUG=1
 | `string_random`           | Generates a random alphanumeric string, 8 characters long by default          |
 | `tui_run`                 | Runs the script named by `SCRIPT_FILE`, feeding it a list of answers on STDIN |
 | `flunk`                   | Fails the test with a message                                                 |
-| `format_error`            | Formats an error message with a border and the captured command output        |
+| `format_error`            | Formats an error message with a border and the captured output and STDERR     |
 
 `fixture_export_codebase` is a no-op unless `BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED` is set to `1`, so an expensive export can be enabled per suite rather than per call:
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Use these after running a command with `run`.
 `run` merges STDERR into `$output`, so on its own it cannot tell which stream a message went to. Pass `--separate-stderr` to capture the two apart: `$output` then holds STDOUT alone, and the assertions above read the captured STDERR.
 
 ```bash
-bats_require_minimum_version 1.5.0
+bats_require_minimum_version 1.13.0
 
 @test "the script warns without polluting stdout" {
   run --separate-stderr ./script.sh
@@ -129,7 +129,7 @@ bats_require_minimum_version 1.5.0
 }
 ```
 
-`bats_require_minimum_version 1.5.0` is what bats-core asks for before `run` accepts flags; without it every flagged call prints a `BW02` warning.
+Without a `bats_require_minimum_version` declaration of `1.5.0` or newer, bats-core prints a `BW02` warning for every `run` that carries a flag.
 
 Each of these assertions fails when `--separate-stderr` is missing, instead of comparing against a value that was never captured:
 
@@ -139,7 +139,7 @@ Stderr was not captured. Run the command with 'run --separate-stderr'.
 
 The check matters most for `assert_stderr_empty`, which would otherwise pass for a command that did write to STDERR - the stream having simply never been captured. Use `assert_stderr_captured` to make the same check on its own.
 
-Once captured, STDERR is appended to every failure report, so a command that failed shows why rather than only that it did:
+A captured STDERR that is not empty is appended to failure reports, so a command that failed shows why rather than only that it did:
 
 ```text
 Command failed with exit status 3

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "lint-fix": "shfmt -i 2 -ci -s -w src/*.bash load.bash tests/*.bats"
     },
     "dependencies": {
-        "bats": "^1.10"
+        "bats": "^1.13"
     },
     "keywords": [
         "bats",

--- a/src/assert.base.bash
+++ b/src/assert.base.bash
@@ -30,13 +30,15 @@ flunk() {
 }
 
 ##
-# Formats an error message with a border and the captured command output.
+# Formats an error message with a border and the captured output and stderr.
 #
 # Arguments:
 #   1. message: Message to format.
 #
 # Globals:
 #   output: Output captured by the last 'run' call. Appended when not empty.
+#   stderr: Standard error captured by the last 'run --separate-stderr' call.
+#     Appended when not empty.
 #
 # Outputs:
 #   STDOUT: The formatted message.
@@ -58,6 +60,13 @@ format_error() {
     echo "----------------------------------------"
     echo "${BATS_TEST_TMPDIR}"
     echo "${output}"
+    echo "----------------------------------------"
+  fi
+
+  if [ "${stderr-}" != "" ]; then
+    echo "----------------------------------------"
+    echo "stderr:"
+    echo "${stderr}"
     echo "----------------------------------------"
   fi
 }

--- a/src/assert.base.bash
+++ b/src/assert.base.bash
@@ -56,17 +56,19 @@ format_error() {
   echo "##################################################"
   echo
 
+  # Captured streams are printed with 'printf' because 'echo' would read a
+  # value of '-n', '-e' or '-E' as one of its own flags and swallow it.
   if [ "${output-}" != "" ]; then
     echo "----------------------------------------"
     echo "${BATS_TEST_TMPDIR}"
-    echo "${output}"
+    printf '%s\n' "${output}"
     echo "----------------------------------------"
   fi
 
   if [ "${stderr-}" != "" ]; then
     echo "----------------------------------------"
     echo "stderr:"
-    echo "${stderr}"
+    printf '%s\n' "${stderr}"
     echo "----------------------------------------"
   fi
 }

--- a/src/assert.command.bash
+++ b/src/assert.command.bash
@@ -99,3 +99,100 @@ assert_output_not_contains() {
   # shellcheck disable=SC2154
   assert_string_not_contains "${output-}" "${expected}"
 }
+
+##
+# Asserts that standard error was captured separately from the output.
+#
+# Only 'run --separate-stderr' populates 'stderr'. The check is that the
+# variable is set rather than that it holds text, so that a command which wrote
+# nothing to standard error is told apart from one whose standard error was
+# never captured at all.
+#
+# Globals:
+#   stderr: Standard error captured by the last 'run --separate-stderr' call.
+##
+assert_stderr_captured() {
+  if [ -z "${stderr+set}" ]; then
+    flunk "Stderr was not captured. Run the command with 'run --separate-stderr'."
+    return 1
+  fi
+}
+
+##
+# Asserts that the standard error of the last command equals a string.
+#
+# Arguments:
+#   1. expected: Expected standard error. Optional, read from STDIN when
+#      omitted.
+#
+# Globals:
+#   stderr: Standard error captured by the last 'run --separate-stderr' call.
+##
+assert_stderr() {
+  assert_stderr_captured || return 1
+
+  local expected
+  if [ "$#" -eq 0 ]; then
+    expected="$(cat -)"
+  else
+    expected="${1}"
+  fi
+
+  assert_equal "${expected}" "${stderr}"
+}
+
+##
+# Asserts that the standard error of the last command contains a string.
+#
+# Arguments:
+#   1. expected: String to search for. Optional, read from STDIN when omitted.
+#
+# Globals:
+#   stderr: Standard error captured by the last 'run --separate-stderr' call.
+##
+assert_stderr_contains() {
+  assert_stderr_captured || return 1
+
+  local expected
+  if [ "$#" -eq 0 ]; then
+    expected="$(cat -)"
+  else
+    expected="${1}"
+  fi
+
+  assert_string_contains "${stderr}" "${expected}"
+}
+
+##
+# Asserts that the standard error of the last command does not contain a string.
+#
+# Arguments:
+#   1. expected: String to search for. Optional, read from STDIN when omitted.
+#
+# Globals:
+#   stderr: Standard error captured by the last 'run --separate-stderr' call.
+##
+assert_stderr_not_contains() {
+  assert_stderr_captured || return 1
+
+  local expected
+  if [ "$#" -eq 0 ]; then
+    expected="$(cat -)"
+  else
+    expected="${1}"
+  fi
+
+  assert_string_not_contains "${stderr}" "${expected}"
+}
+
+##
+# Asserts that the last command wrote nothing to standard error.
+#
+# Globals:
+#   stderr: Standard error captured by the last 'run --separate-stderr' call.
+##
+assert_stderr_empty() {
+  assert_stderr_captured || return 1
+
+  assert_empty "${stderr}"
+}

--- a/tests/assert.base.bats
+++ b/tests/assert.base.bats
@@ -34,6 +34,7 @@ load _test_helper
   # last 'run', so each case sets both explicitly rather than inheriting them
   # from an earlier assertion.
   output=""
+  stderr=""
   run format_error "Some message"
   assert_success
   assert_output_contains "BEGIN ERROR MESSAGE"
@@ -42,6 +43,7 @@ load _test_helper
   assert_output_not_contains "----------------------------------------"
 
   output="Some captured output"
+  stderr=""
   run format_error "Some message"
   assert_success
   assert_output_contains "Some message"

--- a/tests/assert.base.bats
+++ b/tests/assert.base.bats
@@ -30,8 +30,9 @@ load _test_helper
 }
 
 @test "format_error" {
-  # 'format_error' appends the captured output of the last 'run', so each case
-  # sets it explicitly rather than inheriting it from an earlier assertion.
+  # 'format_error' appends the output and the standard error captured by the
+  # last 'run', so each case sets both explicitly rather than inheriting them
+  # from an earlier assertion.
   output=""
   run format_error "Some message"
   assert_success
@@ -47,4 +48,19 @@ load _test_helper
   assert_output_contains "----------------------------------------"
   assert_output_contains "${BATS_TEST_TMPDIR}"
   assert_output_contains "Some captured output"
+
+  # A command that wrote nothing to STDERR adds no block of its own.
+  output=""
+  stderr=""
+  run format_error "Some message"
+  assert_success
+  assert_output_not_contains "stderr:"
+  assert_output_not_contains "----------------------------------------"
+
+  output=""
+  stderr="Some captured stderr"
+  run format_error "Some message"
+  assert_success
+  assert_output_contains "stderr:"
+  assert_output_contains "Some captured stderr"
 }

--- a/tests/assert.command.bats
+++ b/tests/assert.command.bats
@@ -6,6 +6,9 @@
 
 load _test_helper
 
+# Passing flags to 'run' warns below this version.
+bats_require_minimum_version 1.5.0
+
 @test "assert_success" {
   status=0
   assert_success
@@ -13,6 +16,14 @@ load _test_helper
   status=1
   run assert_success
   [ "${status}" -eq 1 ]
+  assert_output_contains "Command failed with exit status 1"
+  assert_output_not_contains "stderr:"
+
+  stderr="stderr needle"
+  status=1
+  run assert_success
+  [ "${status}" -eq 1 ]
+  assert_output_contains "stderr needle"
 }
 
 @test "assert_failure" {
@@ -22,6 +33,14 @@ load _test_helper
   status=0
   run assert_failure
   [ "${status}" -eq 1 ]
+  assert_output_contains "Command succeeded, but should have failed"
+  assert_output_not_contains "stderr:"
+
+  stderr="stderr needle"
+  status=0
+  run assert_failure
+  [ "${status}" -eq 1 ]
+  assert_output_contains "stderr needle"
 }
 
 @test "assert_output" {
@@ -59,4 +78,80 @@ load _test_helper
 
   run assert_output_not_contains "existing"
   assert_failure
+}
+
+@test "assert_stderr_captured" {
+  run --separate-stderr bash -c 'echo "some error" >&2'
+  assert_stderr_captured
+
+  # A command that wrote nothing to STDERR was still captured.
+  run --separate-stderr echo "some output"
+  assert_stderr_captured
+
+  unset stderr
+  run assert_stderr_captured
+  assert_failure
+  assert_output_contains "run --separate-stderr"
+}
+
+@test "assert_stderr" {
+  run --separate-stderr bash -c 'echo "some output"; echo "some error" >&2'
+  assert_stderr "some error"
+  assert_output "some output"
+
+  run assert_stderr "some other error"
+  assert_failure
+
+  unset stderr
+  run assert_stderr "some error"
+  assert_failure
+  assert_output_contains "run --separate-stderr"
+}
+
+@test "assert_stderr_contains" {
+  run --separate-stderr bash -c 'echo "some existing error" >&2'
+  assert_stderr_contains "some existing error"
+  assert_stderr_contains "some EXISTING error"
+  assert_stderr_contains "existing"
+
+  run assert_stderr_contains "non-existing"
+  assert_failure
+
+  unset stderr
+  run assert_stderr_contains "existing"
+  assert_failure
+  assert_output_contains "run --separate-stderr"
+}
+
+@test "assert_stderr_not_contains" {
+  run --separate-stderr bash -c 'echo "some existing error" >&2'
+  assert_stderr_not_contains "non-existing"
+
+  run assert_stderr_not_contains "some existing error"
+  assert_failure
+
+  run assert_stderr_not_contains "some EXISTING error"
+  assert_failure
+
+  run assert_stderr_not_contains "existing"
+  assert_failure
+
+  unset stderr
+  run assert_stderr_not_contains "non-existing"
+  assert_failure
+  assert_output_contains "run --separate-stderr"
+}
+
+@test "assert_stderr_empty" {
+  run --separate-stderr echo "some output"
+  assert_stderr_empty
+
+  run --separate-stderr bash -c 'echo "some error" >&2'
+  run assert_stderr_empty
+  assert_failure
+
+  unset stderr
+  run assert_stderr_empty
+  assert_failure
+  assert_output_contains "run --separate-stderr"
 }

--- a/tests/assert.command.bats
+++ b/tests/assert.command.bats
@@ -94,11 +94,14 @@ bats_require_minimum_version 1.5.0
   assert_output_contains "run --separate-stderr"
 }
 
+# Each negative case re-captures: a plain 'run' clears 'stderr', so a case that
+# reused an earlier capture would only ever reach the guard.
 @test "assert_stderr" {
   run --separate-stderr bash -c 'echo "some output"; echo "some error" >&2'
   assert_stderr "some error"
   assert_output "some output"
 
+  run --separate-stderr bash -c 'echo "some error" >&2'
   run assert_stderr "some other error"
   assert_failure
 
@@ -114,6 +117,7 @@ bats_require_minimum_version 1.5.0
   assert_stderr_contains "some EXISTING error"
   assert_stderr_contains "existing"
 
+  run --separate-stderr bash -c 'echo "some existing error" >&2'
   run assert_stderr_contains "non-existing"
   assert_failure
 
@@ -127,12 +131,15 @@ bats_require_minimum_version 1.5.0
   run --separate-stderr bash -c 'echo "some existing error" >&2'
   assert_stderr_not_contains "non-existing"
 
+  run --separate-stderr bash -c 'echo "some existing error" >&2'
   run assert_stderr_not_contains "some existing error"
   assert_failure
 
+  run --separate-stderr bash -c 'echo "some existing error" >&2'
   run assert_stderr_not_contains "some EXISTING error"
   assert_failure
 
+  run --separate-stderr bash -c 'echo "some existing error" >&2'
   run assert_stderr_not_contains "existing"
   assert_failure
 

--- a/tests/assert.command.bats
+++ b/tests/assert.command.bats
@@ -6,8 +6,8 @@
 
 load _test_helper
 
-# Passing flags to 'run' warns below this version.
-bats_require_minimum_version 1.5.0
+# Matches the library's minimum, and silences the warning flags on 'run' emit.
+bats_require_minimum_version 1.13.0
 
 @test "assert_success" {
   status=0


### PR DESCRIPTION
Closes #180

## Summary

A shell script's contract is that data goes to STDOUT and diagnostics go to STDERR, but `run` merges the two into `$output`, so nothing in the library could check that a message went to the right stream. This adds assertions that read the `$stderr` variable bats-core populates under `run --separate-stderr`: `assert_stderr`, `assert_stderr_contains`, `assert_stderr_not_contains` and `assert_stderr_empty`, plus `assert_stderr_captured`, the shared guard they all call first.

The guard is what makes the family safe to use. Without `--separate-stderr` the `stderr` variable is never set, so a naive `assert_stderr_empty` would pass for a command that did write to STDERR. Every assertion therefore tests that the variable is *set* rather than that it holds text, and fails with a message naming the missing option. `format_error` also appends captured STDERR to its report, so a failing command now shows why it failed rather than only that it did - `assert_success` and `assert_failure` included, along with every other assertion that routes through it.

**This raises the minimum bats-core version to `1.13`** (from `1.10`). Version `1.13.0` made a plain `run` clear `$stderr` so values cannot leak between successive invocations, which is the behaviour the assertions and their tests are written against.

## Changes

**Assertions**

- `src/assert.command.bash`: added the five new assertions. The four value-checking ones call `assert_stderr_captured` first, so a test against uncaptured STDERR reports the missing option instead of comparing against nothing. Messages are delegated to the existing string assertions, exactly as the `assert_output*` family does, so failure wording stays consistent across the two.
- `src/assert.base.bash`: `format_error` appends a `stderr:` block when the captured value is non-empty. The captured streams are now written with `printf` rather than `echo`, so a value of `-n`, `-e` or `-E` reaches the report intact instead of being read as a flag and swallowed.

**Requirement**

- `package.json`, `.github/workflows/test-shell.yml`, `README.md`: bats-core floor raised to `1.13`, including the `lowest` CI matrix leg that pins it explicitly.

**Tests**

- `tests/assert.command.bats`: one `@test` per new assertion, each covering the positive case, the negative case, and the missing-`--separate-stderr` case. Each negative case re-runs `run --separate-stderr` immediately beforehand rather than reusing an earlier capture - without that it would only ever reach the guard, never the comparison being tested.
- `tests/assert.base.bats`: extended the `format_error` test to cover the new block, both when the captured STDERR is empty and when it holds text.

**Documentation**

- `README.md`: new "Standard error assertions" section with the function table, a worked example, the `--separate-stderr` requirement, the `bats_require_minimum_version` note, and how long a capture lives. Table of contents, feature list and the `format_error` row updated to match.

Verified against bats-core `1.10.0`, `1.12.0` and `1.13.0` locally; CI covers `1.13.0` and the latest `1.x` across five operating systems.

## Before / After

```
BEFORE                                    AFTER
────────────────────────────────────      ────────────────────────────────────
run ./script.sh                           run --separate-stderr ./script.sh

  $output ← STDOUT + STDERR merged          $output ← STDOUT only
                                            $stderr ← STDERR only

no way to assert on STDERR alone          assert_stderr              "exact"
                                          assert_stderr_contains     "part"
                                          assert_stderr_not_contains "part"
                                          assert_stderr_empty
                                          assert_stderr_captured

                                          forgot --separate-stderr?
                                            ↓
                                          "Stderr was not captured. Run the
                                           command with 'run --separate-stderr'."
                                          (rather than a silent false pass)


failure report                            failure report
┌──────────────────────────────┐          ┌──────────────────────────────┐
│ Command failed with status 3 │          │ Command failed with status 3 │
├──────────────────────────────┤          ├──────────────────────────────┤
│ <captured output>            │          │ <captured output>            │
└──────────────────────────────┘          ├──────────────────────────────┤
                                          │ stderr:                      │
  why it failed is not shown              │ Error: config file not found │
                                          └──────────────────────────────┘
                                            ↑ the reason, in the report
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added assertions for captured standard error, including exact matches, substring checks, absence checks, and empty-output validation.
  - Improved failure diagnostics to display captured standard error when available.

- **Documentation**
  - Expanded guidance and examples for standard-error assertions, capture requirements, and error reporting.
  - Updated feature listings and assertion references.

- **Compatibility**
  - Minimum supported Bats version is now 1.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
