### PR TITLE
[#183] Added exact exit status assertions that diagnose signal and missing-command failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ actual:   127 (command not found)
 Command failed with exit status 137 (killed by SIGKILL)
 ```
 
-A status of `127` is what a shell returns for a command it could not find, so a test that passes because the binary under test is missing is caught rather than counted. A status above `128` is a process a signal killed rather than one that chose its own status, and the signal is named from the running platform's own table.
+A status of `127` is what a shell returns for a command it could not find, so a test that passes because the binary under test is missing is caught rather than counted. A status above `128` is how a shell reports a process a signal killed, and the signal is named from the running platform's own table. A program is free to exit with such a status of its own accord, so the name says which signal the number stands for, not that a signal was necessarily involved.
 
 Where a missing command *is* the expected outcome, assert it as such:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - [Installation](#-installation)
 - [Usage](#-usage)
   - [Load library](#load-library)
-  - [Assertions](#assertions) - Command run, Standard error, String, Match modes, File, Git
+  - [Assertions](#assertions) - Command run, Exit statuses, Standard error, String, Match modes, File, Git
   - [Data provider](#data-provider) - Parameterized tests
   - [Mocking](#mocking) - Command mocking
   - [Step runner](#step-runner) - Sequential test assertions
@@ -39,7 +39,7 @@
 
 ## ✨ Features
 
-- Assertions for command output, standard error, strings, files, directories and git repositories.
+- Assertions for command output, exit status, standard error, strings, files, directories and git repositories.
 - Literal, regular expression and format matching, with case sensitivity as an explicit choice.
 - Command mocking with per-call output, exit status and side effects.
 - Step runner for sequences of mocked calls and output assertions.
@@ -111,6 +111,59 @@ Use these after running a command with `run`.
 | `assert_output_not_matches_format` | Checks if output does not match a format string  |
 
 The six `contains`, `matches` and `matches_format` assertions each have a `_case` twin that matches case-sensitively - `assert_output_contains_case`, `assert_output_not_matches_format_case` and so on. See [Match modes](#match-modes).
+
+#### Exit statuses
+
+| Function Name                     | Description                                             |
+|-----------------------------------|---------------------------------------------------------|
+| `assert_status`                   | Asserts that a command exits with an exact status       |
+| `assert_status_general_error`     | Asserts that a command exits with status `1`            |
+| `assert_status_command_not_found` | Asserts that a command exits with status `127`          |
+
+`assert_success` and `assert_failure` divide the world into zero and non-zero, which is not enough for a tool that separates a usage error from a runtime failure by exiting `2` rather than `1`. Assert the status itself:
+
+```bash
+run ./script.sh --nonsense
+
+assert_status 2
+```
+
+`assert_failure` takes the same expectation through a `--status` option, so that one call still covers both the failure and the status it failed with:
+
+```bash
+run ./script.sh --nonsense
+
+assert_failure --status 2
+assert_failure --status 2 "Usage: script.sh [--verbose] <path>"
+```
+
+The option is recognised only as the first argument, and everything after it and its value is the exact output, as before. An output that is itself the string `--status` is asserted with `assert_output` instead.
+
+##### Statuses that mean more than a failure
+
+Two statuses mean something other than the code under test deciding to fail, and both satisfy a bare `assert_failure` exactly as well as the intended error path does. Every report that prints a status names them:
+
+```text
+Command exited with an unexpected status
+expected: 2
+actual:   127 (command not found)
+```
+
+```text
+Command failed with exit status 137 (killed by SIGKILL)
+```
+
+A status of `127` is what a shell returns for a command it could not find, so a test that passes because the binary under test is missing is caught rather than counted. A status above `128` is a process a signal killed rather than one that chose its own status, and the signal is named from the running platform's own table.
+
+Where a missing command *is* the expected outcome, assert it as such:
+
+```bash
+# 'run -127' stops bats warning about the status it would otherwise read as a
+# mistake in the test.
+run -127 ./wrapper.sh
+
+assert_status_command_not_found
+```
 
 #### Standard error assertions
 

--- a/src/assert.command.bash
+++ b/src/assert.command.bash
@@ -16,7 +16,7 @@
 assert_success() {
   # shellcheck disable=SC2154
   if [ "${status-}" -ne 0 ]; then
-    format_error "Command failed with exit status ${status}" | flunk
+    format_error "Command failed with exit status $(command_describe_status "${status}")" | flunk
   elif [ "$#" -gt 0 ]; then
     assert_output "${1}"
   fi
@@ -26,18 +26,149 @@ assert_success() {
 # Asserts that the last command failed.
 #
 # Arguments:
-#   1. output: Exact output to additionally assert on. Optional.
+#   1. --status expected: Exact exit status to assert on, as two arguments.
+#      Optional, recognised only in first position.
+#   2. output: Exact output to additionally assert on. Optional.
 #
 # Globals:
 #   status: Exit status of the last 'run' call.
 ##
 assert_failure() {
+  local expected=""
+
+  if [ "${1-}" = "--status" ]; then
+    if [ "$#" -lt 2 ]; then
+      flunk "Option '--status' requires an exit status."
+      return 1
+    fi
+
+    command_validate_status "${2}" || return 1
+
+    if [ "${2}" -eq 0 ]; then
+      flunk "A failure cannot have exit status 0. Use 'assert_success' instead."
+      return 1
+    fi
+
+    expected="${2}"
+    shift 2
+  fi
+
   # shellcheck disable=SC2154
   if [ "${status-}" -eq 0 ]; then
     format_error "Command succeeded, but should have failed" | flunk
-  elif [ "$#" -gt 0 ]; then
+    return 1
+  fi
+
+  if [ "${expected}" != "" ]; then
+    assert_status "${expected}" || return 1
+  fi
+
+  if [ "$#" -gt 0 ]; then
     assert_output "${1}"
   fi
+}
+
+##
+## Exit status assertions.
+##
+
+##
+# Asserts that the last command exited with an exact status.
+#
+# Arguments:
+#   1. expected: Expected exit status.
+#
+# Globals:
+#   status: Exit status of the last 'run' call.
+##
+assert_status() {
+  if [ "$#" -eq 0 ]; then
+    flunk "An expected exit status is required."
+    return 1
+  fi
+
+  command_validate_status "${1}" || return 1
+
+  # shellcheck disable=SC2154
+  if [ "${status-}" -eq "${1}" ]; then
+    return 0
+  fi
+
+  local message="Command exited with an unexpected status"
+  message="${message}"$'\n'"expected: ${1}"
+  message="${message}"$'\n'"actual:   $(command_describe_status "${status}")"
+
+  format_error "${message}" | flunk
+}
+
+##
+# Asserts that the last command exited with the general error status.
+#
+# Globals:
+#   status: Exit status of the last 'run' call.
+##
+assert_status_general_error() {
+  assert_status 1
+}
+
+##
+# Asserts that the last command exited with the command not found status.
+#
+# Globals:
+#   status: Exit status of the last 'run' call.
+##
+assert_status_command_not_found() {
+  assert_status 127
+}
+
+##
+# Validates a value given as an expected exit status.
+#
+# Arguments:
+#   1. expected: Value to validate.
+##
+command_validate_status() {
+  if ! [[ ${1-} =~ ^[0-9]+$ ]] || [ "${1}" -gt 255 ]; then
+    flunk "Exit status '${1-}' is not an integer between 0 and 255."
+    return 1
+  fi
+}
+
+##
+# Describes an exit status, naming the ones that mean more than a failure.
+#
+# A status of 127 is what a shell returns for a command it could not find, and a
+# status above 128 is how it reports a process a signal killed rather than one
+# that chose its own status. Either reads as an ordinary failure of the code
+# under test unless it is named.
+#
+# Arguments:
+#   1. status: Exit status to describe.
+#
+# Outputs:
+#   STDOUT: The status, followed by what it means when it means something.
+##
+command_describe_status() {
+  local code="${1}"
+
+  if [ "${code}" -eq 127 ]; then
+    printf '%s (command not found)\n' "${code}"
+    return 0
+  fi
+
+  local signal=$((code - 128))
+
+  if [ "${signal}" -ge 1 ]; then
+    local name
+    # A number the platform does not name is not one of its signals, so the
+    # status is left to stand for itself rather than named as one.
+    if name="$(kill -l "${signal}" 2>/dev/null)" && [ "${name}" != "" ]; then
+      printf '%s (killed by SIG%s)\n' "${code}" "${name}"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "${code}"
 }
 
 ##

--- a/tests/assert.command.bats
+++ b/tests/assert.command.bats
@@ -19,6 +19,16 @@ bats_require_minimum_version 1.13.0
   assert_output_contains "Command failed with exit status 1"
   assert_output_not_contains "stderr:"
 
+  status=127
+  run assert_success
+  [ "${status}" -eq 1 ]
+  assert_output_contains "Command failed with exit status 127 (command not found)"
+
+  status=137
+  run assert_success
+  [ "${status}" -eq 1 ]
+  assert_output_contains "Command failed with exit status 137 (killed by SIGKILL)"
+
   stderr="stderr needle"
   status=1
   run assert_success
@@ -41,6 +51,131 @@ bats_require_minimum_version 1.13.0
   run assert_failure
   [ "${status}" -eq 1 ]
   assert_output_contains "stderr needle"
+
+  status=2
+  assert_failure --status 2
+
+  run echo "some output"
+  status=2
+  assert_failure --status 2 "some output"
+
+  status=2
+  run assert_failure --status 3
+  assert_failure
+  assert_output_contains "expected: 3"
+  assert_output_contains "actual:   2"
+
+  status=2
+  run assert_failure --status
+  assert_failure
+  assert_output_contains "Option '--status' requires an exit status."
+
+  status=2
+  run assert_failure --status 0
+  assert_failure
+  assert_output_contains "A failure cannot have exit status 0. Use 'assert_success' instead."
+
+  # The command succeeded, so only validating the option first surfaces the
+  # malformed value rather than the failure that did not happen.
+  status=0
+  run assert_failure --status two
+  assert_failure
+  assert_output_contains "Exit status 'two' is not an integer between 0 and 255."
+}
+
+@test "assert_status" {
+  status=0
+  assert_status 0
+
+  status=2
+  assert_status 2
+
+  # A real signal death, so that the 128 offset is asserted end to end and not
+  # only against a status the test wrote itself.
+  run bash -c 'kill -KILL $$'
+  assert_status 137
+
+  status=2
+  run assert_status 3
+  assert_failure
+  assert_output_contains "Command exited with an unexpected status"
+  assert_output_contains "expected: 3"
+  assert_output_contains "actual:   2"
+
+  status=127
+  run assert_status 2
+  assert_failure
+  assert_output_contains "actual:   127 (command not found)"
+
+  status=137
+  run assert_status 2
+  assert_failure
+  assert_output_contains "actual:   137 (killed by SIGKILL)"
+
+  status=2
+  run assert_status
+  assert_failure
+  assert_output_contains "An expected exit status is required."
+
+  status=2
+  run assert_status two
+  assert_failure
+  assert_output_contains "Exit status 'two' is not an integer between 0 and 255."
+
+  status=2
+  run assert_status 256
+  assert_failure
+  assert_output_contains "Exit status '256' is not an integer between 0 and 255."
+}
+
+@test "assert_status_general_error" {
+  status=1
+  assert_status_general_error
+
+  status=2
+  run assert_status_general_error
+  assert_failure
+  assert_output_contains "expected: 1"
+  assert_output_contains "actual:   2"
+}
+
+@test "assert_status_command_not_found" {
+  # The status is asserted by 'run' as well, so the case proves that a missing
+  # command is 127 on this platform before the library is asked about it.
+  run -127 this-command-does-not-exist
+  assert_status_command_not_found
+
+  status=1
+  run assert_status_command_not_found
+  assert_failure
+  assert_output_contains "expected: 127"
+  assert_output_contains "actual:   1"
+}
+
+@test "command_describe_status" {
+  run command_describe_status 0
+  assert_output "0"
+
+  run command_describe_status 3
+  assert_output "3"
+
+  run command_describe_status 127
+  assert_output "127 (command not found)"
+
+  # Only the two signals every supported platform numbers the same way.
+  run command_describe_status 137
+  assert_output "137 (killed by SIGKILL)"
+
+  run command_describe_status 143
+  assert_output "143 (killed by SIGTERM)"
+
+  # The offset leaves signal zero, which is not a signal.
+  run command_describe_status 128
+  assert_output "128"
+
+  # No supported platform numbers a signal this high.
+  run command_describe_status 255
+  assert_output "255"
 }
 
 @test "assert_output" {

--- a/tests/assert.command.bats
+++ b/tests/assert.command.bats
@@ -55,7 +55,7 @@ bats_require_minimum_version 1.13.0
   status=2
   assert_failure --status 2
 
-  run echo "some output"
+  output="some output"
   status=2
   assert_failure --status 2 "some output"
 
@@ -154,27 +154,34 @@ bats_require_minimum_version 1.13.0
 
 @test "command_describe_status" {
   run command_describe_status 0
+  assert_success
   assert_output "0"
 
   run command_describe_status 3
+  assert_success
   assert_output "3"
 
   run command_describe_status 127
+  assert_success
   assert_output "127 (command not found)"
 
   # Only the two signals every supported platform numbers the same way.
   run command_describe_status 137
+  assert_success
   assert_output "137 (killed by SIGKILL)"
 
   run command_describe_status 143
+  assert_success
   assert_output "143 (killed by SIGTERM)"
 
   # The offset leaves signal zero, which is not a signal.
   run command_describe_status 128
+  assert_success
   assert_output "128"
 
   # No supported platform numbers a signal this high.
   run command_describe_status 255
+  assert_success
   assert_output "255"
 }
 


### PR DESCRIPTION
Closes #183

## Summary

The library could previously only assert an exit status as zero (`assert_success`) or non-zero (`assert_failure`), which is not enough for a tool that distinguishes a usage error from a runtime failure by exit code. This adds exact-status assertions - `assert_status`, `assert_status_general_error`, `assert_status_command_not_found` - and a `--status` option on `assert_failure` so a single call can assert both the failure and the status it failed with. It also diagnoses the two statuses that mean more than an ordinary failure: `127` for a command the shell could not find, and `128+n` for a process a signal killed, named from the running platform's own signal table.

## Changes

### `src/assert.command.bash`

- Added `assert_status` to assert an exact exit status, reporting `expected:`/`actual:` side by side in the style already used by `assert_equal`.
- Added `assert_status_general_error` (status `1`) and `assert_status_command_not_found` (status `127`) as named wrappers around `assert_status`.
- Gave `assert_failure` a leading `--status <n>` option, recognised only in first position so it cannot be confused with the existing optional exact-output argument.
- Added internal helpers `command_validate_status` (rejects anything that is not an integer between 0 and 255) and `command_describe_status` (annotates `127` as `command not found` and a `128+n` status with the signal name read from `kill -l`).
- `assert_success` and `assert_status` failure reports now both run the actual status through `command_describe_status`, so a report never reads as an ordinary failure when the process was actually killed or missing.

### `tests/assert.command.bats`

- Added one `@test` per new assertion, each covering the positive and negative path.
- Added cases for the pathological statuses: `127`, a real `SIGKILL` death at `137`, `SIGTERM` at `143`, the non-signal `128`, and the out-of-range `255`.
- Added validation cases for a non-integer and an out-of-range expected status.

### `README.md`

- Added an "Exit statuses" subsection under Assertions, with a function table and usage examples.
- Updated the table of contents and the features list to mention exit status assertions.

## Before / After

```
BEFORE
┌────────────────────────────────────────────────────────
│ run ./script.sh --nonsense
│ assert_failure
│   → pass or fail only, exit status stays invisible
│
│ status=127                          (binary missing)
│ assert_failure
│   → counted as an ordinary failure, same as any other
│
│ status=137                          (killed by SIGKILL)
│ assert_success
│   → "Command failed with exit status 137"
└────────────────────────────────────────────────────────

AFTER
┌────────────────────────────────────────────────────────
│ run ./script.sh --nonsense
│ assert_failure --status 2
│   → fails the test unless the status is exactly 2
│
│ status=127                          (binary missing)
│ assert_status_command_not_found
│   → passes only when the shell reports "not found"
│
│ status=137                          (killed by SIGKILL)
│ assert_success
│   → "Command failed with exit status 137 (killed by SIGKILL)"
└────────────────────────────────────────────────────────
```
