### PR TITLE
[#182] Added line, any-line and line-count assertions for captured command output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - [Installation](#-installation)
 - [Usage](#-usage)
   - [Load library](#load-library)
-  - [Assertions](#assertions) - Command run, Exit statuses, Standard error, String, Match modes, File, Git
+  - [Assertions](#assertions) - Command run, Line, Exit statuses, Standard error, String, Match modes, File, Git
   - [Data provider](#data-provider) - Parameterized tests
   - [Mocking](#mocking) - Command mocking
   - [Step runner](#step-runner) - Sequential test assertions
@@ -39,7 +39,7 @@
 
 ## ✨ Features
 
-- Assertions for command output, exit status, standard error, strings, files, directories and git repositories.
+- Assertions for command output, its individual lines, exit status, standard error, strings, files, directories and git repositories.
 - Literal, regular expression and format matching, with case sensitivity as an explicit choice.
 - Command mocking with per-call output, exit status and side effects.
 - Step runner for sequences of mocked calls and output assertions.
@@ -111,6 +111,103 @@ Use these after running a command with `run`.
 | `assert_output_not_matches_format` | Checks if output does not match a format string  |
 
 The six `contains`, `matches` and `matches_format` assertions each have a `_case` twin that matches case-sensitively - `assert_output_contains_case`, `assert_output_not_matches_format_case` and so on. See [Match modes](#match-modes).
+
+#### Line assertions
+
+`run` also splits what it captured into `${lines[@]}`. These assert against a line rather than against the output as a whole, which is what a command-line tool's output is usually shaped like.
+
+Assert a line by index. A negative index counts back from the end, so `-1` is the last line:
+
+| Function Name                    | Description                                                        |
+|----------------------------------|--------------------------------------------------------------------|
+| `assert_line`                    | Asserts that the line at an index equals a string                  |
+| `assert_line_not`                | Asserts that the line at an index does not equal a string          |
+| `assert_line_contains`           | Checks if the line at an index contains a string                   |
+| `assert_line_not_contains`       | Checks if the line at an index does not contain a string           |
+| `assert_line_matches`            | Checks if the line at an index matches a regular expression        |
+| `assert_line_not_matches`        | Checks if the line at an index does not match a regular expression |
+| `assert_line_matches_format`     | Checks if the line at an index matches a format string             |
+| `assert_line_not_matches_format` | Checks if the line at an index does not match a format string      |
+
+Assert that some line matches, without pinning which one. The positive reads `any`, the negative reads `no`:
+
+| Function Name                       | Description                                            |
+|-------------------------------------|--------------------------------------------------------|
+| `assert_any_line`                   | Asserts that some line equals a string                 |
+| `assert_no_line`                    | Asserts that no line equals a string                   |
+| `assert_any_line_contains`          | Checks if some line contains a string                  |
+| `assert_no_line_contains`           | Checks if no line contains a string                    |
+| `assert_any_line_matches`           | Checks if some line matches a regular expression       |
+| `assert_no_line_matches`            | Checks if no line matches a regular expression         |
+| `assert_any_line_matches_format`    | Checks if some line matches a format string            |
+| `assert_no_line_matches_format`     | Checks if no line matches a format string              |
+
+Assert how many lines there are, or how many of them a needle matches:
+
+| Function Name                        | Description                                                |
+|--------------------------------------|------------------------------------------------------------|
+| `assert_line_count`                  | Asserts the number of lines                                |
+| `assert_line_count_not`              | Asserts that the number of lines differs                   |
+| `assert_line_count_contains`         | Asserts how many lines contain a string                    |
+| `assert_line_count_not_contains`     | Asserts how many lines do not contain a string             |
+| `assert_line_count_matches`          | Asserts how many lines match a regular expression          |
+| `assert_line_count_not_matches`      | Asserts how many lines do not match a regular expression   |
+| `assert_line_count_matches_format`   | Asserts how many lines match a format string               |
+| `assert_line_count_not_matches_format` | Asserts how many lines do not match a format string      |
+
+Every `contains`, `matches` and `matches_format` assertion above has a `_case` twin that matches case-sensitively - `assert_line_contains_case`, `assert_no_line_matches_case`, `assert_line_count_not_contains_case` and so on. `assert_line`, `assert_any_line`, `assert_no_line` and the two `assert_line_count` assertions compare exactly and have no twin. See [Match modes](#match-modes).
+
+Throughout, `not_` describes the needle and never the count, exactly as it does elsewhere in the library. `assert_line_count_not_contains 3 "error"` asserts that three lines do **not** contain `error`, not that the number of lines containing it is other than three:
+
+```bash
+run ./script.sh
+
+assert_line 0 "Usage: script.sh [options]"
+assert_line -1 "Done."
+assert_line_contains 2 "config"
+assert_any_line_matches 'Deleted [0-9]+ files'
+assert_no_line_contains "Warning"
+assert_line_count 4
+assert_line_count_contains 2 "error"
+```
+
+An index outside the captured lines is an error naming both the index and the number of lines, rather than a comparison against an empty string that would read as an ordinary mismatch:
+
+```text
+Line index 5 is out of range for output with 2 lines.
+```
+
+A failure shows the offending line in context rather than the whole stream. The mark overwrites the indent instead of being inserted, so the lines stay in the same column:
+
+```text
+Line 2 does not contain 'error'
+match mode: literal
+case: insensitive
+
+  0: Usage: tool.sh
+  1: Reading config
+> 2: all good
+  3: Done.
+```
+
+##### Empty lines and indices
+
+`run` drops empty lines unless it is asked to keep them, so an empty line is not an element of `${lines[@]}` and every index after it shifts up. Pass `--keep-empty-lines` when the blank lines are part of what is being asserted, or when an index has to line up with the output as it was printed:
+
+```bash
+# 'lines' holds 'first' and 'third'; the empty line is not an element.
+run printf '%s\n' "first" "" "third"
+assert_line_count 2
+assert_line 1 "third"
+
+# 'lines' holds all three, and the indices match the printed output.
+run --keep-empty-lines printf '%s\n' "first" "" "third"
+assert_line_count 3
+assert_line 1 ""
+assert_line 2 "third"
+```
+
+As with `--separate-stderr`, a `bats_require_minimum_version` declaration of `1.5.0` or newer is needed, or bats-core prints a `BW02` warning for every `run` that carries a flag.
 
 #### Exit statuses
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Assert how many lines there are, or how many of them a needle matches:
 | `assert_line_count_matches_format`   | Asserts how many lines match a format string               |
 | `assert_line_count_not_matches_format` | Asserts how many lines do not match a format string      |
 
-Every `contains`, `matches` and `matches_format` assertion above has a `_case` twin that matches case-sensitively - `assert_line_contains_case`, `assert_no_line_matches_case`, `assert_line_count_not_contains_case` and so on. `assert_line`, `assert_any_line`, `assert_no_line` and the two `assert_line_count` assertions compare exactly and have no twin. See [Match modes](#match-modes).
+Every `contains`, `matches` and `matches_format` assertion above has a `_case` twin that matches case-sensitively - `assert_line_contains_case`, `assert_no_line_matches_case`, `assert_line_count_not_contains_case` and so on. `assert_line`, `assert_line_not`, `assert_any_line`, `assert_no_line` and the two `assert_line_count` assertions compare exactly and have no twin. See [Match modes](#match-modes).
 
 `not` negates whatever follows it. Where a verb follows, it negates the match, exactly as it does elsewhere in the library: `assert_line_count_not_contains 3 "error"` asserts that three lines do **not** contain `error`, not that the number of lines containing it is other than three. Where nothing follows it - `assert_line_not`, `assert_line_count_not` - there is no verb to negate, so it negates the assertion's own comparison:
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Assert how many lines there are, or how many of them a needle matches:
 
 Every `contains`, `matches` and `matches_format` assertion above has a `_case` twin that matches case-sensitively - `assert_line_contains_case`, `assert_no_line_matches_case`, `assert_line_count_not_contains_case` and so on. `assert_line`, `assert_any_line`, `assert_no_line` and the two `assert_line_count` assertions compare exactly and have no twin. See [Match modes](#match-modes).
 
-Throughout, `not_` describes the needle and never the count, exactly as it does elsewhere in the library. `assert_line_count_not_contains 3 "error"` asserts that three lines do **not** contain `error`, not that the number of lines containing it is other than three:
+`not` negates whatever follows it. Where a verb follows, it negates the match, exactly as it does elsewhere in the library: `assert_line_count_not_contains 3 "error"` asserts that three lines do **not** contain `error`, not that the number of lines containing it is other than three. Where nothing follows it - `assert_line_not`, `assert_line_count_not` - there is no verb to negate, so it negates the assertion's own comparison:
 
 ```bash
 run ./script.sh
@@ -195,6 +195,8 @@ case: insensitive
 `run` drops empty lines unless it is asked to keep them, so an empty line is not an element of `${lines[@]}` and every index after it shifts up. Pass `--keep-empty-lines` when the blank lines are part of what is being asserted, or when an index has to line up with the output as it was printed:
 
 ```bash
+bats_require_minimum_version 1.13.0
+
 # 'lines' holds 'first' and 'third'; the empty line is not an element.
 run printf '%s\n' "first" "" "third"
 assert_line_count 2
@@ -207,7 +209,7 @@ assert_line 1 ""
 assert_line 2 "third"
 ```
 
-As with `--separate-stderr`, a `bats_require_minimum_version` declaration of `1.5.0` or newer is needed, or bats-core prints a `BW02` warning for every `run` that carries a flag.
+As with `--separate-stderr`, that declaration has to be `1.5.0` or newer, or bats-core prints a `BW02` warning for every `run` that carries a flag.
 
 #### Exit statuses
 

--- a/load.bash
+++ b/load.bash
@@ -10,6 +10,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.base.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.string.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.command.bash"
+source "$(dirname "${BASH_SOURCE[0]}")/src/assert.line.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.file.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.git.bash"
 

--- a/src/assert.line.bash
+++ b/src/assert.line.bash
@@ -440,7 +440,7 @@ assert_line_count() {
 }
 
 ##
-# Asserts that the number of captured lines is not a number.
+# Asserts that the number of captured lines differs from a number.
 #
 # Arguments:
 #   1. expected: Number of lines not to expect.
@@ -1188,7 +1188,8 @@ line_assert_count_match() {
   local participle
   participle="$(line_participle "${mode}" "${negate}")"
 
-  local message="Output has $(line_plural "${actual}") ${participle} '${needle}', but should have ${expected}"
+  local message
+  message="Output has $(line_plural "${actual}") ${participle} '${needle}', but should have ${expected}"
   message="${message}"$'\n'"$(string_match_footer "${mode}" "${case_sensitive}" "${case_decided}")"
 
   format_error "${message}" | flunk

--- a/src/assert.line.bash
+++ b/src/assert.line.bash
@@ -1,0 +1,1195 @@
+#!/usr/bin/env bash
+##
+# @file
+# Assertions for the individual lines of a captured stream.
+#
+# shellcheck disable=SC2154
+
+##
+## Line assertions.
+##
+
+##
+# Asserts that the line at an index equals a string.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. expected: String to compare against.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line() {
+  line_assert_index_equal 0 "$@"
+}
+
+##
+# Asserts that the line at an index does not equal a string.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. expected: String to compare against.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_not() {
+  line_assert_index_equal 1 "$@"
+}
+
+##
+## Line containment assertions.
+##
+
+##
+# Asserts that the line at an index contains a string, ignoring case.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_contains() {
+  line_assert_index_match 0 "literal" 0 "$@"
+}
+
+##
+# Asserts that the line at an index contains a string, case-sensitively.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_contains_case() {
+  line_assert_index_match 0 "literal" 1 "$@"
+}
+
+##
+# Asserts that the line at an index does not contain a string, ignoring case.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_not_contains() {
+  line_assert_index_match 1 "literal" 0 "$@"
+}
+
+##
+# Asserts that the line at an index does not contain a string,
+# case-sensitively.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_not_contains_case() {
+  line_assert_index_match 1 "literal" 1 "$@"
+}
+
+##
+## Line regular expression assertions.
+##
+
+##
+# Asserts that the line at an index matches a regular expression, ignoring
+# case.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_matches() {
+  line_assert_index_match 0 "regex" 0 "$@"
+}
+
+##
+# Asserts that the line at an index matches a regular expression,
+# case-sensitively.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_matches_case() {
+  line_assert_index_match 0 "regex" 1 "$@"
+}
+
+##
+# Asserts that the line at an index does not match a regular expression,
+# ignoring case.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_not_matches() {
+  line_assert_index_match 1 "regex" 0 "$@"
+}
+
+##
+# Asserts that the line at an index does not match a regular expression,
+# case-sensitively.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_not_matches_case() {
+  line_assert_index_match 1 "regex" 1 "$@"
+}
+
+##
+## Line format assertions.
+##
+
+##
+# Asserts that the line at an index matches a format string, ignoring case.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_matches_format() {
+  line_assert_index_match 0 "format" 0 "$@"
+}
+
+##
+# Asserts that the line at an index matches a format string, case-sensitively.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_matches_format_case() {
+  line_assert_index_match 0 "format" 1 "$@"
+}
+
+##
+# Asserts that the line at an index does not match a format string, ignoring
+# case.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_not_matches_format() {
+  line_assert_index_match 1 "format" 0 "$@"
+}
+
+##
+# Asserts that the line at an index does not match a format string,
+# case-sensitively.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line.
+#   2. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_not_matches_format_case() {
+  line_assert_index_match 1 "format" 1 "$@"
+}
+
+##
+## Any line assertions.
+##
+
+##
+# Asserts that some line equals a string.
+#
+# Arguments:
+#   1. expected: String to compare against.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_any_line() {
+  line_assert_any_equal 1 "$@"
+}
+
+##
+# Asserts that no line equals a string.
+#
+# Arguments:
+#   1. expected: String to compare against.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_no_line() {
+  line_assert_any_equal 0 "$@"
+}
+
+##
+## Any line containment assertions.
+##
+
+##
+# Asserts that some line contains a string, ignoring case.
+#
+# Arguments:
+#   1. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_any_line_contains() {
+  line_assert_any_match 1 "literal" 0 "$@"
+}
+
+##
+# Asserts that some line contains a string, case-sensitively.
+#
+# Arguments:
+#   1. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_any_line_contains_case() {
+  line_assert_any_match 1 "literal" 1 "$@"
+}
+
+##
+# Asserts that no line contains a string, ignoring case.
+#
+# Arguments:
+#   1. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_no_line_contains() {
+  line_assert_any_match 0 "literal" 0 "$@"
+}
+
+##
+# Asserts that no line contains a string, case-sensitively.
+#
+# Arguments:
+#   1. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_no_line_contains_case() {
+  line_assert_any_match 0 "literal" 1 "$@"
+}
+
+##
+## Any line regular expression assertions.
+##
+
+##
+# Asserts that some line matches a regular expression, ignoring case.
+#
+# Arguments:
+#   1. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_any_line_matches() {
+  line_assert_any_match 1 "regex" 0 "$@"
+}
+
+##
+# Asserts that some line matches a regular expression, case-sensitively.
+#
+# Arguments:
+#   1. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_any_line_matches_case() {
+  line_assert_any_match 1 "regex" 1 "$@"
+}
+
+##
+# Asserts that no line matches a regular expression, ignoring case.
+#
+# Arguments:
+#   1. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_no_line_matches() {
+  line_assert_any_match 0 "regex" 0 "$@"
+}
+
+##
+# Asserts that no line matches a regular expression, case-sensitively.
+#
+# Arguments:
+#   1. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_no_line_matches_case() {
+  line_assert_any_match 0 "regex" 1 "$@"
+}
+
+##
+## Any line format assertions.
+##
+
+##
+# Asserts that some line matches a format string, ignoring case.
+#
+# Arguments:
+#   1. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_any_line_matches_format() {
+  line_assert_any_match 1 "format" 0 "$@"
+}
+
+##
+# Asserts that some line matches a format string, case-sensitively.
+#
+# Arguments:
+#   1. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_any_line_matches_format_case() {
+  line_assert_any_match 1 "format" 1 "$@"
+}
+
+##
+# Asserts that no line matches a format string, ignoring case.
+#
+# Arguments:
+#   1. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_no_line_matches_format() {
+  line_assert_any_match 0 "format" 0 "$@"
+}
+
+##
+# Asserts that no line matches a format string, case-sensitively.
+#
+# Arguments:
+#   1. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_no_line_matches_format_case() {
+  line_assert_any_match 0 "format" 1 "$@"
+}
+
+##
+## Line count assertions.
+##
+
+##
+# Asserts the number of captured lines.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count() {
+  line_assert_count 0 "$@"
+}
+
+##
+# Asserts that the number of captured lines is not a number.
+#
+# Arguments:
+#   1. expected: Number of lines not to expect.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_not() {
+  line_assert_count 1 "$@"
+}
+
+##
+## Line count containment assertions.
+##
+
+##
+# Asserts how many lines contain a string, ignoring case.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_contains() {
+  line_assert_count_match 0 "literal" 0 "$@"
+}
+
+##
+# Asserts how many lines contain a string, case-sensitively.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_contains_case() {
+  line_assert_count_match 0 "literal" 1 "$@"
+}
+
+##
+# Asserts how many lines do not contain a string, ignoring case.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_not_contains() {
+  line_assert_count_match 1 "literal" 0 "$@"
+}
+
+##
+# Asserts how many lines do not contain a string, case-sensitively.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_not_contains_case() {
+  line_assert_count_match 1 "literal" 1 "$@"
+}
+
+##
+## Line count regular expression assertions.
+##
+
+##
+# Asserts how many lines match a regular expression, ignoring case.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_matches() {
+  line_assert_count_match 0 "regex" 0 "$@"
+}
+
+##
+# Asserts how many lines match a regular expression, case-sensitively.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_matches_case() {
+  line_assert_count_match 0 "regex" 1 "$@"
+}
+
+##
+# Asserts how many lines do not match a regular expression, ignoring case.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_not_matches() {
+  line_assert_count_match 1 "regex" 0 "$@"
+}
+
+##
+# Asserts how many lines do not match a regular expression, case-sensitively.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: Extended regular expression to match.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_not_matches_case() {
+  line_assert_count_match 1 "regex" 1 "$@"
+}
+
+##
+## Line count format assertions.
+##
+
+##
+# Asserts how many lines match a format string, ignoring case.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_matches_format() {
+  line_assert_count_match 0 "format" 0 "$@"
+}
+
+##
+# Asserts how many lines match a format string, case-sensitively.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_matches_format_case() {
+  line_assert_count_match 0 "format" 1 "$@"
+}
+
+##
+# Asserts how many lines do not match a format string, ignoring case.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_not_matches_format() {
+  line_assert_count_match 1 "format" 0 "$@"
+}
+
+##
+# Asserts how many lines do not match a format string, case-sensitively.
+#
+# Arguments:
+#   1. expected: Number of lines to expect.
+#   2. needle: Format string, see 'string_format_to_regex'.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+assert_line_count_not_matches_format_case() {
+  line_assert_count_match 1 "format" 1 "$@"
+}
+
+##
+## Matching.
+##
+
+##
+# Resolves a line index into an offset into the captured lines.
+#
+# Arguments:
+#   1. index: Line index. A negative value counts back from the last line, so
+#      '-1' is the last one.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+#
+# Outputs:
+#   STDOUT: The resolved offset.
+##
+line_resolve_index() {
+  local index="${1-}"
+
+  if ! [[ ${index} =~ ^-?[0-9]+$ ]]; then
+    flunk "Line index '${index}' is not an integer."
+    return 1
+  fi
+
+  local total="${#lines[@]}"
+  local resolved
+
+  # Base 10 is explicit so that a zero-padded index is not read as octal.
+  if [ "${index:0:1}" = "-" ]; then
+    resolved=$((total - 10#${index#-}))
+  else
+    resolved=$((10#${index}))
+  fi
+
+  # An out-of-range index would otherwise compare against an empty string,
+  # which reads as an ordinary mismatch and hides where the fault is.
+  if [ "${resolved}" -lt 0 ] || [ "${resolved}" -ge "${total}" ]; then
+    flunk "Line index ${index} is out of range for output with $(line_plural "${total}")."
+    return 1
+  fi
+
+  printf '%s\n' "${resolved}"
+}
+
+##
+# Names a line by the offset it sits at and the index it was reached through.
+#
+# Arguments:
+#   1. index: Index as it was given.
+#   2. resolved: Offset the index resolved to.
+#
+# Outputs:
+#   STDOUT: The label.
+##
+line_label() {
+  if [ "${1}" = "${2}" ]; then
+    printf 'Line %s\n' "${2}"
+    return 0
+  fi
+
+  printf 'Line %s (from index %s)\n' "${2}" "${1}"
+}
+
+##
+# Prints the lines around one line, with that line marked.
+#
+# The mark overwrites the indent instead of being inserted, so every line stays
+# in the same column and the marked one can still be read against its
+# neighbours.
+#
+# Arguments:
+#   1. index: Offset of the line to mark.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+#
+# Outputs:
+#   STDOUT: The window of lines, one per line.
+##
+line_context() {
+  local index="${1}"
+  local total="${#lines[@]}"
+  local window=2
+
+  local first=$((index - window))
+  local last=$((index + window))
+
+  [ "${first}" -lt 0 ] && first=0
+  [ "${last}" -gt $((total - 1)) ] && last=$((total - 1))
+
+  local width="${#last}"
+  local i
+  local marker
+
+  for ((i = first; i <= last; i++)); do
+    marker="  "
+    [ "${i}" -eq "${index}" ] && marker="> "
+    printf '%s%*d: %s\n' "${marker}" "${width}" "${i}" "${lines[i]}"
+  done
+}
+
+##
+# Names a number of lines.
+#
+# Arguments:
+#   1. count: Number of lines.
+#
+# Outputs:
+#   STDOUT: The count and the noun agreeing with it.
+##
+line_plural() {
+  if [ "${1}" -eq 1 ]; then
+    printf '1 line\n'
+    return 0
+  fi
+
+  printf '%s lines\n' "${1}"
+}
+
+##
+# Names how a needle is read, as a participle for a failure report.
+#
+# Arguments:
+#   1. mode: How the needle is read - 'literal', 'regex' or 'format'.
+#   2. negate: '1' when the report is about the lines that do not match.
+#
+# Outputs:
+#   STDOUT: The participle.
+##
+line_participle() {
+  local participle="containing"
+  [ "${1}" != "literal" ] && participle="matching"
+
+  if [ "${2}" = "1" ]; then
+    printf 'not %s\n' "${participle}"
+    return 0
+  fi
+
+  printf '%s\n' "${participle}"
+}
+
+##
+# Validates a value given as a number of lines.
+#
+# Arguments:
+#   1. count: Value to validate.
+##
+line_validate_count() {
+  if ! [[ ${1-} =~ ^[0-9]+$ ]]; then
+    flunk "Line count '${1-}' is not a non-negative integer."
+    return 1
+  fi
+}
+
+##
+# Lists the offsets of the lines a needle matches.
+#
+# Arguments:
+#   1. negate: '1' to list the lines the needle does not match.
+#   2. mode: How the needle is read - 'literal', 'regex' or 'format'.
+#   3. case_sensitive: '1' to match case-sensitively, '0' to ignore case.
+#   4. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+#
+# Outputs:
+#   STDOUT: The matching offsets, separated by spaces.
+##
+line_match_indices() {
+  local negate="${1}"
+  local mode="${2}"
+  local case_sensitive="${3}"
+  local needle="${4}"
+
+  local pattern="${needle}"
+  local pattern_mode="${mode}"
+
+  if [ "${mode}" = "format" ]; then
+    pattern="$(string_format_to_regex "${needle}")" || return 1
+    pattern_mode="regex"
+  fi
+
+  # Checked once against an empty string, so that an unusable expression is
+  # reported even when there is no line for it to be tried against.
+  local match_status=0
+  string_match "" "${pattern}" "${pattern_mode}" "${case_sensitive}" "anywhere" || match_status=$?
+
+  if [ "${match_status}" -eq 2 ]; then
+    flunk "Invalid regular expression '${needle}'."
+    return 1
+  fi
+
+  local total="${#lines[@]}"
+  local matched=""
+  local i
+
+  for ((i = 0; i < total; i++)); do
+    match_status=0
+    string_match "${lines[i]}" "${pattern}" "${pattern_mode}" "${case_sensitive}" "anywhere" || match_status=$?
+
+    if [ "${negate}" = "1" ]; then
+      [ "${match_status}" -ne 0 ] && matched="${matched}${matched:+ }${i}"
+    else
+      [ "${match_status}" -eq 0 ] && matched="${matched}${matched:+ }${i}"
+    fi
+  done
+
+  printf '%s\n' "${matched}"
+}
+
+##
+# Lists the offsets of the lines equal to a string.
+#
+# Arguments:
+#   1. expected: String to compare against.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+#
+# Outputs:
+#   STDOUT: The matching offsets, separated by spaces.
+##
+line_equal_indices() {
+  local expected="${1}"
+  local total="${#lines[@]}"
+  local matched=""
+  local i
+
+  for ((i = 0; i < total; i++)); do
+    [ "${lines[i]}" = "${expected}" ] && matched="${matched}${matched:+ }${i}"
+  done
+
+  printf '%s\n' "${matched}"
+}
+
+##
+# Asserts that a needle matches the line at an index, reporting how on failure.
+#
+# Arguments:
+#   1. negate: '1' to assert that the needle does not match.
+#   2. mode: How the needle is read - 'literal', 'regex' or 'format'.
+#   3. case_sensitive: '1' to match case-sensitively, '0' to ignore case.
+#   4. index: Line index. A negative value counts back from the last line.
+#   5. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+line_assert_index_match() {
+  if [ "$#" -ne 5 ]; then
+    flunk "A line index and a needle are required."
+    return 1
+  fi
+
+  local negate="${1}"
+  local mode="${2}"
+  local case_sensitive="${3}"
+  local given="${4}"
+  local needle="${5}"
+
+  local index
+  index="$(line_resolve_index "${given}")" || return 1
+
+  local haystack="${lines[index]}"
+
+  local pattern="${needle}"
+  local pattern_mode="${mode}"
+
+  if [ "${mode}" = "format" ]; then
+    pattern="$(string_format_to_regex "${needle}")" || return 1
+    pattern_mode="regex"
+  fi
+
+  local match_status=0
+  string_match "${haystack}" "${pattern}" "${pattern_mode}" "${case_sensitive}" "anywhere" || match_status=$?
+
+  if [ "${match_status}" -eq 2 ]; then
+    flunk "Invalid regular expression '${needle}'."
+    return 1
+  fi
+
+  if [ "${negate}" = "1" ]; then
+    [ "${match_status}" -ne 0 ] && return 0
+  else
+    [ "${match_status}" -eq 0 ] && return 0
+  fi
+
+  local verb="contain"
+  local verb_third_person="contains"
+
+  if [ "${mode}" != "literal" ]; then
+    verb="match"
+    verb_third_person="matches"
+  fi
+
+  local message
+  if [ "${negate}" = "1" ]; then
+    message="$(line_label "${given}" "${index}") ${verb_third_person} '${needle}', but should not"
+  else
+    message="$(line_label "${given}" "${index}") does not ${verb} '${needle}'"
+  fi
+
+  local opposite_status=0
+  string_match "${haystack}" "${pattern}" "${pattern_mode}" $((1 - case_sensitive)) "anywhere" || opposite_status=$?
+
+  local case_decided=0
+  [ "${opposite_status}" -ne "${match_status}" ] && case_decided=1
+
+  message="${message}"$'\n'"$(string_match_footer "${mode}" "${case_sensitive}" "${case_decided}")"
+  message="${message}"$'\n\n'"$(line_context "${index}")"
+
+  format_error "${message}" | flunk
+}
+
+##
+# Asserts that the line at an index equals a string, reporting it on failure.
+#
+# Arguments:
+#   1. negate: '1' to assert that the line does not equal the string.
+#   2. index: Line index. A negative value counts back from the last line.
+#   3. expected: String to compare against.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+line_assert_index_equal() {
+  if [ "$#" -ne 3 ]; then
+    flunk "A line index and a string are required."
+    return 1
+  fi
+
+  local negate="${1}"
+  local given="${2}"
+  local expected="${3}"
+
+  local index
+  index="$(line_resolve_index "${given}")" || return 1
+
+  local equal=0
+  [ "${lines[index]}" = "${expected}" ] || equal=1
+
+  if [ "${negate}" = "1" ]; then
+    [ "${equal}" -ne 0 ] && return 0
+  else
+    [ "${equal}" -eq 0 ] && return 0
+  fi
+
+  local message
+  if [ "${negate}" = "1" ]; then
+    message="$(line_label "${given}" "${index}") equals '${expected}', but should not"
+  else
+    message="$(line_label "${given}" "${index}") does not equal '${expected}'"
+  fi
+
+  message="${message}"$'\n\n'"$(line_context "${index}")"
+
+  format_error "${message}" | flunk
+}
+
+##
+# Asserts that some or no line matches a needle, reporting how on failure.
+#
+# Arguments:
+#   1. present: '1' to assert that some line matches, '0' that none does.
+#   2. mode: How the needle is read - 'literal', 'regex' or 'format'.
+#   3. case_sensitive: '1' to match case-sensitively, '0' to ignore case.
+#   4. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+line_assert_any_match() {
+  if [ "$#" -ne 4 ]; then
+    flunk "A needle is required."
+    return 1
+  fi
+
+  local present="${1}"
+  local mode="${2}"
+  local case_sensitive="${3}"
+  local needle="${4}"
+
+  local matched
+  matched="$(line_match_indices 0 "${mode}" "${case_sensitive}" "${needle}")" || return 1
+
+  # shellcheck disable=SC2206
+  local -a indices=(${matched})
+
+  if [ "${present}" = "1" ]; then
+    [ "${#indices[@]}" -gt 0 ] && return 0
+  else
+    [ "${#indices[@]}" -eq 0 ] && return 0
+  fi
+
+  local opposite
+  opposite="$(line_match_indices 0 "${mode}" $((1 - case_sensitive)) "${needle}")" || return 1
+
+  # shellcheck disable=SC2206
+  local -a opposite_indices=(${opposite})
+
+  local case_decided=0
+  if [ "${present}" = "1" ]; then
+    [ "${#opposite_indices[@]}" -gt 0 ] && case_decided=1
+  else
+    [ "${#opposite_indices[@]}" -eq 0 ] && case_decided=1
+  fi
+
+  local participle
+  participle="$(line_participle "${mode}" 0)"
+
+  local message
+  if [ "${present}" = "1" ]; then
+    message="Output has no line ${participle} '${needle}'"
+  else
+    message="Output has a line ${participle} '${needle}', but should not"
+  fi
+
+  message="${message}"$'\n'"$(string_match_footer "${mode}" "${case_sensitive}" "${case_decided}")"
+
+  if [ "${#indices[@]}" -gt 0 ]; then
+    message="${message}"$'\n\n'"$(line_context "${indices[0]}")"
+  fi
+
+  format_error "${message}" | flunk
+}
+
+##
+# Asserts that some or no line equals a string, reporting it on failure.
+#
+# Arguments:
+#   1. present: '1' to assert that some line equals it, '0' that none does.
+#   2. expected: String to compare against.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+line_assert_any_equal() {
+  if [ "$#" -ne 2 ]; then
+    flunk "A string is required."
+    return 1
+  fi
+
+  local present="${1}"
+  local expected="${2}"
+
+  local matched
+  matched="$(line_equal_indices "${expected}")"
+
+  # shellcheck disable=SC2206
+  local -a indices=(${matched})
+
+  if [ "${present}" = "1" ]; then
+    [ "${#indices[@]}" -gt 0 ] && return 0
+  else
+    [ "${#indices[@]}" -eq 0 ] && return 0
+  fi
+
+  local message
+  if [ "${present}" = "1" ]; then
+    message="Output has no line equal to '${expected}'"
+  else
+    message="Output has a line equal to '${expected}', but should not"
+  fi
+
+  if [ "${#indices[@]}" -gt 0 ]; then
+    message="${message}"$'\n\n'"$(line_context "${indices[0]}")"
+  fi
+
+  format_error "${message}" | flunk
+}
+
+##
+# Asserts the number of captured lines, reporting the tally on failure.
+#
+# Arguments:
+#   1. negate: '1' to assert that the number differs.
+#   2. expected: Number of lines to expect.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+line_assert_count() {
+  if [ "$#" -ne 2 ]; then
+    flunk "A line count is required."
+    return 1
+  fi
+
+  local negate="${1}"
+  local expected="${2}"
+
+  line_validate_count "${expected}" || return 1
+
+  local total="${#lines[@]}"
+
+  if [ "${negate}" = "1" ]; then
+    [ "${total}" -ne "${expected}" ] && return 0
+
+    format_error "Output has $(line_plural "${total}"), but should not" | flunk
+    return 1
+  fi
+
+  [ "${total}" -eq "${expected}" ] && return 0
+
+  format_error "Output has $(line_plural "${total}"), but should have ${expected}" | flunk
+}
+
+##
+# Asserts how many lines a needle matches, reporting the tally on failure.
+#
+# Arguments:
+#   1. negate: '1' to count the lines the needle does not match.
+#   2. mode: How the needle is read - 'literal', 'regex' or 'format'.
+#   3. case_sensitive: '1' to match case-sensitively, '0' to ignore case.
+#   4. expected: Number of lines to expect.
+#   5. needle: String to search for.
+#
+# Globals:
+#   lines: Lines captured by the last 'run' call.
+##
+line_assert_count_match() {
+  if [ "$#" -ne 5 ]; then
+    flunk "A line count and a needle are required."
+    return 1
+  fi
+
+  local negate="${1}"
+  local mode="${2}"
+  local case_sensitive="${3}"
+  local expected="${4}"
+  local needle="${5}"
+
+  line_validate_count "${expected}" || return 1
+
+  local matched
+  matched="$(line_match_indices "${negate}" "${mode}" "${case_sensitive}" "${needle}")" || return 1
+
+  # shellcheck disable=SC2206
+  local -a indices=(${matched})
+  local actual="${#indices[@]}"
+
+  [ "${actual}" -eq "${expected}" ] && return 0
+
+  local opposite
+  opposite="$(line_match_indices "${negate}" "${mode}" $((1 - case_sensitive)) "${needle}")" || return 1
+
+  # shellcheck disable=SC2206
+  local -a opposite_indices=(${opposite})
+
+  local case_decided=0
+  [ "${#opposite_indices[@]}" -eq "${expected}" ] && case_decided=1
+
+  local participle
+  participle="$(line_participle "${mode}" "${negate}")"
+
+  local message="Output has $(line_plural "${actual}") ${participle} '${needle}', but should have ${expected}"
+  message="${message}"$'\n'"$(string_match_footer "${mode}" "${case_sensitive}" "${case_decided}")"
+
+  format_error "${message}" | flunk
+}

--- a/src/assert.string.bash
+++ b/src/assert.string.bash
@@ -516,27 +516,51 @@ string_assert_match() {
     message="String '${haystack}' does not ${verb} '${needle}'"
   fi
 
-  local case_label="insensitive"
-  [ "${case_sensitive}" = "1" ] && case_label="sensitive"
-
-  message="${message}"$'\n'"match mode: ${mode}"
-  message="${message}"$'\n'"case: ${case_label}"
-
   # The setting that was in force is only worth naming when the other one would
   # have decided the assertion the other way.
   local opposite_case=$((1 - case_sensitive))
   local opposite_status=0
   string_match "${haystack}" "${pattern}" "${pattern_mode}" "${opposite_case}" "${anchor}" || opposite_status=$?
 
-  if [ "${opposite_status}" -ne "${match_status}" ]; then
-    if [ "${case_sensitive}" = "1" ]; then
-      message="${message}"$'\n'"note: it matches without the '_case' suffix"
-    else
-      message="${message}"$'\n'"note: it does not match with the '_case' suffix"
-    fi
-  fi
+  local case_decided=0
+  [ "${opposite_status}" -ne "${match_status}" ] && case_decided=1
+
+  message="${message}"$'\n'"$(string_match_footer "${mode}" "${case_sensitive}" "${case_decided}")"
 
   format_error "${message}" | flunk
+}
+
+##
+# Formats how a failed match was performed.
+#
+# Arguments:
+#   1. mode: How the needle was read - 'literal', 'regex' or 'format'.
+#   2. case_sensitive: '1' when the match was case-sensitive, '0' when not.
+#   3. case_decided: '1' when the opposite case setting would have decided the
+#      assertion the other way.
+#
+# Outputs:
+#   STDOUT: The match mode and the case sensitivity, followed by a note naming
+#           the case setting when it is what decided the outcome.
+##
+string_match_footer() {
+  local mode="${1}"
+  local case_sensitive="${2}"
+  local case_decided="${3}"
+
+  local case_label="insensitive"
+  [ "${case_sensitive}" = "1" ] && case_label="sensitive"
+
+  echo "match mode: ${mode}"
+  echo "case: ${case_label}"
+
+  [ "${case_decided}" = "1" ] || return 0
+
+  if [ "${case_sensitive}" = "1" ]; then
+    echo "note: it matches without the '_case' suffix"
+  else
+    echo "note: it does not match with the '_case' suffix"
+  fi
 }
 
 ##

--- a/tests/assert.line.bats
+++ b/tests/assert.line.bats
@@ -19,6 +19,16 @@ capture_counted() {
   run printf '%s\n' "error one" "ok" "error two" "ok"
 }
 
+# The output the format count assertions read.
+capture_formatted() {
+  run printf '%s\n' "Deleted 12 files" "ok" "Deleted 3 files"
+}
+
+# The same, with one of the two matching lines cased differently.
+capture_formatted_mixed() {
+  run printf '%s\n' "Deleted 12 files" "ok" "DELETED 3 files"
+}
+
 ##
 ## Line assertions.
 ##
@@ -540,10 +550,10 @@ capture_counted() {
 ##
 
 @test "assert_line_count_matches_format" {
-  run printf '%s\n' "Deleted 12 files" "ok" "Deleted 3 files"
+  capture_formatted
   assert_line_count_matches_format 2 "Deleted %d files"
 
-  run printf '%s\n' "Deleted 12 files" "ok" "Deleted 3 files"
+  capture_formatted
   run assert_line_count_matches_format 1 "Deleted %d files"
   assert_failure
   assert_output_contains "Output has 2 lines matching 'Deleted %d files', but should have 1"
@@ -551,30 +561,30 @@ capture_counted() {
 }
 
 @test "assert_line_count_matches_format_case" {
-  run printf '%s\n' "Deleted 12 files" "ok" "DELETED 3 files"
+  capture_formatted_mixed
   assert_line_count_matches_format_case 1 "Deleted %d files"
 
-  run printf '%s\n' "Deleted 12 files" "ok" "DELETED 3 files"
+  capture_formatted_mixed
   run assert_line_count_matches_format_case 2 "Deleted %d files"
   assert_failure
   assert_output_contains "Output has 1 line matching 'Deleted %d files', but should have 2"
 }
 
 @test "assert_line_count_not_matches_format" {
-  run printf '%s\n' "Deleted 12 files" "ok" "Deleted 3 files"
+  capture_formatted
   assert_line_count_not_matches_format 1 "Deleted %d files"
 
-  run printf '%s\n' "Deleted 12 files" "ok" "Deleted 3 files"
+  capture_formatted
   run assert_line_count_not_matches_format 2 "Deleted %d files"
   assert_failure
   assert_output_contains "Output has 1 line not matching 'Deleted %d files', but should have 2"
 }
 
 @test "assert_line_count_not_matches_format_case" {
-  run printf '%s\n' "Deleted 12 files" "ok" "DELETED 3 files"
+  capture_formatted_mixed
   assert_line_count_not_matches_format_case 2 "Deleted %d files"
 
-  run printf '%s\n' "Deleted 12 files" "ok" "DELETED 3 files"
+  capture_formatted_mixed
   run assert_line_count_not_matches_format_case 1 "Deleted %d files"
   assert_failure
   assert_output_contains "Output has 2 lines not matching 'Deleted %d files', but should have 1"
@@ -636,6 +646,7 @@ capture_counted() {
   # Clamped at the start.
   capture
   run line_context 0
+  assert_success
   assert_output "> 0: Usage: tool.sh
   1: Reading config
   2: Deleted 12 files"
@@ -643,6 +654,7 @@ capture_counted() {
   # Clamped at the end.
   capture
   run line_context 3
+  assert_success
   assert_output "  1: Reading config
   2: Deleted 12 files
 > 3: Done."
@@ -651,6 +663,7 @@ capture_counted() {
   # that the mark overwrites the indent instead of shifting the line.
   run printf '%s\n' a b c d e f g h i j k l
   run line_context 10
+  assert_success
   assert_output "   8: i
    9: j
 > 10: k
@@ -659,26 +672,33 @@ capture_counted() {
 
 @test "line_plural" {
   run line_plural 0
+  assert_success
   assert_output "0 lines"
 
   run line_plural 1
+  assert_success
   assert_output "1 line"
 
   run line_plural 2
+  assert_success
   assert_output "2 lines"
 }
 
 @test "line_participle" {
   run line_participle "literal" 0
+  assert_success
   assert_output "containing"
 
   run line_participle "regex" 0
+  assert_success
   assert_output "matching"
 
   run line_participle "format" 0
+  assert_success
   assert_output "matching"
 
   run line_participle "literal" 1
+  assert_success
   assert_output "not containing"
 }
 
@@ -708,10 +728,12 @@ capture_counted() {
 @test "line_equal_indices" {
   capture_counted
   run line_equal_indices "ok"
+  assert_success
   assert_output "1 3"
 
   capture_counted
   run line_equal_indices "absent"
+  assert_success
   assert_output ""
 }
 
@@ -750,7 +772,7 @@ capture_counted() {
 
 @test "line_assert_count_match" {
   capture_counted
-  run line_assert_count_match 2 0 "literal" 0
+  run line_assert_count_match 0 "literal" 0 2
   assert_failure
   assert_output_contains "A line count and a needle are required."
 

--- a/tests/assert.line.bats
+++ b/tests/assert.line.bats
@@ -1,0 +1,778 @@
+#!/usr/bin/env bats
+#
+# Tests for line assertions.
+#
+
+load _test_helper
+
+# Matches the library's minimum, and silences the warning flags on 'run' emit.
+bats_require_minimum_version 1.13.0
+
+# The output the index and any-line assertions read.
+capture() {
+  run printf '%s\n' "Usage: tool.sh" "Reading config" "Deleted 12 files" "Done."
+}
+
+# The output the count assertions read, split evenly between the lines a needle
+# matches and the lines it does not.
+capture_counted() {
+  run printf '%s\n' "error one" "ok" "error two" "ok"
+}
+
+##
+## Line assertions.
+##
+
+@test "assert_line" {
+  capture
+  assert_line 0 "Usage: tool.sh"
+  assert_line 3 "Done."
+
+  # A negative index counts back from the last line.
+  assert_line -1 "Done."
+  assert_line -4 "Usage: tool.sh"
+
+  capture
+  run assert_line 0 "Reading config"
+  assert_failure
+  assert_output_contains "Line 0 does not equal 'Reading config'"
+  assert_output_contains "> 0: Usage: tool.sh"
+
+  # The line reached through a negative index is named both ways.
+  capture
+  run assert_line -1 "Usage: tool.sh"
+  assert_failure
+  assert_output_contains "Line 3 (from index -1) does not equal 'Usage: tool.sh'"
+}
+
+@test "assert_line_not" {
+  capture
+  assert_line_not 0 "Reading config"
+  assert_line_not -1 "Usage: tool.sh"
+
+  capture
+  run assert_line_not 0 "Usage: tool.sh"
+  assert_failure
+  assert_output_contains "Line 0 equals 'Usage: tool.sh', but should not"
+  assert_output_contains "> 0: Usage: tool.sh"
+}
+
+##
+## Line containment assertions.
+##
+
+@test "assert_line_contains" {
+  capture
+  assert_line_contains 1 "config"
+  assert_line_contains 1 "CONFIG"
+  assert_line_contains -1 "Done"
+
+  capture
+  run assert_line_contains 1 "absent"
+  assert_failure
+  assert_output_contains "Line 1 does not contain 'absent'"
+  assert_output_contains "match mode: literal"
+  assert_output_contains "case: insensitive"
+  assert_output_contains "> 1: Reading config"
+}
+
+@test "assert_line_contains_case" {
+  capture
+  assert_line_contains_case 1 "config"
+
+  capture
+  run assert_line_contains_case 1 "CONFIG"
+  assert_failure
+  assert_output_contains "Line 1 does not contain 'CONFIG'"
+  assert_output_contains "case: sensitive"
+  assert_output_contains "note: it matches without the '_case' suffix"
+}
+
+@test "assert_line_not_contains" {
+  capture
+  assert_line_not_contains 1 "absent"
+
+  capture
+  run assert_line_not_contains 1 "config"
+  assert_failure
+  assert_output_contains "Line 1 contains 'config', but should not"
+
+  capture
+  run assert_line_not_contains 1 "CONFIG"
+  assert_failure
+  assert_output_contains "Line 1 contains 'CONFIG', but should not"
+}
+
+@test "assert_line_not_contains_case" {
+  capture
+  assert_line_not_contains_case 1 "CONFIG"
+  assert_line_not_contains_case 1 "absent"
+
+  capture
+  run assert_line_not_contains_case 1 "config"
+  assert_failure
+  assert_output_contains "Line 1 contains 'config', but should not"
+}
+
+##
+## Line regular expression assertions.
+##
+
+@test "assert_line_matches" {
+  capture
+  assert_line_matches 2 'Deleted [0-9]+ files'
+  assert_line_matches 2 'DELETED [0-9]+ files'
+  assert_line_matches 2 '^Deleted'
+  assert_line_matches 2 'files$'
+
+  capture
+  run assert_line_matches 2 'Deleted [a-z]+ files'
+  assert_failure
+  assert_output_contains "Line 2 does not match 'Deleted [a-z]+ files'"
+  assert_output_contains "match mode: regex"
+  assert_output_contains "> 2: Deleted 12 files"
+}
+
+@test "assert_line_matches_case" {
+  capture
+  assert_line_matches_case 2 'Deleted [0-9]+ files'
+
+  capture
+  run assert_line_matches_case 2 'DELETED [0-9]+ files'
+  assert_failure
+  assert_output_contains "case: sensitive"
+  assert_output_contains "note: it matches without the '_case' suffix"
+}
+
+@test "assert_line_not_matches" {
+  capture
+  assert_line_not_matches 2 'Deleted [a-z]+ files'
+
+  capture
+  run assert_line_not_matches 2 'Deleted [0-9]+ files'
+  assert_failure
+  assert_output_contains "Line 2 matches 'Deleted [0-9]+ files', but should not"
+}
+
+@test "assert_line_not_matches_case" {
+  capture
+  assert_line_not_matches_case 2 'DELETED [0-9]+ files'
+
+  capture
+  run assert_line_not_matches_case 2 'Deleted [0-9]+ files'
+  assert_failure
+  assert_output_contains "Line 2 matches 'Deleted [0-9]+ files', but should not"
+}
+
+##
+## Line format assertions.
+##
+
+@test "assert_line_matches_format" {
+  capture
+  assert_line_matches_format 2 "Deleted %d files"
+  assert_line_matches_format 2 "DELETED %d files"
+
+  capture
+  run assert_line_matches_format 2 "Deleted %d directories"
+  assert_failure
+  assert_output_contains "Line 2 does not match 'Deleted %d directories'"
+  assert_output_contains "match mode: format"
+
+  capture
+  run assert_line_matches_format 2 "Deleted %z files"
+  assert_failure
+  assert_output_contains "Unknown format placeholder '%z'."
+}
+
+@test "assert_line_matches_format_case" {
+  capture
+  assert_line_matches_format_case 2 "Deleted %d files"
+
+  capture
+  run assert_line_matches_format_case 2 "DELETED %d files"
+  assert_failure
+  assert_output_contains "case: sensitive"
+}
+
+@test "assert_line_not_matches_format" {
+  capture
+  assert_line_not_matches_format 2 "Deleted %d directories"
+
+  capture
+  run assert_line_not_matches_format 2 "Deleted %d files"
+  assert_failure
+  assert_output_contains "Line 2 matches 'Deleted %d files', but should not"
+}
+
+@test "assert_line_not_matches_format_case" {
+  capture
+  assert_line_not_matches_format_case 2 "DELETED %d files"
+
+  capture
+  run assert_line_not_matches_format_case 2 "Deleted %d files"
+  assert_failure
+  assert_output_contains "Line 2 matches 'Deleted %d files', but should not"
+}
+
+##
+## Any line assertions.
+##
+
+@test "assert_any_line" {
+  capture
+  assert_any_line "Done."
+  assert_any_line "Usage: tool.sh"
+
+  capture
+  run assert_any_line "absent"
+  assert_failure
+  assert_output_contains "Output has no line equal to 'absent'"
+}
+
+@test "assert_no_line" {
+  capture
+  assert_no_line "absent"
+
+  # An exact comparison, so a line that merely contains it does not count.
+  assert_no_line "Done"
+
+  capture
+  run assert_no_line "Done."
+  assert_failure
+  assert_output_contains "Output has a line equal to 'Done.', but should not"
+  assert_output_contains "> 3: Done."
+}
+
+##
+## Any line containment assertions.
+##
+
+@test "assert_any_line_contains" {
+  capture
+  assert_any_line_contains "config"
+  assert_any_line_contains "CONFIG"
+
+  capture
+  run assert_any_line_contains "absent"
+  assert_failure
+  assert_output_contains "Output has no line containing 'absent'"
+  assert_output_contains "match mode: literal"
+}
+
+@test "assert_any_line_contains_case" {
+  capture
+  assert_any_line_contains_case "config"
+
+  capture
+  run assert_any_line_contains_case "CONFIG"
+  assert_failure
+  assert_output_contains "Output has no line containing 'CONFIG'"
+  assert_output_contains "case: sensitive"
+  assert_output_contains "note: it matches without the '_case' suffix"
+}
+
+@test "assert_no_line_contains" {
+  capture
+  assert_no_line_contains "absent"
+
+  capture
+  run assert_no_line_contains "config"
+  assert_failure
+  assert_output_contains "Output has a line containing 'config', but should not"
+  assert_output_contains "> 1: Reading config"
+
+  # Only the case setting let this one through, so it is named.
+  capture
+  run assert_no_line_contains "CONFIG"
+  assert_failure
+  assert_output_contains "note: it does not match with the '_case' suffix"
+}
+
+@test "assert_no_line_contains_case" {
+  capture
+  assert_no_line_contains_case "CONFIG"
+
+  capture
+  run assert_no_line_contains_case "config"
+  assert_failure
+  assert_output_contains "Output has a line containing 'config', but should not"
+  assert_output_contains "case: sensitive"
+}
+
+##
+## Any line regular expression assertions.
+##
+
+@test "assert_any_line_matches" {
+  capture
+  assert_any_line_matches 'Deleted [0-9]+ files'
+
+  capture
+  run assert_any_line_matches 'Deleted [a-z]+ files'
+  assert_failure
+  assert_output_contains "Output has no line matching 'Deleted [a-z]+ files'"
+  assert_output_contains "match mode: regex"
+
+  # An unusable expression is an error rather than an absence of matches.
+  capture
+  run assert_any_line_matches '['
+  assert_failure
+  assert_output_contains "Invalid regular expression '['."
+}
+
+@test "assert_any_line_matches_case" {
+  capture
+  assert_any_line_matches_case 'Deleted [0-9]+ files'
+
+  capture
+  run assert_any_line_matches_case 'DELETED [0-9]+ files'
+  assert_failure
+  assert_output_contains "case: sensitive"
+}
+
+@test "assert_no_line_matches" {
+  capture
+  assert_no_line_matches 'Deleted [a-z]+ files'
+
+  capture
+  run assert_no_line_matches 'Deleted [0-9]+ files'
+  assert_failure
+  assert_output_contains "Output has a line matching 'Deleted [0-9]+ files', but should not"
+  assert_output_contains "> 2: Deleted 12 files"
+}
+
+@test "assert_no_line_matches_case" {
+  capture
+  assert_no_line_matches_case 'DELETED [0-9]+ files'
+
+  capture
+  run assert_no_line_matches_case 'Deleted [0-9]+ files'
+  assert_failure
+  assert_output_contains "Output has a line matching 'Deleted [0-9]+ files', but should not"
+}
+
+##
+## Any line format assertions.
+##
+
+@test "assert_any_line_matches_format" {
+  capture
+  assert_any_line_matches_format "Deleted %d files"
+
+  capture
+  run assert_any_line_matches_format "Deleted %d directories"
+  assert_failure
+  assert_output_contains "Output has no line matching 'Deleted %d directories'"
+  assert_output_contains "match mode: format"
+
+  capture
+  run assert_any_line_matches_format "Deleted %z files"
+  assert_failure
+  assert_output_contains "Unknown format placeholder '%z'."
+}
+
+@test "assert_any_line_matches_format_case" {
+  capture
+  assert_any_line_matches_format_case "Deleted %d files"
+
+  capture
+  run assert_any_line_matches_format_case "DELETED %d files"
+  assert_failure
+  assert_output_contains "case: sensitive"
+}
+
+@test "assert_no_line_matches_format" {
+  capture
+  assert_no_line_matches_format "Deleted %d directories"
+
+  capture
+  run assert_no_line_matches_format "Deleted %d files"
+  assert_failure
+  assert_output_contains "Output has a line matching 'Deleted %d files', but should not"
+}
+
+@test "assert_no_line_matches_format_case" {
+  capture
+  assert_no_line_matches_format_case "DELETED %d files"
+
+  capture
+  run assert_no_line_matches_format_case "Deleted %d files"
+  assert_failure
+  assert_output_contains "Output has a line matching 'Deleted %d files', but should not"
+}
+
+##
+## Line count assertions.
+##
+
+@test "assert_line_count" {
+  capture
+  assert_line_count 4
+
+  capture
+  run assert_line_count 3
+  assert_failure
+  assert_output_contains "Output has 4 lines, but should have 3"
+
+  # The noun agrees with the count.
+  run printf '%s\n' "only one"
+  run assert_line_count 2
+  assert_failure
+  assert_output_contains "Output has 1 line, but should have 2"
+
+  capture
+  run assert_line_count "four"
+  assert_failure
+  assert_output_contains "Line count 'four' is not a non-negative integer."
+
+  capture
+  run assert_line_count
+  assert_failure
+  assert_output_contains "A line count is required."
+}
+
+@test "assert_line_count_not" {
+  capture
+  assert_line_count_not 3
+
+  capture
+  run assert_line_count_not 4
+  assert_failure
+  assert_output_contains "Output has 4 lines, but should not"
+}
+
+##
+## Line count containment assertions.
+##
+
+@test "assert_line_count_contains" {
+  capture_counted
+  assert_line_count_contains 2 "error"
+  assert_line_count_contains 2 "ERROR"
+  assert_line_count_contains 0 "absent"
+
+  capture_counted
+  run assert_line_count_contains 3 "error"
+  assert_failure
+  assert_output_contains "Output has 2 lines containing 'error', but should have 3"
+  assert_output_contains "match mode: literal"
+}
+
+@test "assert_line_count_contains_case" {
+  capture_counted
+  assert_line_count_contains_case 2 "error"
+
+  capture_counted
+  run assert_line_count_contains_case 2 "ERROR"
+  assert_failure
+  assert_output_contains "Output has 0 lines containing 'ERROR', but should have 2"
+  assert_output_contains "note: it matches without the '_case' suffix"
+}
+
+@test "assert_line_count_not_contains" {
+  capture_counted
+  assert_line_count_not_contains 2 "error"
+
+  capture_counted
+  run assert_line_count_not_contains 3 "error"
+  assert_failure
+  assert_output_contains "Output has 2 lines not containing 'error', but should have 3"
+}
+
+@test "assert_line_count_not_contains_case" {
+  capture_counted
+  assert_line_count_not_contains_case 4 "ERROR"
+
+  capture_counted
+  run assert_line_count_not_contains_case 2 "ERROR"
+  assert_failure
+  assert_output_contains "Output has 4 lines not containing 'ERROR', but should have 2"
+}
+
+##
+## Line count regular expression assertions.
+##
+
+@test "assert_line_count_matches" {
+  capture_counted
+  assert_line_count_matches 2 '^error'
+
+  capture_counted
+  run assert_line_count_matches 1 '^error'
+  assert_failure
+  assert_output_contains "Output has 2 lines matching '^error', but should have 1"
+  assert_output_contains "match mode: regex"
+}
+
+@test "assert_line_count_matches_case" {
+  capture_counted
+  assert_line_count_matches_case 2 '^error'
+
+  capture_counted
+  run assert_line_count_matches_case 2 '^ERROR'
+  assert_failure
+  assert_output_contains "Output has 0 lines matching '^ERROR', but should have 2"
+}
+
+@test "assert_line_count_not_matches" {
+  capture_counted
+  assert_line_count_not_matches 2 '^error'
+
+  capture_counted
+  run assert_line_count_not_matches 1 '^error'
+  assert_failure
+  assert_output_contains "Output has 2 lines not matching '^error', but should have 1"
+}
+
+@test "assert_line_count_not_matches_case" {
+  capture_counted
+  assert_line_count_not_matches_case 4 '^ERROR'
+
+  capture_counted
+  run assert_line_count_not_matches_case 2 '^ERROR'
+  assert_failure
+  assert_output_contains "Output has 4 lines not matching '^ERROR', but should have 2"
+}
+
+##
+## Line count format assertions.
+##
+
+@test "assert_line_count_matches_format" {
+  run printf '%s\n' "Deleted 12 files" "ok" "Deleted 3 files"
+  assert_line_count_matches_format 2 "Deleted %d files"
+
+  run printf '%s\n' "Deleted 12 files" "ok" "Deleted 3 files"
+  run assert_line_count_matches_format 1 "Deleted %d files"
+  assert_failure
+  assert_output_contains "Output has 2 lines matching 'Deleted %d files', but should have 1"
+  assert_output_contains "match mode: format"
+}
+
+@test "assert_line_count_matches_format_case" {
+  run printf '%s\n' "Deleted 12 files" "ok" "DELETED 3 files"
+  assert_line_count_matches_format_case 1 "Deleted %d files"
+
+  run printf '%s\n' "Deleted 12 files" "ok" "DELETED 3 files"
+  run assert_line_count_matches_format_case 2 "Deleted %d files"
+  assert_failure
+  assert_output_contains "Output has 1 line matching 'Deleted %d files', but should have 2"
+}
+
+@test "assert_line_count_not_matches_format" {
+  run printf '%s\n' "Deleted 12 files" "ok" "Deleted 3 files"
+  assert_line_count_not_matches_format 1 "Deleted %d files"
+
+  run printf '%s\n' "Deleted 12 files" "ok" "Deleted 3 files"
+  run assert_line_count_not_matches_format 2 "Deleted %d files"
+  assert_failure
+  assert_output_contains "Output has 1 line not matching 'Deleted %d files', but should have 2"
+}
+
+@test "assert_line_count_not_matches_format_case" {
+  run printf '%s\n' "Deleted 12 files" "ok" "DELETED 3 files"
+  assert_line_count_not_matches_format_case 2 "Deleted %d files"
+
+  run printf '%s\n' "Deleted 12 files" "ok" "DELETED 3 files"
+  run assert_line_count_not_matches_format_case 1 "Deleted %d files"
+  assert_failure
+  assert_output_contains "Output has 2 lines not matching 'Deleted %d files', but should have 1"
+}
+
+##
+## Matching.
+##
+
+@test "line_resolve_index" {
+  capture
+  run line_resolve_index 0
+  assert_success
+  assert_output "0"
+
+  capture
+  run line_resolve_index 3
+  assert_success
+  assert_output "3"
+
+  capture
+  run line_resolve_index -1
+  assert_success
+  assert_output "3"
+
+  capture
+  run line_resolve_index -4
+  assert_success
+  assert_output "0"
+
+  # Base 10, so a zero-padded index is not read as octal.
+  capture
+  run line_resolve_index 010
+  assert_failure
+  assert_output_contains "Line index 010 is out of range for output with 4 lines."
+
+  capture
+  run line_resolve_index 4
+  assert_failure
+  assert_output_contains "Line index 4 is out of range for output with 4 lines."
+
+  capture
+  run line_resolve_index -5
+  assert_failure
+  assert_output_contains "Line index -5 is out of range for output with 4 lines."
+
+  capture
+  run line_resolve_index "two"
+  assert_failure
+  assert_output_contains "Line index 'two' is not an integer."
+
+  run printf '%s\n' "only one"
+  run line_resolve_index 1
+  assert_failure
+  assert_output_contains "out of range for output with 1 line."
+}
+
+@test "line_context" {
+  # Clamped at the start.
+  capture
+  run line_context 0
+  assert_output "> 0: Usage: tool.sh
+  1: Reading config
+  2: Deleted 12 files"
+
+  # Clamped at the end.
+  capture
+  run line_context 3
+  assert_output "  1: Reading config
+  2: Deleted 12 files
+> 3: Done."
+
+  # A full window either side, with the index padded to the widest one shown so
+  # that the mark overwrites the indent instead of shifting the line.
+  run printf '%s\n' a b c d e f g h i j k l
+  run line_context 10
+  assert_output "   8: i
+   9: j
+> 10: k
+  11: l"
+}
+
+@test "line_plural" {
+  run line_plural 0
+  assert_output "0 lines"
+
+  run line_plural 1
+  assert_output "1 line"
+
+  run line_plural 2
+  assert_output "2 lines"
+}
+
+@test "line_participle" {
+  run line_participle "literal" 0
+  assert_output "containing"
+
+  run line_participle "regex" 0
+  assert_output "matching"
+
+  run line_participle "format" 0
+  assert_output "matching"
+
+  run line_participle "literal" 1
+  assert_output "not containing"
+}
+
+@test "line_match_indices" {
+  capture_counted
+  run line_match_indices 0 "literal" 0 "error"
+  assert_success
+  assert_output "0 2"
+
+  capture_counted
+  run line_match_indices 1 "literal" 0 "error"
+  assert_success
+  assert_output "1 3"
+
+  capture_counted
+  run line_match_indices 0 "literal" 0 "absent"
+  assert_success
+  assert_output ""
+
+  # Checked even when there is no line to try it against.
+  run printf ''
+  run line_match_indices 0 "regex" 0 "["
+  assert_failure
+  assert_output_contains "Invalid regular expression '['."
+}
+
+@test "line_equal_indices" {
+  capture_counted
+  run line_equal_indices "ok"
+  assert_output "1 3"
+
+  capture_counted
+  run line_equal_indices "absent"
+  assert_output ""
+}
+
+@test "line_assert_index_match" {
+  capture
+  run assert_line_contains 1
+  assert_failure
+  assert_output_contains "A line index and a needle are required."
+
+  capture
+  run assert_line_matches 1 "["
+  assert_failure
+  assert_output_contains "Invalid regular expression '['."
+}
+
+@test "line_assert_index_equal" {
+  capture
+  run line_assert_index_equal 1
+  assert_failure
+  assert_output_contains "A line index and a string are required."
+}
+
+@test "line_assert_any_match" {
+  capture
+  run line_assert_any_match 1 "literal" 0
+  assert_failure
+  assert_output_contains "A needle is required."
+}
+
+@test "line_assert_any_equal" {
+  capture
+  run line_assert_any_equal 1
+  assert_failure
+  assert_output_contains "A string is required."
+}
+
+@test "line_assert_count_match" {
+  capture_counted
+  run line_assert_count_match 2 0 "literal" 0
+  assert_failure
+  assert_output_contains "A line count and a needle are required."
+
+  capture_counted
+  run assert_line_count_contains "two" "error"
+  assert_failure
+  assert_output_contains "Line count 'two' is not a non-negative integer."
+}
+
+##
+## Empty lines.
+##
+
+@test "Empty lines are dropped unless the runner is asked to keep them" {
+  # Without the option, an empty line is not an element and the indices of
+  # everything after it shift up.
+  run printf '%s\n' "first" "" "third"
+  assert_line_count 2
+  assert_line 1 "third"
+
+  run --keep-empty-lines printf '%s\n' "first" "" "third"
+  assert_line_count 3
+  assert_line 1 ""
+  assert_line 2 "third"
+}

--- a/tests/assert.line.bats
+++ b/tests/assert.line.bats
@@ -53,6 +53,18 @@ capture_formatted_mixed() {
   run assert_line -1 "Usage: tool.sh"
   assert_failure
   assert_output_contains "Line 3 (from index -1) does not equal 'Usage: tool.sh'"
+
+  # An index outside the captured lines is an error rather than a comparison
+  # against an empty string, at either end.
+  capture
+  run assert_line 4 "Done."
+  assert_failure
+  assert_output_contains "Line index 4 is out of range for output with 4 lines."
+
+  capture
+  run assert_line -5 "Usage: tool.sh"
+  assert_failure
+  assert_output_contains "Line index -5 is out of range for output with 4 lines."
 }
 
 @test "assert_line_not" {
@@ -84,6 +96,11 @@ capture_formatted_mixed() {
   assert_output_contains "match mode: literal"
   assert_output_contains "case: insensitive"
   assert_output_contains "> 1: Reading config"
+
+  capture
+  run assert_line_contains 9 "config"
+  assert_failure
+  assert_output_contains "Line index 9 is out of range for output with 4 lines."
 }
 
 @test "assert_line_contains_case" {


### PR DESCRIPTION
Closes #182

## Summary

Output could previously only be asserted as a whole (`assert_output`) or as a substring somewhere within it (`assert_output_contains`). Nothing addressed an individual line. This adds a family of assertions over the `${lines[@]}` array that bats-core's `run` already populates, covering a line at a specific index, any line regardless of position, exact line counts, and match-based occurrence counts, with every assertion composing with the library's existing match modes (literal, regex, format) and case sensitivity rather than reimplementing them.

## Changes

### New `src/assert.line.bash`

- 42 public assertions across four subjects: line at index (14) - `assert_line`, `assert_line_not`, and `assert_line_[not_]{contains,matches,matches_format}[_case]`, where a negative index counts back from the end so `-1` is the last line; any line (14) - `assert_any_line` / `assert_no_line` and `assert_{any,no}_line_{contains,matches,matches_format}[_case]`; line count (2) - `assert_line_count`, `assert_line_count_not`; occurrence count (12) - `assert_line_count_[not_]{contains,matches,matches_format}[_case]`, where `not_` negates the match rather than the count, matching its meaning everywhere else in the library.
- Nine internal engines carry the logic so every public wrapper is a single line passing its anchor, polarity, mode and case sensitivity as literals: `line_resolve_index`, `line_label`, `line_context`, `line_plural`, `line_participle` and `line_validate_count` are helpers, and `line_assert_index_match`, `line_assert_index_equal`, `line_assert_any_match`, `line_assert_any_equal`, `line_assert_count` and `line_assert_count_match` are the assert engines, backed by `line_match_indices` and `line_equal_indices` for locating matching offsets.
- An out-of-range index fails with a message naming both the index and the actual line count (`Line index 5 is out of range for output with 2 lines.`) instead of comparing against an empty string, which would otherwise read as an ordinary mismatch.
- A failure prints a window of two lines either side of the offending line, with the offending line marked by overwriting the indent (`> `) rather than inserting a character, so every line in the window stays in the same column.

### `src/assert.string.bash`

- Extracted `string_match_footer` out of `string_assert_match` so the line engines can build the same "match mode / case / case-decided note" footer without duplicating that logic. `string_assert_match` keeps its exact six-argument contract and identical output.

### `load.bash`

- Sources the new `src/assert.line.bash` module.

### `tests/assert.line.bats`

- 54 tests: one per public assertion covering both the positive and the negative path, plus engine tests for index resolution (negative, zero-padded, out of range at both ends, non-integer), the context window (clamped at each end, and index padding across a width change), and a test pinning that empty lines collapse without `--keep-empty-lines` and are preserved with it.

### `README.md`

- New "Line assertions" subsection with three tables (index-based, any-line, count-based assertions), the out-of-range and context report formats, and a `--keep-empty-lines` note explaining that `run` drops empty lines unless told to keep them, which shifts every later index.
- Table of contents and the features list updated to mention line assertions.

## Before / After

```
BEFORE - no way to target, count or contextualise a single line
┌──────────────────────────────────────────────────────────────────────┐
│ run tool.sh                                                          │
│ assert_output_contains "Deleted"   # matched somewhere in the        │
│                                     # stream - which line? how many? │
│                                                                       │
│ assert_output_contains "error"     # fails by dumping the entire     │
│                                     # captured stream, however long  │
└──────────────────────────────────────────────────────────────────────┘

AFTER - a full line-assertion family, contextualised failures
┌──────────────────────────────────────────────────────────────────────┐
│ run tool.sh                                                          │
│ assert_line_contains 2 "Deleted"          # line at index            │
│ assert_any_line_matches 'Deleted [0-9]+'  # any line                 │
│ assert_line_count 4                       # how many lines total     │
│ assert_line_count_contains 2 "error"      # how many lines match     │
│                                                                       │
│ # a failing assertion now prints a small window instead of the       │
│ # whole stream, with the offending line marked in place:             │
│                                                                       │
│     0: Usage: tool.sh                                                │
│     1: Reading config                                                │
│   > 2: all good                                                      │
│     3: Done.                                                         │
└──────────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added line-level assertions for exact matches, text containment, regular expressions, and format patterns.
  * Supports indexed lines, negative indices, any/no matching lines, line counts, and case-sensitive or insensitive checks.
  * Added handling for empty lines, invalid inputs, and detailed contextual failure messages.

* **Documentation**
  * Expanded the README with line assertion APIs, usage details, supported options, and error behavior.

* **Bug Fixes**
  * Improved string assertion failure messages with clearer match-mode and case-sensitivity details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->