### PR TITLE
[#189] Added named cases, chosen assertions and matrix expansion to the data provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ add_numbers() {
 
 A failure names the rows that broke by their zero-based index:
 
-```
+```text
 Failed sets (0-based): 1, 3
 Total failed test sets: 2
 ```
@@ -566,7 +566,7 @@ provide_cases() {
 
 The label is what a failure names, so nothing has to be counted to find the case that broke:
 
-```
+```text
 Error: Failed for set 'an empty argument'
 
 Failed sets: 'an empty argument'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - [Usage](#-usage)
   - [Load library](#load-library)
   - [Assertions](#assertions) - Command run, Line, Exit statuses, Standard error, String, Match modes, File, Git
-  - [Data provider](#data-provider) - Parameterized tests
+  - [Data provider](#data-provider) - Parameterized tests, named cases, matrices
   - [Mocking](#mocking) - Command mocking, Call log, Argument specifications, Strictness
   - [Step runner](#step-runner) - Sequential test assertions
   - [Helpers](#helpers) - Utility functions
@@ -44,7 +44,7 @@
 - An ordered log of every mocked call, asserted as a sequence and reported as a unified diff.
 - Mock expectations that fail the test when they go unused or when an unanticipated call arrives.
 - Step runner for sequences of mocked calls and output assertions.
-- Data provider for running one function over many test cases.
+- Data provider for running one function over many test cases, with named cases, per-case arity, a chosen assertion and matrix expansion.
 - Fixture and file utilities for building and restoring test sandboxes.
 - TUI helper for driving interactive scripts with scripted answers.
 
@@ -490,20 +490,22 @@ assert_dir_contains_string "${dir}" "needle"
 
 ### Data provider
 
-Run multiple test cases for a given function (aka "data provider").
+Run one function over many test cases (aka "data provider").
 
-Arguments:
+| Function                 | Description                                      | Arguments                                    |
+|--------------------------|--------------------------------------------------|----------------------------------------------|
+| `dataprovider_run`       | Runs the cases held in the `TEST_CASES` array    | `func_name`, `[args_per_row]`, `[assertion]` |
+| `dataprovider_run_cases` | Runs the cases that a function declares          | `func_name`, `cases_func`, `[assertion]`     |
+| `dataprovider_case`      | Declares and runs one case                       | `label`, `[arg...]`, `expected`              |
+| `dataprovider_matrix`    | Expands value lists into their cartesian product | `case_func`, `list_name...`                  |
 
-1. `func_name`: The name of the function to be tested.
-2. `args_per_row`: (Optional) The number of arguments in each row of the `TEST_CASES` array, defaults to `1`. Last argument is always the expected value.
+There are three forms. Reach for the **flat array** when every case has the same shape and reads well as a table. Reach for **declared cases** when a case needs a name, when arity differs between cases, or when a value is empty or holds spaces, tabs or newlines. Reach for the **matrix** when the cases are every combination of two or more value lists.
 
-Global Variables:
+Every form runs the function under test with `run` and then applies an assertion to the case's expected value, so any single-argument assertion in this library is a valid choice: `assert_output`, `assert_output_matches`, `assert_status`, `assert_output_not_contains`, and so on. The default is `assert_output_contains`.
 
-- `TEST_CASES`: An array containing test cases with their expected values.
+#### Flat array
 
-**Examples:**
-
-To run a function `add_numbers` with `TEST_CASES` containing three arguments per row, you can call `dataprovider_run` like so:
+`TEST_CASES` holds every case end to end, `args_per_row` says how wide a row is, and the last column of each row is the expected value:
 
 ```bash
 # Function to test.
@@ -520,6 +522,86 @@ add_numbers() {
   dataprovider_run "add_numbers" 3
 }
 ```
+
+A failure names the rows that broke by their zero-based index:
+
+```
+Failed sets (0-based): 1, 3
+Total failed test sets: 2
+```
+
+An expected value must not be empty here, because in a fixed-width table an empty last column is how a short row shows up. Use declared cases for a case whose expected value is genuinely empty.
+
+Pass an assertion as the third argument to check something other than containment:
+
+```bash
+declare -a TEST_CASES=(
+  1 2 3
+)
+dataprovider_run "add_numbers" 3 "assert_output"
+```
+
+#### Declared cases
+
+A function declares one case per `dataprovider_case` call. Each call states its own arity, and the values never leave the argument list, so empty values and values holding spaces, tabs or newlines need no quoting:
+
+```bash
+# Function to test.
+count_args() {
+  echo "count=$#"
+}
+
+provide_cases() {
+  dataprovider_case "no arguments" "count=0"
+  dataprovider_case "one argument" "a" "count=1"
+  dataprovider_case "an empty argument" "" "count=1"
+  # An empty label reports the case by its index instead.
+  dataprovider_case "" "a" "b" "count=2"
+}
+
+@test "Test count_args" {
+  dataprovider_run_cases "count_args" "provide_cases"
+}
+```
+
+The label is what a failure names, so nothing has to be counted to find the case that broke:
+
+```
+Error: Failed for set 'an empty argument'
+
+Failed sets: 'an empty argument'
+Total failed test sets: 1
+```
+
+#### Matrix
+
+`dataprovider_matrix` expands value lists into their cartesian product and hands each combination to a function, which turns it into a case. That is where the label and the expected value are derived from the combination rather than repeated for it:
+
+```bash
+# Function to test.
+describe_match() {
+  echo "${1}:${2}"
+}
+
+emit_case() {
+  dataprovider_case "${1}, case ${2}" "${1}" "${2}" "${1}:${2}"
+}
+
+provide_cases() {
+  dataprovider_matrix "emit_case" modes flags
+}
+
+@test "Test describe_match" {
+  declare -a modes=("literal" "regex" "format")
+  declare -a flags=(0 1)
+
+  dataprovider_run_cases "describe_match" "provide_cases"
+}
+```
+
+That runs six cases in the order `literal 0`, `literal 1`, `regex 0`, `regex 1`, `format 0`, `format 1` - the last list varies fastest, so they arrive in the order a written-out table would list them.
+
+Lists are passed by name rather than by value, because separating them inside one argument list would need a separator and any separator is also a value a list is entitled to hold. A list that is empty is an error rather than an empty product, since a provider that expands to nothing runs nothing and would otherwise pass.
 
 ### Mocking
 

--- a/src/dataprovider.bash
+++ b/src/dataprovider.bash
@@ -7,11 +7,18 @@
 ##
 # Runs multiple test cases for a given function (aka data provider).
 #
+# An expected value must not be empty: in a fixed-width table an empty last
+# column is how a short row shows up. Use 'dataprovider_run_cases' for a case
+# whose expected value is genuinely empty.
+#
 # Arguments:
 #   1. func_name: Name of the function to be tested.
 #   2. args_per_row: Number of elements in each row of the TEST_CASES array,
 #      counting the trailing expected value. Optional, defaults to 1. The
 #      function under test receives one argument fewer.
+#   3. assertion: Assertion to apply to each case, called with the case's
+#      expected value once the output has been captured. Optional, defaults to
+#      'assert_output_contains'.
 #
 # Globals:
 #   TEST_CASES: Array of test cases, each row ending with its expected value.
@@ -22,43 +29,42 @@
 #     dataprovider_run "add_numbers" 3
 ##
 dataprovider_run() {
-  local func_name="${1}"
+  local func_name="${1-}"
   local args_per_row="${2:-1}"
+  local assertion="${3-assert_output_contains}"
 
   ##
   ## Input validation.
   ##
 
-  if [ -z "${func_name}" ]; then
-    flunk "Function name must not be empty."
-    return
-  fi
+  dataprovider_validate_function "${func_name}" "Function" || return 1
+  dataprovider_validate_function "${assertion}" "Assertion" || return 1
 
-  if ! type -t "${func_name}" | grep -q 'function'; then
-    flunk "Function '${func_name}' is not a valid function."
-    return
+  if ! [[ ${args_per_row} =~ ^-?[0-9]+$ ]]; then
+    flunk "Number of arguments per test case '${args_per_row}' is not an integer."
+    return 1
   fi
 
   # Using the normal run() function is sufficient for testing functions with no
   # arguments.
   if [ "${args_per_row}" -le 0 ]; then
     flunk "Number of arguments per test case must be greater than zero."
-    return
+    return 1
   fi
 
   if [ -z "${TEST_CASES+x}" ]; then
     flunk "TEST_CASES array is empty."
-    return
+    return 1
   fi
 
-  if [ "${args_per_row}" -gt ${#TEST_CASES[@]} ]; then
+  if [ "${args_per_row}" -gt "${#TEST_CASES[@]}" ]; then
     flunk "Number of arguments per test case is greater than the total elements in TEST_CASES."
-    return
+    return 1
   fi
 
   if [ "$((${#TEST_CASES[@]} % args_per_row))" -ne 0 ]; then
     flunk "Total elements in TEST_CASES must be a multiple of ${args_per_row}."
-    return
+    return 1
   fi
 
   local i
@@ -66,7 +72,7 @@ dataprovider_run() {
   for ((i = args_per_row - 1, data_set_idx = 0; i < ${#TEST_CASES[@]}; i += args_per_row, data_set_idx++)); do
     if [ -z "${TEST_CASES[i]}" ]; then
       flunk "Expected value (last element) in the data set ${data_set_idx} is empty."
-      return
+      return 1
     fi
   done
 
@@ -74,35 +80,317 @@ dataprovider_run() {
   ## Runner.
   ##
 
-  local set_idx=0
-  local error_count=0
-  local failed_sets=""
-  local expected
-  local test_args
+  # 'dataprovider_case' reads the run's state from this frame through dynamic
+  # scoping, which is why the state is declared here and not in a shared helper.
+  local BATS_HELPERS_DATAPROVIDER_FUNC="${func_name}"
+  local BATS_HELPERS_DATAPROVIDER_ASSERT="${assertion}"
+  local BATS_HELPERS_DATAPROVIDER_INDEX=0
+  local BATS_HELPERS_DATAPROVIDER_LABELLED=0
+  local -a BATS_HELPERS_DATAPROVIDER_FAILED=()
 
   for ((i = 0; i < ${#TEST_CASES[@]}; i += args_per_row)); do
-    expected="${TEST_CASES[i + args_per_row - 1]}"
-    test_args=("${TEST_CASES[@]:i:args_per_row-1}")
+    dataprovider_case "" "${TEST_CASES[@]:i:args_per_row}"
+  done
 
-    run "${func_name}" "${test_args[@]}"
+  dataprovider_report
+}
 
-    if ! assert_output_contains "${expected}"; then
-      echo "Error: Failed for set ${set_idx}"
-      error_count=$((error_count + 1))
-      failed_sets="${failed_sets}${set_idx}, "
+##
+## Declared cases.
+##
+
+##
+# Runs the test cases that a function declares.
+#
+# Arguments:
+#   1. func_name: Name of the function to be tested.
+#   2. cases_func: Name of the function declaring the cases. It is called once
+#      and calls 'dataprovider_case' for each case.
+#   3. assertion: Assertion to apply to each case, called with the case's
+#      expected value once the output has been captured. Optional, defaults to
+#      'assert_output_contains'.
+#
+# Examples:
+#   provide_cases() {
+#     dataprovider_case "adds two positives" 1 2 3
+#     dataprovider_case "adds a negative" 5 -2 3
+#   }
+#   dataprovider_run_cases "add_numbers" "provide_cases"
+##
+dataprovider_run_cases() {
+  local func_name="${1-}"
+  local cases_func="${2-}"
+  local assertion="${3-assert_output_contains}"
+
+  dataprovider_validate_function "${func_name}" "Function" || return 1
+  dataprovider_validate_function "${cases_func}" "Cases function" || return 1
+  dataprovider_validate_function "${assertion}" "Assertion" || return 1
+
+  # 'dataprovider_case' reads the run's state from this frame through dynamic
+  # scoping, which is why the state is declared here and not in a shared helper.
+  local BATS_HELPERS_DATAPROVIDER_FUNC="${func_name}"
+  local BATS_HELPERS_DATAPROVIDER_ASSERT="${assertion}"
+  local BATS_HELPERS_DATAPROVIDER_INDEX=0
+  local BATS_HELPERS_DATAPROVIDER_LABELLED=0
+  local -a BATS_HELPERS_DATAPROVIDER_FAILED=()
+
+  if ! "${cases_func}"; then
+    flunk "Cases function '${cases_func}' exited with a non-zero status."
+    return 1
+  fi
+
+  # A provider that declares nothing runs nothing and would otherwise pass.
+  if [ "${BATS_HELPERS_DATAPROVIDER_INDEX}" -eq 0 ]; then
+    flunk "Cases function '${cases_func}' declared no test cases."
+    return 1
+  fi
+
+  dataprovider_report
+}
+
+##
+# Declares one test case and runs it.
+#
+# The case runs where it is declared so that its values never leave the argument
+# list: an empty value, or one holding spaces, tabs or newlines, survives
+# without quoting. Arity is stated per call, so it may differ between cases.
+#
+# Arguments:
+#   1. label: Name to report the case by. Pass an empty string to report it by
+#      its index instead.
+#   2. args: Arguments to pass to the function under test. Optional.
+#   3. expected: Expected value to pass to the assertion, always last.
+#
+# Globals:
+#   BATS_HELPERS_DATAPROVIDER_FUNC: Function under test.
+#   BATS_HELPERS_DATAPROVIDER_ASSERT: Assertion to apply.
+#   BATS_HELPERS_DATAPROVIDER_INDEX: Index of the next case, advanced here.
+#   BATS_HELPERS_DATAPROVIDER_LABELLED: Set to 1 once a case carries a label.
+#   BATS_HELPERS_DATAPROVIDER_FAILED: Failed cases, appended to here.
+#
+# Outputs:
+#   STDOUT: A line naming the case, when it fails.
+#
+# Returns:
+#   Zero for a case that fails its assertion, so that the remaining cases still
+#   run; non-zero only when the call itself is malformed.
+##
+dataprovider_case() {
+  if [ -z "${BATS_HELPERS_DATAPROVIDER_FUNC+x}" ]; then
+    flunk "Function 'dataprovider_case' must be called from the function passed to 'dataprovider_run_cases'."
+    return 1
+  fi
+
+  if [ "$#" -lt 2 ]; then
+    flunk "A test case requires a label and an expected value."
+    return 1
+  fi
+
+  local label="${1}"
+  shift
+
+  local expected="${*: -1}"
+  local -a args=("${@:1:$#-1}")
+
+  local description="${BATS_HELPERS_DATAPROVIDER_INDEX}"
+
+  if [ "${label}" != "" ]; then
+    description="'${label}'"
+    BATS_HELPERS_DATAPROVIDER_LABELLED=1
+  fi
+
+  BATS_HELPERS_DATAPROVIDER_INDEX=$((BATS_HELPERS_DATAPROVIDER_INDEX + 1))
+
+  run "${BATS_HELPERS_DATAPROVIDER_FUNC}" "${args[@]}"
+
+  if "${BATS_HELPERS_DATAPROVIDER_ASSERT}" "${expected}"; then
+    return 0
+  fi
+
+  echo "Error: Failed for set ${description}"
+  BATS_HELPERS_DATAPROVIDER_FAILED+=("${description}")
+}
+
+##
+## Matrix expansion.
+##
+
+##
+# Expands value lists into their cartesian product.
+#
+# Each combination is handed to a function that turns it into a test case, which
+# is what lets the label and the expected value be derived from the combination
+# rather than repeated for it. Combinations are emitted in row-major order, so
+# the last list varies fastest and they arrive in the order a written-out table
+# would list them.
+#
+# Lists are named rather than passed by value because separating them inside one
+# argument list needs a separator, and any separator is also a value a list is
+# entitled to hold.
+#
+# Arguments:
+#   1. case_func: Function called once per combination, with the combination as
+#      its arguments.
+#   2. list_names: Names of the indexed arrays to expand. At least one.
+#
+# Examples:
+#   declare -a modes=("literal" "regex")
+#   declare -a flags=(0 1)
+#   dataprovider_matrix "emit_case" modes flags
+##
+dataprovider_matrix() {
+  local case_func="${1-}"
+
+  dataprovider_validate_function "${case_func}" "Case function" || return 1
+
+  if [ "$#" -lt 2 ]; then
+    flunk "At least one value list is required."
+    return 1
+  fi
+
+  shift
+
+  ##
+  ## List resolution.
+  ##
+
+  local -a values=()
+  local -a counts=()
+  local name
+  local ref
+  local -a list
+
+  for name in "$@"; do
+    if ! [[ ${name} =~ ^[A-Za-z_][A-Za-z_0-9]*$ ]]; then
+      flunk "Value list name '${name}' is not a valid variable name."
+      return 1
     fi
 
-    set_idx=$((set_idx + 1))
+    if ! declare -p "${name}" >/dev/null 2>&1; then
+      flunk "Value list '${name}' is not declared."
+      return 1
+    fi
+
+    if [[ $(declare -p "${name}") != "declare -a"* ]]; then
+      flunk "Value list '${name}' is not an indexed array."
+      return 1
+    fi
+
+    ref="${name}[@]"
+    list=("${!ref}")
+
+    # An empty list makes the product empty, which would run no cases at all and
+    # report nothing.
+    if [ "${#list[@]}" -eq 0 ]; then
+      flunk "Value list '${name}' is empty."
+      return 1
+    fi
+
+    counts+=("${#list[@]}")
+    values+=("${list[@]}")
   done
 
   ##
-  ## Error reporting.
+  ## Product walk.
   ##
 
-  if [ "${error_count}" -ne 0 ]; then
-    failed_sets=${failed_sets%, } # Remove the trailing comma.
-    echo
-    echo "Failed sets (0-based): ${failed_sets}"
-    flunk "Total failed test sets: ${error_count}"
+  local list_count="$#"
+  local -a cursor=()
+  local i
+
+  for ((i = 0; i < list_count; i++)); do
+    cursor[i]=0
+  done
+
+  local -a combination
+  local offset
+  local position
+
+  while true; do
+    combination=()
+    offset=0
+
+    for ((i = 0; i < list_count; i++)); do
+      combination+=("${values[offset + cursor[i]]}")
+      offset=$((offset + counts[i]))
+    done
+
+    "${case_func}" "${combination[@]}" || return 1
+
+    for ((position = list_count - 1; position >= 0; position--)); do
+      cursor[position]=$((cursor[position] + 1))
+
+      if [ "${cursor[position]}" -lt "${counts[position]}" ]; then
+        break
+      fi
+
+      cursor[position]=0
+    done
+
+    if [ "${position}" -lt 0 ]; then
+      break
+    fi
+  done
+}
+
+##
+## Validation and reporting.
+##
+
+##
+# Validates that a name given to the provider is a function.
+#
+# Arguments:
+#   1. name: Name to validate.
+#   2. noun: Capitalised role of the name, used to open both messages.
+##
+dataprovider_validate_function() {
+  local name="${1}"
+  local noun="${2}"
+
+  if [ -z "${name}" ]; then
+    flunk "${noun} name must not be empty."
+    return 1
   fi
+
+  if [ "$(type -t "${name}")" != "function" ]; then
+    flunk "${noun} '${name}' is not a valid function."
+    return 1
+  fi
+}
+
+##
+# Reports the cases that failed.
+#
+# Globals:
+#   BATS_HELPERS_DATAPROVIDER_LABELLED: '1' when at least one case carried a
+#     label, which is what makes the indices in the summary meaningless.
+#   BATS_HELPERS_DATAPROVIDER_FAILED: Failed cases.
+#
+# Outputs:
+#   STDOUT: The failed cases, when there are any.
+##
+dataprovider_report() {
+  if [ "${#BATS_HELPERS_DATAPROVIDER_FAILED[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  local list=""
+  local description
+
+  for description in "${BATS_HELPERS_DATAPROVIDER_FAILED[@]}"; do
+    list="${list}${description}, "
+  done
+
+  list="${list%, }"
+
+  echo
+
+  if [ "${BATS_HELPERS_DATAPROVIDER_LABELLED}" = "1" ]; then
+    echo "Failed sets: ${list}"
+  else
+    echo "Failed sets (0-based): ${list}"
+  fi
+
+  flunk "Total failed test sets: ${#BATS_HELPERS_DATAPROVIDER_FAILED[@]}"
 }

--- a/src/dataprovider.bash
+++ b/src/dataprovider.bash
@@ -375,21 +375,21 @@ dataprovider_report() {
     return 0
   fi
 
-  local list=""
+  local summary=""
   local description
 
   for description in "${BATS_HELPERS_DATAPROVIDER_FAILED[@]}"; do
-    list="${list}${description}, "
+    summary="${summary}${description}, "
   done
 
-  list="${list%, }"
+  summary="${summary%, }"
 
   echo
 
   if [ "${BATS_HELPERS_DATAPROVIDER_LABELLED}" = "1" ]; then
-    echo "Failed sets: ${list}"
+    echo "Failed sets: ${summary}"
   else
-    echo "Failed sets (0-based): ${list}"
+    echo "Failed sets (0-based): ${summary}"
   fi
 
   flunk "Total failed test sets: ${#BATS_HELPERS_DATAPROVIDER_FAILED[@]}"

--- a/tests/dataprovider.bats
+++ b/tests/dataprovider.bats
@@ -86,6 +86,11 @@ matrix_emit_pair() {
   dataprovider_case "${1}-${2}" "${1}" "${2}" "${1}${2}"
 }
 
+matrix_emit_single() {
+  matrix_seen+=("${1}")
+  dataprovider_case "${1}" "${1}" "${1}" "${1}${1}"
+}
+
 matrix_emit_triple() {
   matrix_seen+=("${1}${2}${3}")
   dataprovider_case "" "${1}" "${2}" "${3}" "count=3"
@@ -93,6 +98,10 @@ matrix_emit_triple() {
 
 provide_matrix_pairs() {
   dataprovider_matrix "matrix_emit_pair" matrix_first matrix_second
+}
+
+provide_matrix_singles() {
+  dataprovider_matrix "matrix_emit_single" matrix_first
 }
 
 provide_matrix_triples() {
@@ -352,6 +361,16 @@ provide_matrix_triples() {
 }
 
 @test "Test dataprovider matrix, single list - success" {
+  declare -a matrix_first=("a" "b")
+  declare -a matrix_seen=()
+
+  dataprovider_run_cases "fixture_concat" "provide_matrix_singles"
+
+  assert_equal "2" "${#matrix_seen[@]}"
+  assert_equal "a b" "${matrix_seen[*]}"
+}
+
+@test "Test dataprovider matrix, list holding one value - success" {
   declare -a matrix_first=("a" "b")
   declare -a matrix_second=("1")
   declare -a matrix_seen=()

--- a/tests/dataprovider.bats
+++ b/tests/dataprovider.bats
@@ -18,6 +18,87 @@ fixture_concat() {
   echo "${num1}${num2}"
 }
 
+fixture_args() {
+  echo "count=$#"
+  local arg
+  for arg in "$@"; do
+    echo "arg=[${arg}]"
+  done
+}
+
+provide_cases() {
+  dataprovider_case "adds two positives" 1 2 3
+  dataprovider_case "adds a negative" 5 -2 3
+}
+
+provide_failing_cases() {
+  dataprovider_case "adds two positives" 1 2 3
+  dataprovider_case "adds a negative" 5 -2 33
+  dataprovider_case "adds zero" 0 0 1
+}
+
+provide_unlabelled_cases() {
+  dataprovider_case "" 1 2 33
+}
+
+provide_mixed_labels() {
+  dataprovider_case "" 1 2 33
+  dataprovider_case "named" 1 2 33
+}
+
+provide_varying_arity() {
+  dataprovider_case "no arguments" "count=0"
+  dataprovider_case "one argument" "a" "count=1"
+  dataprovider_case "two arguments" "a" "b" "count=2"
+}
+
+provide_empty_values() {
+  dataprovider_case "empty value" "" $'count=1\narg=[]'
+  dataprovider_case "empty among values" "" "x" "" $'count=3\narg=[]\narg=[x]\narg=[]'
+}
+
+provide_space_values() {
+  dataprovider_case "spaces" "a b  c" $'count=1\narg=[a b  c]'
+}
+
+provide_tab_values() {
+  dataprovider_case "tabs" $'a\tb' $'count=1\narg=[a\tb]'
+}
+
+provide_newline_values() {
+  dataprovider_case "newlines" $'a\nb' $'count=1\narg=[a\nb]'
+}
+
+provide_regex_cases() {
+  dataprovider_case "sums to a number" 1 2 "^[0-9]+$"
+}
+
+provide_no_cases() {
+  return 0
+}
+
+provide_case_without_expected() {
+  dataprovider_case "no expected value"
+}
+
+matrix_emit_pair() {
+  matrix_seen+=("${1}|${2}")
+  dataprovider_case "${1}-${2}" "${1}" "${2}" "${1}${2}"
+}
+
+matrix_emit_triple() {
+  matrix_seen+=("${1}${2}${3}")
+  dataprovider_case "" "${1}" "${2}" "${3}" "count=3"
+}
+
+provide_matrix_pairs() {
+  dataprovider_matrix "matrix_emit_pair" matrix_first matrix_second
+}
+
+provide_matrix_triples() {
+  dataprovider_matrix "matrix_emit_triple" matrix_first matrix_second matrix_third
+}
+
 @test "Test dataprovider runner, direct - success" {
   # Numbers.
   declare -a TEST_CASES=(
@@ -75,6 +156,18 @@ fixture_concat() {
   assert_failure
   assert_output_contains "Function 'non_existing_func' is not a valid function."
 
+  run dataprovider_run "fixture_add" 3 ""
+  assert_failure
+  assert_output_contains "Assertion name must not be empty."
+
+  run dataprovider_run "fixture_add" 3 "non_existing_func"
+  assert_failure
+  assert_output_contains "Assertion 'non_existing_func' is not a valid function."
+
+  run dataprovider_run "fixture_add" "three"
+  assert_failure
+  assert_output_contains "Number of arguments per test case 'three' is not an integer."
+
   run dataprovider_run "fixture_add" 0
   assert_failure
   assert_output_contains "Number of arguments per test case must be greater than zero."
@@ -111,4 +204,217 @@ fixture_concat() {
   run dataprovider_run "fixture_add" 3
   assert_failure
   assert_output_contains "Expected value (last element) in the data set 1 is empty."
+}
+
+@test "Test dataprovider runner, custom assertion - success" {
+  declare -a TEST_CASES=(
+    1 2 3
+    4 5 9
+  )
+
+  dataprovider_run "fixture_add" 3 "assert_output"
+}
+
+@test "Test dataprovider runner, custom assertion - failure" {
+  declare -a TEST_CASES=(
+    1 23 23
+  )
+
+  # The same data passes containment and fails an exact comparison, so only the
+  # assertion tells the two runs apart.
+  dataprovider_run "fixture_concat" 3
+
+  run dataprovider_run "fixture_concat" 3 "assert_output"
+  assert_failure
+  assert_output_contains "Failed sets (0-based): 0"
+  assert_output_contains "Total failed test sets: 1"
+}
+
+@test "Test dataprovider runner, declared cases, direct - success" {
+  dataprovider_run_cases "fixture_add" "provide_cases"
+}
+
+@test "Test dataprovider runner, declared cases - success" {
+  run dataprovider_run_cases "fixture_add" "provide_cases"
+  assert_success
+
+  assert_output_not_contains "Failed sets"
+  assert_output_not_contains "Total failed test sets"
+}
+
+@test "Test dataprovider runner, declared cases - failure" {
+  run dataprovider_run_cases "fixture_add" "provide_failing_cases"
+  assert_failure
+  assert_output_contains "Error: Failed for set 'adds a negative'"
+  assert_output_contains "Error: Failed for set 'adds zero'"
+  assert_output_contains "Failed sets: 'adds a negative', 'adds zero'"
+  assert_output_contains "Total failed test sets: 2"
+  assert_output_not_contains "0-based"
+}
+
+@test "Test dataprovider runner, declared cases without a label - failure" {
+  run dataprovider_run_cases "fixture_add" "provide_unlabelled_cases"
+  assert_failure
+  assert_output_contains "Error: Failed for set 0"
+  assert_output_contains "Failed sets (0-based): 0"
+  assert_output_contains "Total failed test sets: 1"
+}
+
+@test "Test dataprovider runner, declared cases with mixed labels - failure" {
+  run dataprovider_run_cases "fixture_add" "provide_mixed_labels"
+  assert_failure
+  assert_output_contains "Error: Failed for set 0"
+  assert_output_contains "Error: Failed for set 'named'"
+  assert_output_contains "Failed sets: 0, 'named'"
+  assert_output_contains "Total failed test sets: 2"
+}
+
+@test "Test dataprovider runner, declared cases with varying arity - success" {
+  dataprovider_run_cases "fixture_args" "provide_varying_arity"
+}
+
+@test "Test dataprovider runner, declared cases with empty values - success" {
+  dataprovider_run_cases "fixture_args" "provide_empty_values" "assert_output"
+}
+
+@test "Test dataprovider runner, declared cases with spaces - success" {
+  dataprovider_run_cases "fixture_args" "provide_space_values" "assert_output"
+}
+
+@test "Test dataprovider runner, declared cases with tabs - success" {
+  dataprovider_run_cases "fixture_args" "provide_tab_values" "assert_output"
+}
+
+@test "Test dataprovider runner, declared cases with newlines - success" {
+  dataprovider_run_cases "fixture_args" "provide_newline_values" "assert_output"
+}
+
+@test "Test dataprovider runner, declared cases with a custom assertion - success" {
+  dataprovider_run_cases "fixture_add" "provide_regex_cases" "assert_output_matches"
+}
+
+@test "Test dataprovider runner, declared cases with a custom assertion - failure" {
+  run dataprovider_run_cases "fixture_add" "provide_regex_cases" "assert_output_not_matches"
+  assert_failure
+  assert_output_contains "Failed sets: 'sums to a number'"
+}
+
+@test "Test dataprovider runner, declared cases validation - failure" {
+  run dataprovider_run_cases "" "provide_cases"
+  assert_failure
+  assert_output_contains "Function name must not be empty."
+
+  run dataprovider_run_cases "non_existing_func" "provide_cases"
+  assert_failure
+  assert_output_contains "Function 'non_existing_func' is not a valid function."
+
+  run dataprovider_run_cases "fixture_add" ""
+  assert_failure
+  assert_output_contains "Cases function name must not be empty."
+
+  run dataprovider_run_cases "fixture_add" "non_existing_func"
+  assert_failure
+  assert_output_contains "Cases function 'non_existing_func' is not a valid function."
+
+  run dataprovider_run_cases "fixture_add" "provide_cases" ""
+  assert_failure
+  assert_output_contains "Assertion name must not be empty."
+
+  run dataprovider_run_cases "fixture_add" "provide_cases" "non_existing_func"
+  assert_failure
+  assert_output_contains "Assertion 'non_existing_func' is not a valid function."
+
+  run dataprovider_run_cases "fixture_add" "provide_no_cases"
+  assert_failure
+  assert_output_contains "Cases function 'provide_no_cases' declared no test cases."
+
+  run dataprovider_run_cases "fixture_add" "provide_case_without_expected"
+  assert_failure
+  assert_output_contains "A test case requires a label and an expected value."
+  assert_output_contains "Cases function 'provide_case_without_expected' exited with a non-zero status."
+}
+
+@test "Test dataprovider case, outside a runner - failure" {
+  run dataprovider_case "label" "expected"
+  assert_failure
+  assert_output_contains "Function 'dataprovider_case' must be called from the function passed to 'dataprovider_run_cases'."
+}
+
+@test "Test dataprovider matrix - success" {
+  declare -a matrix_first=("a" "b")
+  declare -a matrix_second=("1" "2" "3")
+  declare -a matrix_seen=()
+
+  dataprovider_run_cases "fixture_concat" "provide_matrix_pairs"
+
+  assert_equal "6" "${#matrix_seen[@]}"
+  assert_equal "a|1 a|2 a|3 b|1 b|2 b|3" "${matrix_seen[*]}"
+}
+
+@test "Test dataprovider matrix, single list - success" {
+  declare -a matrix_first=("a" "b")
+  declare -a matrix_second=("1")
+  declare -a matrix_seen=()
+
+  dataprovider_run_cases "fixture_concat" "provide_matrix_pairs"
+
+  assert_equal "2" "${#matrix_seen[@]}"
+  assert_equal "a|1 b|1" "${matrix_seen[*]}"
+}
+
+@test "Test dataprovider matrix, three lists - success" {
+  declare -a matrix_first=("a" "b")
+  declare -a matrix_second=("1" "2")
+  declare -a matrix_third=("x" "y")
+  declare -a matrix_seen=()
+
+  dataprovider_run_cases "fixture_args" "provide_matrix_triples"
+
+  assert_equal "8" "${#matrix_seen[@]}"
+  assert_equal "a1x a1y a2x a2y b1x b1y b2x b2y" "${matrix_seen[*]}"
+}
+
+@test "Test dataprovider matrix - failure" {
+  declare -a matrix_first=("a" "b")
+  declare -a matrix_second=("1" "2")
+  declare -a matrix_seen=()
+
+  run dataprovider_run_cases "fixture_concat" "provide_matrix_pairs" "assert_output_not_contains"
+  assert_failure
+  assert_output_contains "Failed sets: 'a-1', 'a-2', 'b-1', 'b-2'"
+  assert_output_contains "Total failed test sets: 4"
+}
+
+@test "Test dataprovider matrix, validation - failure" {
+  declare -a matrix_first=("a" "b")
+  declare -a matrix_empty=()
+  declare matrix_scalar="a"
+
+  run dataprovider_matrix "" matrix_first
+  assert_failure
+  assert_output_contains "Case function name must not be empty."
+
+  run dataprovider_matrix "non_existing_func" matrix_first
+  assert_failure
+  assert_output_contains "Case function 'non_existing_func' is not a valid function."
+
+  run dataprovider_matrix "matrix_emit_pair"
+  assert_failure
+  assert_output_contains "At least one value list is required."
+
+  run dataprovider_matrix "matrix_emit_pair" "not an identifier"
+  assert_failure
+  assert_output_contains "Value list name 'not an identifier' is not a valid variable name."
+
+  run dataprovider_matrix "matrix_emit_pair" matrix_missing
+  assert_failure
+  assert_output_contains "Value list 'matrix_missing' is not declared."
+
+  run dataprovider_matrix "matrix_emit_pair" matrix_scalar
+  assert_failure
+  assert_output_contains "Value list 'matrix_scalar' is not an indexed array."
+
+  run dataprovider_matrix "matrix_emit_pair" matrix_empty
+  assert_failure
+  assert_output_contains "Value list 'matrix_empty' is empty."
 }


### PR DESCRIPTION
Closes #189

## Summary

The data provider in `src/dataprovider.bash` had three limits that compounded on each other: cases were anonymous, so a failure only ever named a zero-based row index; every row in `TEST_CASES` had to share one fixed width, with the last column always the expected value; and the assertion applied to every case was hardcoded to `assert_output_contains`. This adds three entry points alongside the existing `dataprovider_run`, so a case can carry its own label and its own arity, and a run can choose which assertion checks its output. The original flat-array form doesn't change behaviour and keeps its exact failure messages, so anyone not opting into the new forms sees no difference.

## Changes

- `dataprovider_run` gains an optional third `assertion` argument (default `assert_output_contains`) and now validates both it and `args_per_row`; an unlabelled run still reports `Failed sets (0-based): ...` byte-for-byte.
- `dataprovider_case` declares and runs one case from inside a cases function: a label (an empty string falls back to its index), any number of arguments, and a trailing expected value, checked against the chosen assertion once `run` has captured the output. The case runs where it's declared, so its values never leave the argument list - empty values and values holding spaces, tabs or newlines round-trip without quoting.
- `dataprovider_run_cases` runs the cases a function declares via repeated `dataprovider_case` calls, taking the same optional `assertion` argument as `dataprovider_run`, and reports labelled failures as `Failed sets: 'label', ...`.
- `dataprovider_matrix` expands one or more named indexed-array value lists into their cartesian product, in row-major order, and hands each combination to a case function - so a matrix of scenarios is declared as lists instead of a fully written-out table. Lists are passed by name because separating them inside one argument list would need a separator, and any separator is also a legal list value.
- Validation (`dataprovider_validate_function`) and reporting (`dataprovider_report`) are factored out of `dataprovider_run` so every entry point produces the same failure format.
- `tests/dataprovider.bats` grows from 4 to 26 tests, covering labelled, unlabelled and mixed-label failures, varying arity, empty/space/tab/newline-holding values, custom assertions, and matrix expansion including single-list and three-list cases.
- `README.md` documents all four functions in a table and adds worked examples for declared cases and matrix expansion.

## Before / After

```
BEFORE
┌─────────────────────────────────────────────────┐
│ dataprovider_run(func_name, args_per_row)       │
│                                                 │
│ One entry point.                                │
│ TEST_CASES rows must all share one fixed width. │
│ Assertion is always assert_output_contains.     │
│ A failure names only a zero-based row index.    │
└─────────────────────────────────────────────────┘

AFTER
┌───────────────────────────────────────────────────────────────┐
│ dataprovider_run(func_name, args_per_row, [assertion])        │
│ dataprovider_run_cases(func_name, cases_func, [assertion])    │
│ dataprovider_case(label, [arg...], expected)                  │
│ dataprovider_matrix(case_func, list_name...)                  │
│                                                               │
│ Four entry points: flat array, declared cases,                │
│ one declared case, or a matrix expansion of value lists.      │
│ A declared case states its own arity and may be empty.        │
│ Any single-argument assertion may check the output.           │
│ A failure names the case's label, or its index if unlabelled. │
└───────────────────────────────────────────────────────────────┘

Failure output, unlabelled (unchanged) vs. a declared, labelled case:

  Failed sets (0-based): 1, 3    Failed sets: 'adds a negative'
  Total failed test sets: 2      Total failed test sets: 1
```
