### PR TITLE
[#190] Added 'cleanup_register' and 'cleanup_run' for deferred per-test cleanup.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This is a BATS (Bash Automated Testing System) helpers library that provides ass
 - **load.bash**: Central loading point that sources all helper modules
 - **src/**: Contains all helper modules:
   - `assert.*.bash`: Various assertion helpers (base, command, string, file, git)
+  - `cleanup.bash`: Deferred cleanup that runs once the current test has finished
   - `file.bash`: File utilities for creating, trimming, backing up and restoring files
   - `mock.bash`: Command mocking - the sandbox, mock creation, responses, argument specifications, strictness, the ordered call log and its assertions
   - `steps.bash`: Step runner for sequential command and string assertions

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
   - [Data provider](#data-provider) - Parameterized tests, named cases, matrices
   - [Mocking](#mocking) - Command mocking, Call log, Argument specifications, Strictness
   - [Step runner](#step-runner) - Sequential test assertions
+  - [Cleanup](#cleanup) - Deferred per-test cleanup
   - [Helpers](#helpers) - Utility functions
   - [Environment variables](#environment-variables) - Full variable reference
   - [Deprecations](#deprecations) - Renamed functions and variables
@@ -44,6 +45,7 @@
 - An ordered log of every mocked call, asserted as a sequence and reported as a unified diff.
 - Mock expectations that fail the test when they go unused or when an unanticipated call arrives.
 - Step runner for sequences of mocked calls and output assertions.
+- Deferred cleanup registered next to the code that created the thing it removes.
 - Data provider for running one function over many test cases, with named cases, per-case arity, a chosen assertion and matrix expansion.
 - Fixture and file utilities for building and restoring test sandboxes.
 - TUI helper for driving interactive scripts with scripted answers.
@@ -999,6 +1001,99 @@ Set `BATS_HELPERS_STEPS_DEBUG` to `1` to print the parsing and matching decision
 export BATS_HELPERS_STEPS_DEBUG=1
 ```
 
+### Cleanup
+
+Cleanup that belongs to one test can be registered next to the code that created the thing it removes, instead of being written into a shared `teardown` or repeated on every early-exit path:
+
+```bash
+@test "Build writes an artifact" {
+  build_dir="${BATS_TEST_TMPDIR}/build"
+  mkdir -p "${build_dir}"
+  cleanup_register rm -rf "${build_dir}"
+
+  run ./build.sh "${build_dir}"
+  assert_success
+  assert_file_exists "${build_dir}/artifact.tar"
+}
+```
+
+| Function                | Description                                                           | Arguments              | Returns       |
+|-------------------------|-----------------------------------------------------------------------|------------------------|---------------|
+| `cleanup_register`      | Registers a command to run once the current test has finished         | `command`, `[args...]` | None          |
+| `cleanup_run`           | Runs the registered commands in reverse order. Call from `teardown()` | None                   | None          |
+| `cleanup_registry_path` | Resolves the file the registry is stored in                           | None                   | Registry path |
+
+#### Composing with your teardown
+
+`teardown` belongs to your test file, so the library does not define it. Call `cleanup_run` from your own `teardown`, the way `mock_setup` is called from `setup`:
+
+```bash
+setup() {
+  mock_setup
+}
+
+teardown() {
+  cleanup_run
+}
+```
+
+Without that call nothing is ever run, so wire it up once per test file - or once in the helper every test file loads.
+
+#### Order and statuses
+
+Registrations run in reverse order, so a resource created inside another one is removed while the outer one still exists:
+
+```bash
+cleanup_register rm -rf "${repo_dir}"
+cleanup_register git -C "${repo_dir}" worktree remove "${worktree_dir}"
+```
+
+BATS runs `teardown` after a test whether it passed or failed, so the registered commands run either way. From there:
+
+- A cleanup that succeeds leaves the test's own result alone. A test that failed still reports its own failure, not the cleanup.
+- A cleanup that fails fails an otherwise-passing test, and reports the command and its exit status. A cleanup that silently fails is how leaked state accumulates.
+- A cleanup that fails does not stop the ones registered before it, and does not mask a failure that preceded it.
+
+#### Registering a command
+
+Arguments are quoted when they are registered, so reassigning a variable afterwards cannot redirect the command:
+
+```bash
+dir="${BATS_TEST_TMPDIR}/first"
+cleanup_register rm -rf "${dir}"
+
+# The registered command still removes "first".
+dir="${BATS_TEST_TMPDIR}/second"
+```
+
+Anything that needs a pipeline, a redirection or several statements is registered as a function:
+
+```bash
+archive_logs() {
+  tar -czf "${1}.tar.gz" "${1}"
+}
+
+cleanup_register archive_logs "${log_dir}"
+```
+
+#### Cleanup sandbox
+
+The registry is the file `${BATS_TEST_TMPDIR}/bats-helpers-cleanup`, so BATS removes it together with the rest of the test sandbox and concurrent runs cannot overwrite each other's registrations. Keeping it on disk rather than in a variable also means a registration made inside a subshell - under `run`, a command substitution or a pipeline - still reaches `cleanup_run`.
+
+Set `BATS_HELPERS_CLEANUP_DIR` to store the registry elsewhere. Only the default location carries the guarantees above - a directory outside `${BATS_TEST_TMPDIR}` is not removed by BATS and is shared with concurrent runs:
+
+```bash
+export BATS_HELPERS_CLEANUP_DIR="${BATS_TEST_TMPDIR}/cleanup"
+```
+
+Use `cleanup_registry_path` to resolve where the registry is stored:
+
+```bash
+assert_file_not_exists "$(cleanup_registry_path)"
+```
+
+`cleanup_run` drains the registry before running anything, so calling it a second time - from the test body and again from `teardown`, say - runs nothing.
+
 ### Helpers
 
 | Function Name             | Description                                                                   |
@@ -1072,6 +1167,7 @@ Every variable the library defines, in one place. Each is also covered by the se
 | `BATS_HELPERS_ASSERT_DIR_EXCLUDE`              | `assert_dir_contains_string`, `assert_dir_not_contains_string` | Array of directory names to exclude from the search, on top of the always-excluded four     |
 | `BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED` | `fixture_export_codebase`                                     | Set to `1` to enable the export; anything else makes the function a no-op                   |
 | `BATS_HELPERS_BACKUP_DIR`                      | `file_add_var`, `file_restore`, `file_backup_path`            | Backup root. Defaults to `${BATS_TEST_TMPDIR}/bats-helpers-backup`                          |
+| `BATS_HELPERS_CLEANUP_DIR`                     | `cleanup_register`, `cleanup_run`, `cleanup_registry_path`    | Directory holding the cleanup registry. Defaults to `${BATS_TEST_TMPDIR}`                   |
 | `BATS_HELPERS_MOCK_TMPDIR`                     | `mock_setup`, `mock_create`                                   | Directory the mocks are written below. Defaults to `${BATS_TEST_TMPDIR}`, and `mock_setup` exports the resolved path |
 | `BATS_HELPERS_MOCK_USER`                       | `mock_get_call_user`                                          | User a mock call is reported as. Defaults to `id -un`                                       |
 | `BATS_HELPERS_MOCK_STRICT`                     | `mock_create`                                                 | Set to `0` to answer the calls a mock's expectations do not cover. Defaults to `1`, and is read when the mock is created |

--- a/load.bash
+++ b/load.bash
@@ -14,6 +14,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/src/assert.line.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.file.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.git.bash"
 
+source "$(dirname "${BASH_SOURCE[0]}")/src/cleanup.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/file.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/fixture.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/dataprovider.bash"

--- a/src/cleanup.bash
+++ b/src/cleanup.bash
@@ -25,7 +25,7 @@ cleanup_registry_path() {
   if [ -z "${dir}" ]; then
     # Written directly rather than through 'flunk', whose path rewriting needs
     # the non-empty BATS_TEST_TMPDIR that is missing here.
-    echo "Unable to resolve the cleanup registry: BATS_TEST_TMPDIR is not set. Set BATS_HELPERS_CLEANUP_DIR to a writable directory" >&2
+    echo "Cleanup registry cannot be resolved: 'BATS_TEST_TMPDIR' is not set. Set BATS_HELPERS_CLEANUP_DIR to a writable directory." >&2
     return 1
   fi
 
@@ -56,7 +56,7 @@ cleanup_register() {
   dir="$(dirname "${registry}")"
 
   if ! mkdir -p "${dir}"; then
-    flunk "Unable to create the cleanup registry directory '${dir}'."
+    flunk "Cleanup registry directory '${dir}' cannot be created."
     return 1
   fi
 
@@ -93,7 +93,7 @@ cleanup_run() {
   done <"${registry}"
 
   if ! rm -f "${registry}"; then
-    flunk "Unable to drain the cleanup registry '${registry}'."
+    flunk "Cleanup registry '${registry}' cannot be removed."
     return 1
   fi
 

--- a/src/cleanup.bash
+++ b/src/cleanup.bash
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+##
+# @file
+# Deferred cleanup for the current test.
+#
+
+##
+# Resolves the file that the current test's cleanup registry is stored in.
+#
+# Globals:
+#   BATS_HELPERS_CLEANUP_DIR: Directory holding the registry. Defaults to the
+#     per-test temporary directory, so that BATS removes the registry with the
+#     rest of the test sandbox.
+#
+# Outputs:
+#   STDOUT: The registry path.
+##
+cleanup_registry_path() {
+  local dir="${BATS_HELPERS_CLEANUP_DIR:-${BATS_TEST_TMPDIR-}}"
+
+  if [ -z "${dir}" ]; then
+    format_error "Unable to resolve the cleanup registry: BATS_TEST_TMPDIR is not set. Set BATS_HELPERS_CLEANUP_DIR to a writable directory" | flunk
+    return 1
+  fi
+
+  echo "${dir%/}/bats-helpers-cleanup"
+}
+
+##
+# Registers a command to run once the current test has finished.
+#
+# The registry lives in a file rather than in a variable, so a registration
+# made inside a subshell - under 'run', a command substitution or a pipeline -
+# still reaches the runner.
+#
+# Arguments:
+#   1. command: Command to run.
+#   2+. args: Arguments to pass to the command. Optional.
+##
+cleanup_register() {
+  if [ "$#" -eq 0 ]; then
+    flunk "Cleanup command is required."
+    return 1
+  fi
+
+  local registry
+  registry="$(cleanup_registry_path)" || return 1
+
+  mkdir -p "$(dirname "${registry}")" || return 1
+
+  # Quoting the arguments here snapshots them, so reassigning a variable after
+  # the call cannot redirect the command that was registered. '%q' escapes a
+  # newline as well, keeping one registration on one line.
+  local line
+  line="$(printf '%q ' "$@")"
+
+  printf '%s\n' "${line% }" >>"${registry}"
+}
+
+##
+# Runs the commands registered for the current test, in reverse order.
+#
+# Call this function from your test's teardown() method.
+#
+# The registry is drained before the commands run, so a second call runs
+# nothing and a command that registers another one does not re-enter this
+# function.
+#
+# Returns:
+#   0 when every registered command succeeded or none was registered, 1 when
+#   any of them failed.
+##
+cleanup_run() {
+  local registry
+  registry="$(cleanup_registry_path)" || return 1
+
+  if [ ! -f "${registry}" ]; then
+    return 0
+  fi
+
+  local commands=()
+  local line
+  while IFS= read -r line; do
+    commands+=("${line}")
+  done <"${registry}"
+
+  rm -f "${registry}" || return 1
+
+  local status=0
+  local command_status
+  local i
+  for ((i = ${#commands[@]} - 1; i >= 0; i--)); do
+    command_status=0
+    eval "${commands[${i}]}" || command_status="$?"
+
+    if [ "${command_status}" -ne 0 ]; then
+      # 'flunk' returns non-zero, so the assignment both records the failure and
+      # keeps the remaining commands running under errexit.
+      flunk "Cleanup command '${commands[${i}]}' failed with exit status ${command_status}." || status=1
+    fi
+  done
+
+  return "${status}"
+}

--- a/src/cleanup.bash
+++ b/src/cleanup.bash
@@ -14,12 +14,18 @@
 #
 # Outputs:
 #   STDOUT: The registry path.
+#   STDERR: The error message when the directory cannot be resolved.
+#
+# Returns:
+#   1 when neither of the globals is set.
 ##
 cleanup_registry_path() {
   local dir="${BATS_HELPERS_CLEANUP_DIR:-${BATS_TEST_TMPDIR-}}"
 
   if [ -z "${dir}" ]; then
-    format_error "Unable to resolve the cleanup registry: BATS_TEST_TMPDIR is not set. Set BATS_HELPERS_CLEANUP_DIR to a writable directory" | flunk
+    # Written directly rather than through 'flunk', whose path rewriting needs
+    # the non-empty BATS_TEST_TMPDIR that is missing here.
+    echo "Unable to resolve the cleanup registry: BATS_TEST_TMPDIR is not set. Set BATS_HELPERS_CLEANUP_DIR to a writable directory" >&2
     return 1
   fi
 
@@ -38,7 +44,7 @@ cleanup_registry_path() {
 #   2+. args: Arguments to pass to the command. Optional.
 ##
 cleanup_register() {
-  if [ "$#" -eq 0 ]; then
+  if [ "$#" -eq 0 ] || [ -z "${1}" ]; then
     flunk "Cleanup command is required."
     return 1
   fi
@@ -46,7 +52,13 @@ cleanup_register() {
   local registry
   registry="$(cleanup_registry_path)" || return 1
 
-  mkdir -p "$(dirname "${registry}")" || return 1
+  local dir
+  dir="$(dirname "${registry}")"
+
+  if ! mkdir -p "${dir}"; then
+    flunk "Unable to create the cleanup registry directory '${dir}'."
+    return 1
+  fi
 
   # Quoting the arguments here snapshots them, so reassigning a variable after
   # the call cannot redirect the command that was registered. '%q' escapes a
@@ -65,10 +77,6 @@ cleanup_register() {
 # The registry is drained before the commands run, so a second call runs
 # nothing and a command that registers another one does not re-enter this
 # function.
-#
-# Returns:
-#   0 when every registered command succeeded or none was registered, 1 when
-#   any of them failed.
 ##
 cleanup_run() {
   local registry
@@ -84,13 +92,19 @@ cleanup_run() {
     commands+=("${line}")
   done <"${registry}"
 
-  rm -f "${registry}" || return 1
+  if ! rm -f "${registry}"; then
+    flunk "Unable to drain the cleanup registry '${registry}'."
+    return 1
+  fi
 
   local status=0
   local command_status
   local i
   for ((i = ${#commands[@]} - 1; i >= 0; i--)); do
     command_status=0
+    # 'eval' undoes the quoting 'cleanup_register' applied, turning the line
+    # back into the argument vector it was registered with. Running the line
+    # unevaluated would look for one command named after the whole of it.
     eval "${commands[${i}]}" || command_status="$?"
 
     if [ "${command_status}" -ne 0 ]; then

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -18,3 +18,7 @@ setup() {
   fi
   # LCOV_EXCL_STOP
 }
+
+teardown() {
+  cleanup_run
+}

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -52,6 +52,11 @@ third"
   assert_failure
   assert_output_contains "Cleanup command is required."
 
+  # An empty command would register a line that evaluates to nothing at all.
+  run cleanup_register ""
+  assert_failure
+  assert_output_contains "Cleanup command is required."
+
   assert_file_not_exists "$(cleanup_registry_path)"
 }
 
@@ -148,6 +153,36 @@ two"
   assert_file_exists "${BATS_TEST_TMPDIR}/marker"
 }
 
+@test "cleanup_register when the registry directory cannot be created" {
+  touch "${BATS_TEST_TMPDIR}/regular_file"
+  export BATS_HELPERS_CLEANUP_DIR="${BATS_TEST_TMPDIR}/regular_file/custom"
+
+  run cleanup_register touch "${BATS_TEST_TMPDIR}/marker"
+  assert_failure
+  assert_output_contains "Unable to create the cleanup registry directory"
+
+  assert_file_not_exists "${BATS_TEST_TMPDIR}/marker"
+}
+
+@test "cleanup_run when the registry cannot be drained" {
+  # A read-only directory does not stop root from removing the registry.
+  if [ "$(id -u)" -eq 0 ]; then
+    skip "Test requires a non-root user."
+  fi
+
+  export BATS_HELPERS_CLEANUP_DIR="${BATS_TEST_TMPDIR}/readonly"
+
+  cleanup_register touch "${BATS_TEST_TMPDIR}/marker"
+
+  chmod 500 "${BATS_HELPERS_CLEANUP_DIR}"
+  run cleanup_run
+  chmod 700 "${BATS_HELPERS_CLEANUP_DIR}"
+
+  assert_failure
+  assert_output_contains "Unable to drain the cleanup registry"
+  assert_file_not_exists "${BATS_TEST_TMPDIR}/marker"
+}
+
 @test "cleanup_registry_path without a sandbox" {
   local original="${BATS_TEST_TMPDIR}"
 
@@ -156,6 +191,7 @@ two"
   BATS_TEST_TMPDIR="${original}"
 
   assert_failure
+  assert_output_contains "Set BATS_HELPERS_CLEANUP_DIR to a writable directory"
 }
 
 @test "cleanup_register without a sandbox" {

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -2,8 +2,28 @@
 #
 # Tests for deferred cleanup.
 #
+# shellcheck disable=SC2030,SC2031
 
 load _test_helper
+
+##
+# Runs one test of the teardown fixture in a nested BATS process.
+#
+# Filtering down to a single test keeps the captured output specific to the
+# scenario the caller names.
+#
+# Arguments:
+#   1. name: Name of the fixture test to run.
+#
+# Globals:
+#   CLEANUP_FIXTURE_DIR: Set to the directory the fixture writes its markers to.
+##
+cleanup_fixture_run() {
+  export CLEANUP_FIXTURE_DIR="${BATS_TEST_TMPDIR}/fixture"
+  mkdir -p "${CLEANUP_FIXTURE_DIR}"
+
+  run "${BATS_ROOT}/bin/bats" --tap --filter "^${1}\$" "${BATS_TEST_DIRNAME}/fixtures/cleanup_teardown.bats"
+}
 
 @test "cleanup_register and cleanup_run" {
   cleanup_register touch "${BATS_TEST_TMPDIR}/marker"
@@ -159,7 +179,7 @@ two"
 
   run cleanup_register touch "${BATS_TEST_TMPDIR}/marker"
   assert_failure
-  assert_output_contains "Unable to create the cleanup registry directory"
+  assert_output_contains "cannot be created"
 
   assert_file_not_exists "${BATS_TEST_TMPDIR}/marker"
 }
@@ -179,7 +199,7 @@ two"
   chmod 700 "${BATS_HELPERS_CLEANUP_DIR}"
 
   assert_failure
-  assert_output_contains "Unable to drain the cleanup registry"
+  assert_output_contains "cannot be removed"
   assert_file_not_exists "${BATS_TEST_TMPDIR}/marker"
 }
 
@@ -266,23 +286,4 @@ two"
   # The reported failure is the test's own, not the one raised in teardown.
   assert_output_not_contains "from function \`teardown'"
   assert_output_contains "Cleanup command 'false' failed with exit status 1."
-}
-
-##
-# Runs one test of the teardown fixture in a nested BATS process.
-#
-# Filtering down to a single test keeps the captured output specific to the
-# scenario the caller names.
-#
-# Arguments:
-#   1. name: Name of the fixture test to run.
-#
-# Globals:
-#   CLEANUP_FIXTURE_DIR: Set to the directory the fixture writes its markers to.
-##
-cleanup_fixture_run() {
-  export CLEANUP_FIXTURE_DIR="${BATS_TEST_TMPDIR}/fixture"
-  mkdir -p "${CLEANUP_FIXTURE_DIR}"
-
-  run "${BATS_ROOT}/bin/bats" --tap --filter "^${1}\$" "${BATS_TEST_DIRNAME}/fixtures/cleanup_teardown.bats"
 }

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -1,0 +1,252 @@
+#!/usr/bin/env bats
+#
+# Tests for deferred cleanup.
+#
+
+load _test_helper
+
+@test "cleanup_register and cleanup_run" {
+  cleanup_register touch "${BATS_TEST_TMPDIR}/marker"
+
+  assert_file_not_exists "${BATS_TEST_TMPDIR}/marker"
+
+  cleanup_run
+
+  assert_file_exists "${BATS_TEST_TMPDIR}/marker"
+}
+
+@test "cleanup_run in reverse order of registration" {
+  cleanup_register echo "third"
+  cleanup_register echo "second"
+  cleanup_register echo "first"
+
+  run cleanup_run
+  assert_success
+  assert_output "first
+second
+third"
+}
+
+@test "cleanup_run without registrations" {
+  assert_file_not_exists "$(cleanup_registry_path)"
+
+  run cleanup_run
+  assert_success
+  assert_output ""
+}
+
+@test "cleanup_run twice" {
+  cleanup_register touch "${BATS_TEST_TMPDIR}/marker"
+
+  cleanup_run
+  assert_file_exists "${BATS_TEST_TMPDIR}/marker"
+
+  rm -f "${BATS_TEST_TMPDIR}/marker"
+
+  cleanup_run
+  assert_file_not_exists "${BATS_TEST_TMPDIR}/marker"
+}
+
+@test "cleanup_register without a command" {
+  run cleanup_register
+  assert_failure
+  assert_output_contains "Cleanup command is required."
+
+  assert_file_not_exists "$(cleanup_registry_path)"
+}
+
+@test "cleanup_register from a subshell" {
+  run cleanup_register touch "${BATS_TEST_TMPDIR}/marker"
+  assert_success
+
+  cleanup_run
+
+  assert_file_exists "${BATS_TEST_TMPDIR}/marker"
+}
+
+@test "cleanup_register preserves arguments verbatim" {
+  local dir="${BATS_TEST_TMPDIR}/dir with spaces"
+  mkdir -p "${dir}"
+
+  cleanup_register touch "${dir}/file with spaces.txt"
+  cleanup_register touch "${dir}/*"
+  cleanup_register touch "${dir}/quote'd.txt"
+
+  cleanup_run
+
+  run ls "${dir}"
+  assert_success
+  assert_output_contains "file with spaces.txt"
+  assert_output_contains "*"
+  assert_output_contains "quote'd.txt"
+}
+
+# A newline that was not escaped would split the registration across two lines
+# of the registry, so the two words would come back reversed or not at all.
+@test "cleanup_register preserves a newline in an argument" {
+  cleanup_register echo "one
+two"
+
+  run cleanup_run
+  assert_success
+  assert_output "one
+two"
+}
+
+@test "cleanup_run with a failing command" {
+  cleanup_register false
+
+  run cleanup_run
+  assert_failure
+  assert_output_contains "Cleanup command 'false' failed with exit status 1."
+}
+
+@test "cleanup_run continues past a failing command" {
+  cleanup_register touch "${BATS_TEST_TMPDIR}/first.marker"
+  cleanup_register bash -c "exit 3"
+  cleanup_register touch "${BATS_TEST_TMPDIR}/last.marker"
+
+  run cleanup_run
+  assert_failure
+  assert_output_contains "failed with exit status 3"
+
+  assert_file_exists "${BATS_TEST_TMPDIR}/first.marker"
+  assert_file_exists "${BATS_TEST_TMPDIR}/last.marker"
+}
+
+@test "cleanup_registry_path" {
+  run cleanup_registry_path
+  assert_success
+  assert_output "${BATS_TEST_TMPDIR}/bats-helpers-cleanup"
+}
+
+@test "cleanup_registry_path with a custom directory" {
+  export BATS_HELPERS_CLEANUP_DIR="${BATS_TEST_TMPDIR}/custom"
+
+  run cleanup_registry_path
+  assert_success
+  assert_output "${BATS_TEST_TMPDIR}/custom/bats-helpers-cleanup"
+
+  # A trailing slash does not produce a double separator.
+  export BATS_HELPERS_CLEANUP_DIR="${BATS_TEST_TMPDIR}/custom/"
+
+  run cleanup_registry_path
+  assert_success
+  assert_output "${BATS_TEST_TMPDIR}/custom/bats-helpers-cleanup"
+}
+
+@test "cleanup_register and cleanup_run in a custom directory" {
+  export BATS_HELPERS_CLEANUP_DIR="${BATS_TEST_TMPDIR}/custom"
+
+  cleanup_register touch "${BATS_TEST_TMPDIR}/marker"
+
+  assert_file_exists "${BATS_TEST_TMPDIR}/custom/bats-helpers-cleanup"
+  assert_file_not_exists "${BATS_TEST_TMPDIR}/bats-helpers-cleanup"
+
+  cleanup_run
+
+  assert_file_exists "${BATS_TEST_TMPDIR}/marker"
+}
+
+@test "cleanup_registry_path without a sandbox" {
+  local original="${BATS_TEST_TMPDIR}"
+
+  BATS_TEST_TMPDIR=""
+  run cleanup_registry_path
+  BATS_TEST_TMPDIR="${original}"
+
+  assert_failure
+}
+
+@test "cleanup_register without a sandbox" {
+  local original="${BATS_TEST_TMPDIR}"
+
+  BATS_TEST_TMPDIR=""
+  run cleanup_register touch "${original}/marker"
+  BATS_TEST_TMPDIR="${original}"
+
+  assert_failure
+  assert_file_not_exists "${original}/marker"
+}
+
+@test "cleanup_run without a sandbox" {
+  local original="${BATS_TEST_TMPDIR}"
+
+  BATS_TEST_TMPDIR=""
+  run cleanup_run
+  BATS_TEST_TMPDIR="${original}"
+
+  assert_failure
+}
+
+# The two tests below share one registry location, because with the per-test
+# default nothing could leak between them in the first place.
+@test "cleanup registrations do not leak into the next test" {
+  export BATS_HELPERS_CLEANUP_DIR="${BATS_FILE_TMPDIR}"
+
+  cleanup_register touch "${BATS_FILE_TMPDIR}/leak.marker"
+
+  assert_file_exists "$(cleanup_registry_path)"
+  assert_file_not_exists "${BATS_FILE_TMPDIR}/leak.marker"
+}
+
+@test "cleanup registrations do not leak into the next test - next test" {
+  export BATS_HELPERS_CLEANUP_DIR="${BATS_FILE_TMPDIR}"
+
+  assert_file_exists "${BATS_FILE_TMPDIR}/leak.marker"
+  assert_file_not_exists "$(cleanup_registry_path)"
+}
+
+@test "cleanup_run from teardown after a passing test" {
+  cleanup_fixture_run "passing test with a cleanup"
+
+  assert_success
+  assert_output_contains "ok 1 passing test with a cleanup"
+  assert_file_exists "${CLEANUP_FIXTURE_DIR}/passing.marker"
+}
+
+@test "cleanup_run from teardown after a failing test" {
+  cleanup_fixture_run "failing test with a cleanup"
+
+  assert_failure
+  assert_output_contains "not ok 1 failing test with a cleanup"
+  assert_file_exists "${CLEANUP_FIXTURE_DIR}/failing.marker"
+}
+
+@test "cleanup_run from teardown fails an otherwise-passing test" {
+  cleanup_fixture_run "passing test with a failing cleanup"
+
+  assert_failure
+  assert_output_contains "not ok 1 passing test with a failing cleanup"
+  assert_output_contains "from function \`teardown'"
+  assert_output_contains "Cleanup command 'false' failed with exit status 1."
+}
+
+@test "cleanup_run from teardown does not mask a preceding failure" {
+  cleanup_fixture_run "failing test with a failing cleanup"
+
+  assert_failure
+  assert_output_contains "not ok 1 failing test with a failing cleanup"
+  # The reported failure is the test's own, not the one raised in teardown.
+  assert_output_not_contains "from function \`teardown'"
+  assert_output_contains "Cleanup command 'false' failed with exit status 1."
+}
+
+##
+# Runs one test of the teardown fixture in a nested BATS process.
+#
+# Filtering down to a single test keeps the captured output specific to the
+# scenario the caller names.
+#
+# Arguments:
+#   1. name: Name of the fixture test to run.
+#
+# Globals:
+#   CLEANUP_FIXTURE_DIR: Set to the directory the fixture writes its markers to.
+##
+cleanup_fixture_run() {
+  export CLEANUP_FIXTURE_DIR="${BATS_TEST_TMPDIR}/fixture"
+  mkdir -p "${CLEANUP_FIXTURE_DIR}"
+
+  run "${BATS_ROOT}/bin/bats" --tap --filter "^${1}\$" "${BATS_TEST_DIRNAME}/fixtures/cleanup_teardown.bats"
+}

--- a/tests/fixtures/cleanup_teardown.bats
+++ b/tests/fixtures/cleanup_teardown.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+#
+# Fixture for the deferred cleanup teardown tests.
+#
+# Run by the tests in 'tests/cleanup.bats', not by the suite.
+#
+
+load ../../load.bash
+
+teardown() {
+  cleanup_run
+}
+
+@test "passing test with a cleanup" {
+  cleanup_register touch "${CLEANUP_FIXTURE_DIR}/passing.marker"
+}
+
+@test "failing test with a cleanup" {
+  cleanup_register touch "${CLEANUP_FIXTURE_DIR}/failing.marker"
+
+  false
+}
+
+@test "passing test with a failing cleanup" {
+  cleanup_register false
+}
+
+@test "failing test with a failing cleanup" {
+  cleanup_register false
+
+  false
+}


### PR DESCRIPTION
Closes #190

## Summary

Adds a `src/cleanup.bash` module that lets a test register a cleanup command next to the code that creates the thing it removes, instead of writing that cleanup into a shared `teardown` or repeating it on every early-exit path.

`cleanup_register` appends a quoted command line to a per-test registry file, and `cleanup_run` - called from the consumer's own `teardown()` - drains that registry and runs the commands in reverse order, so a resource created inside another one is removed while the outer one still exists.

The registry lives on disk under `BATS_TEST_TMPDIR` rather than in a shell variable, so a registration made inside a subshell (`run`, a command substitution, a pipeline) still reaches the runner, and BATS removes the registry together with the rest of the test sandbox.

## Changes

### Library

- `src/cleanup.bash` (new): `cleanup_registry_path` resolves the registry file location and validates that either `BATS_HELPERS_CLEANUP_DIR` or `BATS_TEST_TMPDIR` is available; `cleanup_register` rejects a missing or empty command, then quotes the arguments with `printf '%q'` at registration time so a later variable reassignment cannot redirect the command, and appends one line to the registry; `cleanup_run` reads and drains the registry before running anything, then evaluates each line in reverse order via `eval`, reporting any failing command through `flunk` without stopping the commands registered before it and without masking a test failure that preceded it.
- `load.bash`: sources `src/cleanup.bash` alongside the other helper modules.

### Tests

- `tests/cleanup.bats` (new): 24 tests covering registration and reverse-order execution, argument quoting (spaces, glob characters, embedded quotes, embedded newlines), the missing/empty command guard, a custom `BATS_HELPERS_CLEANUP_DIR` location, registry-directory-creation and registry-drain failures, behaviour with no test sandbox, and per-test isolation of the registry. Four of these drive `tests/fixtures/cleanup_teardown.bats` in a nested BATS process to observe the pass/fail/failing-cleanup interactions end to end.
- `tests/fixtures/cleanup_teardown.bats` (new): a standalone fixture with its own `teardown()` calling `cleanup_run`, exercising four scenarios - passing test with a cleanup, failing test with a cleanup, passing test with a failing cleanup, and failing test with a failing cleanup - that the nested-process tests filter down to individually.
- `tests/_test_helper.bash`: adds a `teardown()` that calls `cleanup_run`, so the library's own suite dogfoods the documented composition point rather than only asserting it in isolation.

### Documentation

- `README.md`: adds a `## Cleanup` section (usage example, function reference table, composing with `teardown`, ordering and status semantics, argument quoting, and the cleanup sandbox), a Features bullet, a Table of Contents entry, and a `BATS_HELPERS_CLEANUP_DIR` row in the environment variable reference table.
- `CLAUDE.md`: adds `cleanup.bash` to the architecture's module list.

## Before / After

```
BEFORE
──────

  @test "build writes an artifact" {
    build_dir="${BATS_TEST_TMPDIR}/build"
    mkdir -p "${build_dir}"

    run ./build.sh "${build_dir}"
    assert_success

    rm -rf "${build_dir}"     # skipped if assert_success fails above
  }

  teardown() {
    # nothing removes "${build_dir}" on the failure path
  }


AFTER
─────

  load.bash ──sources──> src/cleanup.bash

  @test "build writes an artifact" {
    build_dir="${BATS_TEST_TMPDIR}/build"
    mkdir -p "${build_dir}"
    cleanup_register rm -rf "${build_dir}"   # registered next to creation

    run ./build.sh "${build_dir}"
    assert_success                            # cleanup still runs on failure
  }

  teardown() {
    cleanup_run
  }

  ${BATS_TEST_TMPDIR}/bats-helpers-cleanup
  ┌────────────────────────────────┐
  │ rm -rf .../build                │  <- registered 1st, run last
  └────────────────────────────────┘
       │
       ▼ cleanup_run() drains the file, runs in reverse order
```
