### PR TITLE
[#188] Added an inline fixture file tree archive, its serialiser and its assertion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1174,7 +1174,7 @@ FOO=bar
 FIXTURE
 ```
 
-A line is a marker when it starts with `-- ` and ends with ` --`, and the name between them is trimmed, so markers can be padded to line up. Every other line is content, which is what makes the format safe to hand-edit: there is nothing to get syntactically wrong. An entry holds every line from its marker to the next marker or to the end of the archive, and parent directories are created implicitly.
+A line is a marker when it opens with `--` followed by a space and closes with a space followed by `--`; the name between them is trimmed, so markers can be padded to line up. Every other line is content, which is what makes the format safe to hand-edit: there is nothing to get syntactically wrong. An entry holds every line from its marker to the next marker or to the end of the archive, and parent directories are created implicitly.
 
 Anything before the first marker is a comment and is discarded, so a fixture can carry a note about what it stands for:
 
@@ -1199,7 +1199,7 @@ FIXTURE
 
 A content line that would otherwise be read as a marker carries one leading backslash. Reading removes one backslash from a line that is marker-shaped without it, so `\-- README.md --` is the content `-- README.md --`, and `\\-- README.md --` is the content `\-- README.md --`. A backslash anywhere else is left alone.
 
-An archive path is a plain relative path naming a file. An absolute path, a `..` or `.` component, a trailing slash, a marker naming nothing, and a path declared twice are each rejected with a message naming the path.
+An archive path is a plain relative path naming a file. An absolute path, a `..`, `.` or empty component, a trailing slash, a marker naming nothing, and a path declared twice are each rejected with a message naming the path. `fixture_create_dir` also refuses to write through a symlink already sitting on the path, so a link an earlier fixture or the code under test left behind cannot carry the write outside the directory.
 
 `fixture_dump_dir` prints an existing directory in the same format, ordered by path. It is both a debugging aid - dump what the code under test actually produced and paste it back into the test - and the way to regenerate an expectation:
 
@@ -1235,7 +1235,7 @@ unexpected: src/extra.sh
 +#!/bin/sh
 ```
 
-The format covers text files and nothing else. Binary content, file modes and symlinks are deliberately out of scope - `assert_file_mode`, `file_mktouch` and `ln -s` remain the way to handle those - and `fixture_dump_dir` serialises regular files only, failing on a file that is not text. Because the format is line-based, every file it names ends with a newline: `fixture_dump_dir` adds one to a file that lacks it, and `fixture_assert_dir` compares bytes, so a file with no trailing newline differs from the archive that names it.
+The format covers text files and nothing else. Binary content, file modes and symlinks are deliberately out of scope - `assert_file_mode`, `file_mktouch` and `ln -s` remain the way to handle those - and `fixture_dump_dir` serialises regular files only, failing on a file that is not text. `fixture_assert_dir` compares regular files only for the same reason: a symlink standing where the archive names a file is reported as a difference, and one the archive says nothing about is left alone. Because the format is line-based, every file it names ends with a newline: `fixture_dump_dir` adds one to a file that lacks it, and `fixture_assert_dir` compares bytes, so a file with no trailing newline differs from the archive that names it.
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -1158,7 +1158,7 @@ assert_file_exists "$(file_backup_path "${BATS_TEST_TMPDIR}/.env")"
 
 #### Fixture trees
 
-`fixture_create_dir` builds a whole file tree from a plain-text archive read from STDIN, so the shape of the fixture is visible in the test rather than reconstructed from a run of `mkdir` and `echo` calls. Fed from a quoted here-document, the content passes through byte for byte, with no escaping:
+`fixture_create_dir` builds a whole file tree from a plain-text archive read from STDIN, so the shape of the fixture is visible in the test rather than reconstructed from a run of `mkdir` and `echo` calls. Fed from a quoted here-document, the content passes through byte for byte: nothing is expanded, and nothing needs escaping apart from a line that would itself read as a marker:
 
 ```bash
 fixture_create_dir "${dir}" <<'FIXTURE'
@@ -1174,7 +1174,7 @@ FOO=bar
 FIXTURE
 ```
 
-A line is a marker when it opens with `--` followed by a space and closes with a space followed by `--`; the name between them is trimmed, so markers can be padded to line up. Every other line is content, which is what makes the format safe to hand-edit: there is nothing to get syntactically wrong. An entry holds every line from its marker to the next marker or to the end of the archive, and parent directories are created implicitly.
+A line is a marker when it opens with `--` followed by a space and closes with a space followed by `--`; the name between them is trimmed, so markers can be padded to line up. After the first marker, every line that is not itself a marker is content, which is what makes the format safe to hand-edit: there is nothing to get syntactically wrong. An entry holds every line from its marker to the next marker or to the end of the archive, and parent directories are created implicitly.
 
 Anything before the first marker is a comment and is discarded, so a fixture can carry a note about what it stands for:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
   - [Mocking](#mocking) - Command mocking, Call log, Argument specifications, Strictness
   - [Step runner](#step-runner) - Sequential test assertions
   - [Cleanup](#cleanup) - Deferred per-test cleanup
-  - [Helpers](#helpers) - Utility functions
+  - [Helpers](#helpers) - Utility functions, inline fixture trees
   - [Environment variables](#environment-variables) - Full variable reference
   - [Deprecations](#deprecations) - Renamed functions and variables
 - [Contributing](#-contributing)
@@ -48,6 +48,7 @@
 - Deferred cleanup registered next to the code that created the thing it removes.
 - Data provider for running one function over many test cases, with named cases, per-case arity, a chosen assertion and matrix expansion.
 - Fixture and file utilities for building and restoring test sandboxes.
+- A plain-text archive for declaring a whole fixture file tree inline in the test, serialising a directory back to it, and asserting a directory against it with per-file diffs.
 - TUI helper for driving interactive scripts with scripted answers.
 
 ## 📦 Installation
@@ -1106,6 +1107,9 @@ assert_file_not_exists "$(cleanup_registry_path)"
 | `file_restore`            | Restores a file from the backup taken by `file_add_var`                       |
 | `fixture_prepare_dir`     | Creates an empty directory for a fixture, removing any existing content       |
 | `fixture_export_codebase` | Exports the codebase at the latest commit to a destination directory          |
+| `fixture_create_dir`      | Creates a file tree from an archive read from STDIN                           |
+| `fixture_dump_dir`        | Prints a directory as an archive                                              |
+| `fixture_assert_dir`      | Asserts that a directory holds the file tree of an archive read from STDIN    |
 | `string_random`           | Generates a random alphanumeric string, 8 characters long by default          |
 | `string_match`            | Reports whether a needle matches a haystack, without asserting on it          |
 | `string_format_to_regex`  | Translates a format string into an extended regular expression                |
@@ -1151,6 +1155,87 @@ Use `file_backup_path` to resolve where a given file's backup is stored:
 ```bash
 assert_file_exists "$(file_backup_path "${BATS_TEST_TMPDIR}/.env")"
 ```
+
+#### Fixture trees
+
+`fixture_create_dir` builds a whole file tree from a plain-text archive read from STDIN, so the shape of the fixture is visible in the test rather than reconstructed from a run of `mkdir` and `echo` calls. Fed from a quoted here-document, the content passes through byte for byte, with no escaping:
+
+```bash
+fixture_create_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+
+-- src/app.sh --
+#!/usr/bin/env bash
+echo "value is ${UNEXPANDED}"
+
+-- config/.env --
+FOO=bar
+FIXTURE
+```
+
+A line is a marker when it starts with `-- ` and ends with ` --`, and the name between them is trimmed, so markers can be padded to line up. Every other line is content, which is what makes the format safe to hand-edit: there is nothing to get syntactically wrong. An entry holds every line from its marker to the next marker or to the end of the archive, and parent directories are created implicitly.
+
+Anything before the first marker is a comment and is discarded, so a fixture can carry a note about what it stands for:
+
+```bash
+fixture_create_dir "${dir}" <<'FIXTURE'
+The tree the installer expects to find before it runs.
+
+-- config/.env --
+FOO=bar
+FIXTURE
+```
+
+The directory is created when it does not exist, and only the files the archive names are written. Pair the call with `fixture_prepare_dir` to start from an empty directory:
+
+```bash
+fixture_prepare_dir "${dir}"
+fixture_create_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+FIXTURE
+```
+
+A content line that would otherwise be read as a marker carries one leading backslash. Reading removes one backslash from a line that is marker-shaped without it, so `\-- README.md --` is the content `-- README.md --`, and `\\-- README.md --` is the content `\-- README.md --`. A backslash anywhere else is left alone.
+
+An archive path is a plain relative path naming a file. An absolute path, a `..` or `.` component, a trailing slash, a marker naming nothing, and a path declared twice are each rejected with a message naming the path.
+
+`fixture_dump_dir` prints an existing directory in the same format, ordered by path. It is both a debugging aid - dump what the code under test actually produced and paste it back into the test - and the way to regenerate an expectation:
+
+```bash
+run fixture_dump_dir "${dir}"
+assert_success
+```
+
+`fixture_assert_dir` compares a directory against an inline expected tree:
+
+```bash
+fixture_assert_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+-- src/app.sh --
+#!/usr/bin/env bash
+FIXTURE
+```
+
+A mismatch lists every file that is missing, unexpected or different, and appends a unified diff for each differing file:
+
+```text
+Directory '${BATS_TEST_TMPDIR}/build' does not match the expected fixture
+
+differs: src/app.sh
+missing: src/missing.sh
+unexpected: src/extra.sh
+
+--- expected src/app.sh
++++ actual src/app.sh
+@@ -1 +1 @@
+-#!/usr/bin/env bash
++#!/bin/sh
+```
+
+The format covers text files and nothing else. Binary content, file modes and symlinks are deliberately out of scope - `assert_file_mode`, `file_mktouch` and `ln -s` remain the way to handle those - and `fixture_dump_dir` serialises regular files only, failing on a file that is not text. Because the format is line-based, every file it names ends with a newline: `fixture_dump_dir` adds one to a file that lacks it, and `fixture_assert_dir` compares bytes, so a file with no trailing newline differs from the archive that names it.
 
 ### Environment variables
 

--- a/src/fixture.bash
+++ b/src/fixture.bash
@@ -102,17 +102,17 @@ fixture_create_dir() {
     path="${paths[index]}"
     target="${dir}/${path}"
 
+    fixture_validate_target "${dir}" "${path}" || return 1
+
     if [ -d "${target}" ]; then
       flunk "Fixture path '${path}' exists as a directory."
       return 1
     fi
 
-    if ! file_mktouch "${target}"; then
+    if ! file_mktouch "${target}" || ! printf '%s' "${contents[index]}" >"${target}"; then
       flunk "Unable to create fixture file '${path}'."
       return 1
     fi
-
-    printf '%s' "${contents[index]}" >"${target}"
   done
 
   return 0
@@ -186,12 +186,14 @@ fixture_assert_dir() {
   local -a contents=()
   fixture_read_archive || return 1
 
+  local listing
+  listing="$(fixture_list_files "${dir}")" || return 1
+
   ##
   ## Expected files.
   ##
 
-  # The paths are held as one newline-delimited value so that a path is matched
-  # as a whole word without becoming an array subscript.
+  local actual=$'\n'"${listing}"$'\n'
   local expected=$'\n'
   local summary=""
   local report=""
@@ -206,8 +208,16 @@ fixture_assert_dir() {
     expected="${expected}${path}"$'\n'
     target="${dir}/${path}"
 
-    if [ ! -f "${target}" ]; then
-      summary="${summary}missing: ${path}"$'\n'
+    # The listing decides what the directory holds, so a symlink standing where
+    # the archive names a regular file is a difference rather than something to
+    # read through.
+    if ! fixture_list_holds "${actual}" "${path}"; then
+      if [ -L "${target}" ]; then
+        summary="${summary}not a regular file: ${path}"$'\n'
+      else
+        summary="${summary}missing: ${path}"$'\n'
+      fi
+
       differences=$((differences + 1))
       continue
     fi
@@ -223,18 +233,13 @@ fixture_assert_dir() {
   ## Unexpected files.
   ##
 
-  local listing
-  listing="$(fixture_list_files "${dir}")" || return 1
-
   local file
   while IFS= read -r file; do
     [ -n "${file}" ] || continue
 
-    case "${expected}" in
-      *$'\n'"${file}"$'\n'*)
-        continue
-        ;;
-    esac
+    if fixture_list_holds "${expected}" "${file}"; then
+      continue
+    fi
 
     summary="${summary}unexpected: ${file}"$'\n'
     differences=$((differences + 1))
@@ -270,8 +275,6 @@ fixture_read_archive() {
   # A content line carrying the escape loses one backslash, so a line that is
   # marker-shaped after the removal is the one to unescape.
   local escaped_marker='^\\+-- .* --$'
-  # The declared paths are held as one newline-delimited value so that a path is
-  # matched as a whole word without becoming an array subscript.
   local declared=$'\n'
   local index=-1
   local line
@@ -292,12 +295,10 @@ fixture_read_archive() {
 
       fixture_validate_path "${path}" || return 1
 
-      case "${declared}" in
-        *$'\n'"${path}"$'\n'*)
-          flunk "Fixture path '${path}' is declared more than once."
-          return 1
-          ;;
-      esac
+      if fixture_list_holds "${declared}" "${path}"; then
+        flunk "Fixture path '${path}' is declared more than once."
+        return 1
+      fi
 
       declared="${declared}${path}"$'\n'
       index=$((index + 1))
@@ -379,7 +380,73 @@ fixture_validate_path() {
       flunk "Fixture path '${path}' contains a '.' component, but must be a plain relative path."
       return 1
       ;;
+    *//*)
+      flunk "Fixture path '${path}' contains an empty component, but must be a plain relative path."
+      return 1
+      ;;
   esac
 
   return 0
+}
+
+##
+# Validates that no component of a path below a directory is a symlink.
+#
+# A path is validated against what is already on disk, rather than against the
+# archive, because a symlink left by an earlier fixture or by the code under
+# test would send the write outside the directory.
+#
+# Arguments:
+#   1. dir: Directory the path is relative to.
+#   2. path: Path to walk.
+##
+fixture_validate_target() {
+  local dir="${1}"
+  local path="${2}"
+
+  local remainder="${path}"
+  local walked="${dir}"
+  local component
+
+  while [ -n "${remainder}" ]; do
+    component="${remainder%%/*}"
+
+    if [ "${component}" = "${remainder}" ]; then
+      remainder=""
+    else
+      remainder="${remainder#*/}"
+    fi
+
+    walked="${walked}/${component}"
+
+    if [ -L "${walked}" ]; then
+      flunk "Fixture path '${path}' leads through the symlink '${walked}'."
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+##
+# Reports whether a newline-delimited list holds a path.
+#
+# The list is matched as text rather than held as an array, so that a path of
+# '@' or '*' stays an ordinary value instead of becoming a subscript.
+#
+# Arguments:
+#   1. list: Newline-delimited list, opened and closed by a newline.
+#   2. path: Path to look for.
+#
+# Returns:
+#   0 when the list holds the path, 1 when it does not.
+##
+fixture_list_holds() {
+  case "${1}" in
+    *$'\n'"${2}"$'\n'*)
+      return 0
+      ;;
+  esac
+
+  return 1
 }

--- a/src/fixture.bash
+++ b/src/fixture.bash
@@ -442,8 +442,11 @@ fixture_validate_target() {
 #   0 when the list holds the path, 1 when it does not.
 ##
 fixture_list_holds() {
-  case "${1}" in
-    *$'\n'"${2}"$'\n'*)
+  local list="${1}"
+  local path="${2}"
+
+  case "${list}" in
+    *$'\n'"${path}"$'\n'*)
       return 0
       ;;
   esac

--- a/src/fixture.bash
+++ b/src/fixture.bash
@@ -335,7 +335,15 @@ fixture_list_files() {
   local -a files=()
   local file
 
+  # The walk runs in a process substitution, where its exit status is out of
+  # reach, so a failure is signalled in band with an empty record - a shape no
+  # path printed below '.' can take.
   while IFS= read -r -d '' file; do
+    if [ -z "${file}" ]; then
+      flunk "Unable to list the files of fixture directory '${dir}'."
+      return 1
+    fi
+
     file="${file#./}"
 
     if [[ ${file} == *$'\n'* ]]; then
@@ -344,7 +352,7 @@ fixture_list_files() {
     fi
 
     files+=("${file}")
-  done < <(cd "${dir}" && find . -type f -print0)
+  done < <({ cd "${dir}" && find . -type f -print0; } || printf '\0')
 
   [ "${#files[@]}" -gt 0 ] || return 0
 

--- a/src/fixture.bash
+++ b/src/fixture.bash
@@ -61,3 +61,325 @@ fixture_prepare_dir() {
   mkdir -p "${dir}"
   assert_dir_exists "${dir}"
 }
+
+##
+## File trees.
+##
+
+##
+# Creates a file tree from an archive read from STDIN.
+#
+# An archive is a run of file entries. Each entry opens with a marker line
+# naming the file - '-- src/app.sh --' - and holds every line up to the next
+# marker, so anything that is not a marker is content and the format has no
+# syntax errors. Content before the first marker is a comment and is discarded.
+# Parent directories are created implicitly.
+#
+# The directory is created when it does not exist, and only the files the
+# archive names are written, so 'fixture_prepare_dir' is the way to start from
+# an empty directory.
+#
+# Arguments:
+#   1. dir: Directory to create the tree in.
+##
+fixture_create_dir() {
+  local dir="${1?Directory is required.}"
+
+  local -a paths=()
+  local -a contents=()
+  fixture_read_archive || return 1
+
+  if ! mkdir -p "${dir}"; then
+    flunk "Unable to create fixture directory '${dir}'."
+    return 1
+  fi
+
+  local index
+  local path
+  local target
+
+  for ((index = 0; index < ${#paths[@]}; index++)); do
+    path="${paths[index]}"
+    target="${dir}/${path}"
+
+    if [ -d "${target}" ]; then
+      flunk "Fixture path '${path}' exists as a directory."
+      return 1
+    fi
+
+    if ! file_mktouch "${target}"; then
+      flunk "Unable to create fixture file '${path}'."
+      return 1
+    fi
+
+    printf '%s' "${contents[index]}" >"${target}"
+  done
+
+  return 0
+}
+
+##
+# Prints a directory as an archive.
+#
+# Only regular files are serialised, so symlinks, empty directories and file
+# modes are not represented. A file that does not end with a newline is printed
+# with one, because the format is line-based.
+#
+# Arguments:
+#   1. dir: Directory to serialise.
+#
+# Outputs:
+#   STDOUT: The archive, with the entries ordered by path.
+##
+fixture_dump_dir() {
+  local dir="${1?Directory is required.}"
+
+  assert_dir_exists "${dir}" || return 1
+
+  local listing
+  listing="$(fixture_list_files "${dir}")" || return 1
+
+  [ -n "${listing}" ] || return 0
+
+  # A content line that would otherwise be read as a marker, and one already
+  # carrying the escape, both take one more backslash.
+  local marker_line='^\\*-- .* --$'
+  local file
+  local line
+
+  while IFS= read -r file; do
+    if [ -s "${dir}/${file}" ] && ! LC_ALL=C grep -Iq '^' "${dir}/${file}"; then
+      flunk "Fixture file '${file}' is not a text file."
+      return 1
+    fi
+
+    printf -- '-- %s --\n' "${file}"
+
+    while IFS= read -r line || [ -n "${line}" ]; do
+      if [[ ${line} =~ ${marker_line} ]]; then
+        line="\\${line}"
+      fi
+
+      printf '%s\n' "${line}"
+    done <"${dir}/${file}"
+  done <<<"${listing}"
+
+  return 0
+}
+
+##
+# Asserts that a directory holds the file tree of an archive read from STDIN.
+#
+# Only regular files are compared, and the comparison is byte-exact, so a file
+# that does not end with a newline differs from the archive, which always names
+# one.
+#
+# Arguments:
+#   1. dir: Directory to compare.
+##
+fixture_assert_dir() {
+  local dir="${1?Directory is required.}"
+
+  assert_dir_exists "${dir}" || return 1
+
+  local -a paths=()
+  local -a contents=()
+  fixture_read_archive || return 1
+
+  ##
+  ## Expected files.
+  ##
+
+  # The paths are held as one newline-delimited value so that a path is matched
+  # as a whole word without becoming an array subscript.
+  local expected=$'\n'
+  local summary=""
+  local report=""
+  local differences=0
+  local index
+  local path
+  local target
+  local file_diff
+
+  for ((index = 0; index < ${#paths[@]}; index++)); do
+    path="${paths[index]}"
+    expected="${expected}${path}"$'\n'
+    target="${dir}/${path}"
+
+    if [ ! -f "${target}" ]; then
+      summary="${summary}missing: ${path}"$'\n'
+      differences=$((differences + 1))
+      continue
+    fi
+
+    file_diff="$(diff -u -L "expected ${path}" -L "actual ${path}" <(printf '%s' "${contents[index]}") "${target}")" && continue
+
+    summary="${summary}differs: ${path}"$'\n'
+    report="${report}${file_diff}"$'\n'
+    differences=$((differences + 1))
+  done
+
+  ##
+  ## Unexpected files.
+  ##
+
+  local listing
+  listing="$(fixture_list_files "${dir}")" || return 1
+
+  local file
+  while IFS= read -r file; do
+    [ -n "${file}" ] || continue
+
+    case "${expected}" in
+      *$'\n'"${file}"$'\n'*)
+        continue
+        ;;
+    esac
+
+    summary="${summary}unexpected: ${file}"$'\n'
+    differences=$((differences + 1))
+  done <<<"${listing}"
+
+  ##
+  ## Failure report.
+  ##
+
+  [ "${differences}" -eq 0 ] && return 0
+
+  local message="Directory '${dir}' does not match the expected fixture"$'\n\n'"${summary%$'\n'}"
+
+  if [ -n "${report}" ]; then
+    message="${message}"$'\n\n'"${report%$'\n'}"
+  fi
+
+  format_error "${message}" | flunk
+}
+
+##
+# Reads an archive from STDIN into the caller's entry arrays.
+#
+# The arrays are resolved through Bash dynamic scoping, so the caller declares
+# them as locals and this function fills them in place.
+#
+# Globals:
+#   paths: Array the caller declares, filled with the path of every entry, in
+#     the order the entries appear.
+#   contents: Array the caller declares, filled with the matching contents.
+##
+fixture_read_archive() {
+  # A content line carrying the escape loses one backslash, so a line that is
+  # marker-shaped after the removal is the one to unescape.
+  local escaped_marker='^\\+-- .* --$'
+  # The declared paths are held as one newline-delimited value so that a path is
+  # matched as a whole word without becoming an array subscript.
+  local declared=$'\n'
+  local index=-1
+  local line
+  local path
+
+  while IFS= read -r line || [ -n "${line}" ]; do
+    if [[ ${line} == '-- '*' --' ]]; then
+      path="${line:3:${#line}-6}"
+      # Strip the whitespace a marker may carry around the name, so that a name
+      # can be padded to line the markers up.
+      path="${path#"${path%%[![:space:]]*}"}"
+      path="${path%"${path##*[![:space:]]}"}"
+
+      if [ -z "${path}" ]; then
+        flunk "Fixture marker line '${line}' does not name a file."
+        return 1
+      fi
+
+      fixture_validate_path "${path}" || return 1
+
+      case "${declared}" in
+        *$'\n'"${path}"$'\n'*)
+          flunk "Fixture path '${path}' is declared more than once."
+          return 1
+          ;;
+      esac
+
+      declared="${declared}${path}"$'\n'
+      index=$((index + 1))
+      paths+=("${path}")
+      contents+=("")
+
+      continue
+    fi
+
+    [ "${index}" -ge 0 ] || continue
+
+    if [[ ${line} =~ ${escaped_marker} ]]; then
+      line="${line:1}"
+    fi
+
+    contents[index]+="${line}"$'\n'
+  done
+
+  return 0
+}
+
+##
+# Prints the regular files of a directory.
+#
+# Arguments:
+#   1. dir: Directory to walk.
+#
+# Outputs:
+#   STDOUT: One path per line, relative to the directory and sorted.
+##
+fixture_list_files() {
+  local dir="${1}"
+
+  local -a files=()
+  local file
+
+  while IFS= read -r -d '' file; do
+    file="${file#./}"
+
+    if [[ ${file} == *$'\n'* ]]; then
+      flunk "Fixture file name '${file}' contains a newline, which a marker line cannot hold."
+      return 1
+    fi
+
+    files+=("${file}")
+  done < <(cd "${dir}" && find . -type f -print0)
+
+  [ "${#files[@]}" -gt 0 ] || return 0
+
+  printf '%s\n' "${files[@]}" | LC_ALL=C sort
+}
+
+##
+# Validates that a path is one an archive may name.
+#
+# Arguments:
+#   1. path: Path to validate, relative to the fixture directory.
+##
+fixture_validate_path() {
+  local path="${1}"
+
+  case "${path}" in
+    /*)
+      flunk "Fixture path '${path}' is absolute, but must be relative to the fixture directory."
+      return 1
+      ;;
+    */)
+      flunk "Fixture path '${path}' names a directory, but must name a file."
+      return 1
+      ;;
+  esac
+
+  case "/${path}/" in
+    */../*)
+      flunk "Fixture path '${path}' escapes the fixture directory."
+      return 1
+      ;;
+    */./*)
+      flunk "Fixture path '${path}' contains a '.' component, but must be a plain relative path."
+      return 1
+      ;;
+  esac
+
+  return 0
+}

--- a/tests/fixture.bats
+++ b/tests/fixture.bats
@@ -262,6 +262,47 @@ FIXTURE
   assert_output_contains "contains a '.' component"
 }
 
+@test "fixture_create_dir with an empty path component" {
+  run fixture_create_dir "${BATS_TEST_TMPDIR}/tree" <<'FIXTURE'
+-- src//app.sh --
+x
+FIXTURE
+  assert_failure
+  assert_output_contains "contains an empty component"
+}
+
+@test "fixture_create_dir with a symlinked parent" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  mkdir -p "${dir}"
+  mkdir -p "${BATS_TEST_TMPDIR}/outside"
+  ln -s "${BATS_TEST_TMPDIR}/outside" "${dir}/src"
+
+  run fixture_create_dir "${dir}" <<'FIXTURE'
+-- src/app.sh --
+x
+FIXTURE
+  assert_failure
+  assert_output_contains "leads through the symlink"
+
+  assert_file_not_exists "${BATS_TEST_TMPDIR}/outside/app.sh"
+}
+
+@test "fixture_create_dir with a symlinked file" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  mkdir -p "${dir}"
+  echo "outside" >"${BATS_TEST_TMPDIR}/outside.txt"
+  ln -s "${BATS_TEST_TMPDIR}/outside.txt" "${dir}/app.sh"
+
+  run fixture_create_dir "${dir}" <<'FIXTURE'
+-- app.sh --
+x
+FIXTURE
+  assert_failure
+  assert_output_contains "leads through the symlink"
+
+  assert_file_contains "${BATS_TEST_TMPDIR}/outside.txt" "outside"
+}
+
 @test "fixture_create_dir with a directory path" {
   run fixture_create_dir "${BATS_TEST_TMPDIR}/tree" <<'FIXTURE'
 -- src/ --
@@ -484,6 +525,22 @@ FIXTURE
 FIXTURE
   assert_failure
   assert_output_contains "unexpected: src/app.sh"
+}
+
+@test "fixture_assert_dir with a symlink in place of a file" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  mkdir -p "${dir}"
+  echo "# Project" >"${BATS_TEST_TMPDIR}/outside.md"
+  ln -s "${BATS_TEST_TMPDIR}/outside.md" "${dir}/README.md"
+
+  # The content behind the symlink matches, but the directory does not hold the
+  # regular file the archive names.
+  run fixture_assert_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+FIXTURE
+  assert_failure
+  assert_output_contains "not a regular file: README.md"
 }
 
 @test "fixture_assert_dir with an empty archive" {

--- a/tests/fixture.bats
+++ b/tests/fixture.bats
@@ -451,6 +451,12 @@ EXPECTED
   assert_output_contains "Fixture file 'binary.bin' is not a text file"
 }
 
+@test "fixture_list_files with a directory it cannot walk" {
+  run fixture_list_files "${BATS_TEST_TMPDIR}/missing"
+  assert_failure
+  assert_output_contains "Unable to list the files"
+}
+
 @test "fixture_dump_dir with a newline in a file name" {
   dir="${BATS_TEST_TMPDIR}/tree"
   mkdir -p "${dir}"
@@ -525,6 +531,21 @@ FIXTURE
 FIXTURE
   assert_failure
   assert_output_contains "unexpected: src/app.sh"
+}
+
+@test "fixture_assert_dir with a file that has no trailing newline" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  mkdir -p "${dir}"
+  printf 'no newline' >"${dir}/file.txt"
+
+  # The archive always names a trailing newline, so a file without one differs.
+  run fixture_assert_dir "${dir}" <<'FIXTURE'
+-- file.txt --
+no newline
+FIXTURE
+  assert_failure
+  assert_output_contains "differs: file.txt"
+  assert_output_contains "No newline at end of file"
 }
 
 @test "fixture_assert_dir with a symlink in place of a file" {

--- a/tests/fixture.bats
+++ b/tests/fixture.bats
@@ -105,3 +105,414 @@ load _test_helper
 
   assert_equal 1 "${recovered}"
 }
+
+@test "fixture_create_dir" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+Everything before the first marker annotates the fixture and is discarded.
+
+-- README.md --
+# Project
+-- src/app.sh --
+#!/usr/bin/env bash
+echo "one"
+-- config/nested/.env --
+FOO=bar
+FIXTURE
+
+  assert_file_contains "${dir}/README.md" "# Project"
+  assert_file_contains "${dir}/src/app.sh" 'echo "one"'
+  assert_file_contains "${dir}/config/nested/.env" "FOO=bar"
+  assert_file_not_contains "${dir}/README.md" "annotates"
+}
+
+@test "fixture_create_dir preserves the content verbatim" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+-- src/app.sh --
+#!/usr/bin/env bash
+# A hash, a $dollar and a `backtick`.
+echo "value is ${UNEXPANDED}"
+printf '%s\n' 'single'"double"
+FIXTURE
+
+  run cat "${dir}/src/app.sh"
+  assert_success
+  assert_output <<'EXPECTED'
+#!/usr/bin/env bash
+# A hash, a $dollar and a `backtick`.
+echo "value is ${UNEXPANDED}"
+printf '%s\n' 'single'"double"
+EXPECTED
+}
+
+@test "fixture_create_dir with an empty entry" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+-- empty.txt --
+-- other.txt --
+content
+FIXTURE
+
+  assert_file_exists "${dir}/empty.txt"
+
+  run cat "${dir}/empty.txt"
+  assert_success
+  assert_output ""
+
+  assert_file_contains "${dir}/other.txt" "content"
+}
+
+@test "fixture_create_dir trims the marker name" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+--   src/app.sh   --
+one
+FIXTURE
+
+  assert_file_contains "${dir}/src/app.sh" "one"
+}
+
+@test "fixture_create_dir with an escaped marker line" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+-- doc.md --
+An archive looks like this:
+\-- README.md --
+# Project
+\\-- nested --
+\keep the backslash
+FIXTURE
+
+  run cat "${dir}/doc.md"
+  assert_success
+  assert_output <<'EXPECTED'
+An archive looks like this:
+-- README.md --
+# Project
+\-- nested --
+\keep the backslash
+EXPECTED
+}
+
+@test "fixture_create_dir without a trailing newline" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" < <(printf -- '-- file.txt --\nlast line')
+
+  run cat "${dir}/file.txt"
+  assert_success
+  assert_output "last line"
+}
+
+@test "fixture_create_dir with an empty archive" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" </dev/null
+
+  assert_dir_exists "${dir}"
+  assert_dir_empty "${dir}"
+}
+
+@test "fixture_create_dir keeps the files it does not name" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  file_mktouch "${dir}/keep.txt"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+-- add.txt --
+added
+FIXTURE
+
+  assert_file_exists "${dir}/keep.txt"
+  assert_file_contains "${dir}/add.txt" "added"
+}
+
+@test "fixture_create_dir with an absolute path" {
+  run fixture_create_dir "${BATS_TEST_TMPDIR}/tree" <<'FIXTURE'
+-- /etc/passwd --
+x
+FIXTURE
+  assert_failure
+  assert_output_contains "Fixture path '/etc/passwd' is absolute"
+
+  # The archive is read before anything is created.
+  assert_dir_not_exists "${BATS_TEST_TMPDIR}/tree"
+}
+
+@test "fixture_create_dir with a parent directory reference" {
+  run fixture_create_dir "${BATS_TEST_TMPDIR}/tree" <<'FIXTURE'
+-- ../escape.txt --
+x
+FIXTURE
+  assert_failure
+  assert_output_contains "escapes the fixture directory"
+}
+
+@test "fixture_create_dir with a current directory reference" {
+  run fixture_create_dir "${BATS_TEST_TMPDIR}/tree" <<'FIXTURE'
+-- ./file.txt --
+x
+FIXTURE
+  assert_failure
+  assert_output_contains "contains a '.' component"
+}
+
+@test "fixture_create_dir with a directory path" {
+  run fixture_create_dir "${BATS_TEST_TMPDIR}/tree" <<'FIXTURE'
+-- src/ --
+x
+FIXTURE
+  assert_failure
+  assert_output_contains "names a directory"
+}
+
+@test "fixture_create_dir with an unnamed marker" {
+  run fixture_create_dir "${BATS_TEST_TMPDIR}/tree" <<'FIXTURE'
+--  --
+x
+FIXTURE
+  assert_failure
+  assert_output_contains "does not name a file"
+}
+
+@test "fixture_create_dir with a duplicate path" {
+  run fixture_create_dir "${BATS_TEST_TMPDIR}/tree" <<'FIXTURE'
+-- file.txt --
+one
+-- file.txt --
+two
+FIXTURE
+  assert_failure
+  assert_output_contains "is declared more than once"
+}
+
+@test "fixture_create_dir with a path that is a directory" {
+  run fixture_create_dir "${BATS_TEST_TMPDIR}/tree" <<'FIXTURE'
+-- src/app.sh --
+one
+-- src --
+two
+FIXTURE
+  assert_failure
+  assert_output_contains "Fixture path 'src' exists as a directory"
+}
+
+@test "fixture_create_dir with a path below a file" {
+  run fixture_create_dir "${BATS_TEST_TMPDIR}/tree" <<'FIXTURE'
+-- src --
+one
+-- src/app.sh --
+two
+FIXTURE
+  assert_failure
+  assert_output_contains "Unable to create fixture file 'src/app.sh'"
+}
+
+@test "fixture_create_dir with an unusable directory" {
+  file_mktouch "${BATS_TEST_TMPDIR}/file"
+
+  run fixture_create_dir "${BATS_TEST_TMPDIR}/file/tree" <<'FIXTURE'
+-- a.txt --
+x
+FIXTURE
+  assert_failure
+  assert_output_contains "Unable to create fixture directory"
+}
+
+@test "fixture_dump_dir" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+-- src/app.sh --
+echo "one"
+-- .hidden --
+hidden
+-- README.md --
+# Project
+FIXTURE
+
+  run fixture_dump_dir "${dir}"
+  assert_success
+  assert_output <<'EXPECTED'
+-- .hidden --
+hidden
+-- README.md --
+# Project
+-- src/app.sh --
+echo "one"
+EXPECTED
+}
+
+@test "fixture_dump_dir escapes a marker line" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+-- doc.md --
+An archive looks like this:
+\-- README.md --
+# Project
+\\-- nested --
+\keep the backslash
+FIXTURE
+
+  run fixture_dump_dir "${dir}"
+  assert_success
+  assert_output <<'EXPECTED'
+-- doc.md --
+An archive looks like this:
+\-- README.md --
+# Project
+\\-- nested --
+\keep the backslash
+EXPECTED
+}
+
+@test "fixture_dump_dir adds a trailing newline" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  mkdir -p "${dir}"
+  printf 'no newline' >"${dir}/file.txt"
+
+  run fixture_dump_dir "${dir}"
+  assert_success
+  assert_output <<'EXPECTED'
+-- file.txt --
+no newline
+EXPECTED
+}
+
+@test "fixture_dump_dir with an empty directory" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  mkdir -p "${dir}"
+
+  run fixture_dump_dir "${dir}"
+  assert_success
+  assert_output ""
+}
+
+@test "fixture_dump_dir with a missing directory" {
+  run fixture_dump_dir "${BATS_TEST_TMPDIR}/missing"
+  assert_failure
+  assert_output_contains "does not exist"
+}
+
+@test "fixture_dump_dir with a binary file" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  mkdir -p "${dir}"
+  printf 'a\000b\n' >"${dir}/binary.bin"
+
+  run fixture_dump_dir "${dir}"
+  assert_failure
+  assert_output_contains "Fixture file 'binary.bin' is not a text file"
+}
+
+@test "fixture_dump_dir with a newline in a file name" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  mkdir -p "${dir}"
+  touch "${dir}/$(printf 'one\ntwo')"
+
+  run fixture_dump_dir "${dir}"
+  assert_failure
+  assert_output_contains "contains a newline"
+}
+
+@test "fixture_assert_dir" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+-- src/app.sh --
+echo "one"
+FIXTURE
+
+  fixture_assert_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+-- src/app.sh --
+echo "one"
+FIXTURE
+
+  run fixture_assert_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+-- src/app.sh --
+echo "two"
+FIXTURE
+  assert_failure
+  assert_output_contains "does not match the expected fixture"
+  assert_output_contains "differs: src/app.sh"
+  assert_output_contains '-echo "two"'
+  assert_output_contains '+echo "one"'
+}
+
+@test "fixture_assert_dir with a missing file" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+FIXTURE
+
+  run fixture_assert_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+-- src/app.sh --
+echo "one"
+FIXTURE
+  assert_failure
+  assert_output_contains "missing: src/app.sh"
+}
+
+@test "fixture_assert_dir with an unexpected file" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+
+  fixture_create_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+-- src/app.sh --
+echo "one"
+FIXTURE
+
+  run fixture_assert_dir "${dir}" <<'FIXTURE'
+-- README.md --
+# Project
+FIXTURE
+  assert_failure
+  assert_output_contains "unexpected: src/app.sh"
+}
+
+@test "fixture_assert_dir with an empty archive" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  mkdir -p "${dir}"
+
+  fixture_assert_dir "${dir}" </dev/null
+
+  file_mktouch "${dir}/extra.txt"
+
+  run fixture_assert_dir "${dir}" </dev/null
+  assert_failure
+  assert_output_contains "unexpected: extra.txt"
+}
+
+@test "fixture_assert_dir with an invalid archive" {
+  dir="${BATS_TEST_TMPDIR}/tree"
+  mkdir -p "${dir}"
+
+  run fixture_assert_dir "${dir}" <<'FIXTURE'
+-- /etc/passwd --
+x
+FIXTURE
+  assert_failure
+  assert_output_contains "is absolute"
+}
+
+@test "fixture_assert_dir with a missing directory" {
+  run fixture_assert_dir "${BATS_TEST_TMPDIR}/missing" </dev/null
+  assert_failure
+  assert_output_contains "does not exist"
+}


### PR DESCRIPTION
Closes #188

## Summary

Adds a plain-text archive format for declaring an entire fixture file tree inline in a test, instead of building it up with a run of `mkdir` and `echo` calls. The format mirrors Go's `txtar`: a `-- path --` marker line opens each entry and every following line up to the next marker is that entry's verbatim content, which means the archive has no syntax to get wrong beyond the marker itself.

## Changes

### `src/fixture.bash`

Adds three public functions:

- `fixture_create_dir` - builds a file tree under a directory from an archive read from STDIN. The directory is created if missing, and only the files the archive names are written, so it pairs with `fixture_prepare_dir` when a clean start is needed.
- `fixture_dump_dir` - serialises an existing directory's regular files back into the same archive format, ordered by path, both as a debugging aid and as the way to regenerate an expectation.
- `fixture_assert_dir` - compares a directory against an inline expected tree read from STDIN, reporting missing, unexpected and differing files in a summary followed by a per-file unified diff.

And five internal helpers that back them:

- `fixture_read_archive` - parses STDIN into the caller's `paths`/`contents` arrays via Bash dynamic scoping.
- `fixture_list_files` - lists a directory's regular files, sorted, relative to the directory. The walk runs in a process substitution where its exit status is out of reach, so a failure is signalled in band with an empty record - a shape no path printed below `.` can take - rather than silently yielding an empty listing.
- `fixture_validate_path` - rejects an absolute path, `..`, `.` or empty path components, and a trailing slash.
- `fixture_validate_target` - walks a path component by component and rejects one that passes through an existing symlink, so a link left by an earlier fixture or by the code under test cannot redirect a write outside the directory.
- `fixture_list_holds` - checks newline-delimited list membership as text rather than as an array, so a path of `@` or `*` cannot be misread as a subscript.

Path rules enforced throughout: no absolute paths, no `..`/`.`/empty components, no trailing slashes, no unnamed markers, and no path declared twice - each rejected with a message naming the offending path. A content line that would otherwise read as a marker carries one leading backslash to escape it. Binary content, file modes and symlinks are deliberate non-goals; `fixture_dump_dir` fails on a non-text file and `fixture_assert_dir` treats a symlink standing where the archive names a file as a difference.

### `tests/fixture.bats`

Adds 36 tests covering both the positive and negative behaviour of all three public functions - marker parsing and trimming, escaped markers, missing trailing newlines on both the input and the compared file, empty archives, symlink rejection on both a parent component and the leaf, duplicate and directory-shaped paths, a directory that cannot be walked, binary-file rejection in `fixture_dump_dir`, and the missing/unexpected/differs reporting in `fixture_assert_dir`.

### `README.md`

Adds a "Fixture trees" subsection under Helpers documenting the archive format, the escaping rule, the path rules and the failure report shape, plus three new rows in the Helpers table, a Features bullet, and an updated Table of Contents entry.

## Before / After

```
Building a fixture
──────────────────

Before                                     After
──────                                     ─────
mkdir -p "${dir}/src"                      fixture_create_dir "${dir}" <<'FIXTURE'
echo '# Project' > "${dir}/README.md"      -- README.md --
cat > "${dir}/src/app.sh" <<'EOF'          # Project
#!/usr/bin/env bash                        -- src/app.sh --
echo "one"                                 #!/usr/bin/env bash
EOF                                        echo "one"
                                           FIXTURE

Tree shape hidden across several           Tree shape visible as one literal
shell calls; escaping handled by           block; only a marker-shaped content
the caller each time.                      line needs an escape.


Verifying the result
────────────────────

Before                                     After
──────                                     ─────
assert_file_exists "${dir}/README.md"      fixture_assert_dir "${dir}" <<'FIXTURE'
assert_file_contains \                     -- README.md --
  "${dir}/README.md" '# Project'           # Project
assert_file_exists "${dir}/src/app.sh"     -- src/app.sh --
assert_file_contains \                     #!/usr/bin/env bash
  "${dir}/src/app.sh" 'echo "one"'         echo "one"
                                           FIXTURE

One assertion per fact; an unexpected      One call. A mismatch reports every
file is never noticed, and a mismatch      missing, unexpected and differing
says only that it differs.                 file, then a per-file unified diff:

                                           ┌──────────────────────────────────┐
                                           │ differs: src/app.sh              │
                                           │ unexpected: src/extra.sh         │
                                           │                                  │
                                           │ --- expected src/app.sh          │
                                           │ +++ actual src/app.sh            │
                                           │ @@ -1 +1 @@                      │
                                           │ -echo "one"                      │
                                           │ +echo "two"                      │
                                           └──────────────────────────────────┘
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added inline fixture tree archives for creating, dumping, and validating directory contents.
  - Supports deterministic file ordering, empty entries, path validation, symlink protection, and detailed mismatch reporting.
  - Preserves file content accurately, including escaped marker text and trailing newlines.

- **Documentation**
  - Added usage examples, archive syntax, validation behavior, limitations, and helper references to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
