### PR TITLE
[#191] Added a retry helper for eventually-true conditions.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ This is a BATS (Bash Automated Testing System) helpers library that provides ass
 - **src/**: Contains all helper modules:
   - `assert.*.bash`: Various assertion helpers (base, command, string, file, git)
   - `cleanup.bash`: Deferred cleanup that runs once the current test has finished
+  - `retry.bash`: Retry runner for conditions that become true shortly
   - `file.bash`: File utilities for creating, trimming, backing up and restoring files
   - `mock.bash`: Command mocking - the sandbox, mock creation, responses, argument specifications, strictness, the ordered call log and its assertions
   - `steps.bash`: Step runner for sequential command and string assertions

--- a/README.md
+++ b/README.md
@@ -1171,7 +1171,7 @@ assert_string_contains "${BATS_HELPERS_RETRY_OUTPUT}" "\"status\":\"ok\""
 When every bound is exhausted the failure names the elapsed time, the attempt count and the last observed state, so the run does not have to be reproduced by hand to find out what it was doing:
 
 ```text
-Command 'curl' did not succeed within 5 attempt(s)
+Command 'curl' did not succeed within 5 attempt(s).
 attempts: 5
 elapsed: 4 second(s)
 last status: 7

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   - [Mocking](#mocking) - Command mocking, Call log, Argument specifications, Strictness
   - [Step runner](#step-runner) - Sequential test assertions
   - [Cleanup](#cleanup) - Deferred per-test cleanup
+  - [Retry](#retry) - Conditions that become true shortly
   - [Helpers](#helpers) - Utility functions, inline fixture trees
   - [Environment variables](#environment-variables) - Full variable reference
   - [Deprecations](#deprecations) - Renamed functions and variables
@@ -46,6 +47,7 @@
 - Mock expectations that fail the test when they go unused or when an unanticipated call arrives.
 - Step runner for sequences of mocked calls and output assertions.
 - Deferred cleanup registered next to the code that created the thing it removes.
+- Retry for anything asynchronous, bounded by an attempt count, a delay and an optional deadline.
 - Data provider for running one function over many test cases, with named cases, per-case arity, a chosen assertion and matrix expansion.
 - Fixture and file utilities for building and restoring test sandboxes.
 - A plain-text archive for declaring a whole fixture file tree inline in the test, serialising a directory back to it, and asserting a directory against it with per-file diffs.
@@ -1095,6 +1097,104 @@ assert_file_not_exists "$(cleanup_registry_path)"
 
 `cleanup_run` drains the registry before running anything, so calling it a second time - from the test body and again from `teardown`, say - runs nothing.
 
+### Retry
+
+Anything asynchronous - a background process writing a file, a service coming up, a lock being released - is waited for by re-running the check rather than by sleeping for a fixed time:
+
+```bash
+@test "Server comes up" {
+  ./start-server.sh &
+
+  retry_run 20 0.25 curl -sf "http://localhost:8080/health"
+}
+```
+
+| Function    | Description                                                    | Arguments                                   | Returns |
+|-------------|----------------------------------------------------------------|---------------------------------------------|---------|
+| `retry_run` | Runs a command until it succeeds or until a bound is reached   | `attempts`, `delay`, `command`, `[args...]` | None    |
+
+The first attempt runs immediately and the last one is not followed by a wait, so a condition that is already true costs no delay at all and an exhausted retry does not end on a delay that changes nothing. A delay may carry a fractional part.
+
+Any command is retryable, including the library's own assertions, so nothing has to be reimplemented to be waited for:
+
+```bash
+retry_run 10 0.5 assert_file_exists "${build_dir}/artifact.tar"
+retry_run 10 0.5 assert_file_contains "${log}" "Ready"
+```
+
+Anything that needs a pipeline, a redirection or several statements is retried as a function, the same way it is registered for cleanup:
+
+```bash
+queue_is_drained() {
+  [ "$(wc -l <"${queue}")" -eq 0 ]
+}
+
+retry_run 30 1 queue_is_drained
+```
+
+#### Deadline
+
+`BATS_HELPERS_RETRY_TIMEOUT` bounds the whole retry in seconds, independently of the attempt count, so a generous attempt count can be capped by the time the suite can afford to spend:
+
+```bash
+export BATS_HELPERS_RETRY_TIMEOUT=10
+
+retry_run 200 0.05 assert_file_exists "${socket}"
+```
+
+Whichever bound is reached first ends the retry. The deadline is checked after each failed attempt: once it has passed, the helper stops rather than waiting again. It never interrupts an attempt that is already running, so a slow command can overshoot it.
+
+The deadline is in whole seconds, because `SECONDS` is the only clock available across the Bash versions the library supports.
+
+#### Reporting
+
+An immediate success is silent. A success that took more than one attempt writes a notice to file descriptor 3, so a test that has quietly degraded to a fourth attempt does not read like a healthy one:
+
+```text
+Retried: 'curl' succeeded on attempt 4 of 20 after 1 seconds.
+```
+
+Three variables describe the run that just finished:
+
+| Variable                      | Description                                                          |
+|-------------------------------|----------------------------------------------------------------------|
+| `BATS_HELPERS_RETRY_ATTEMPTS` | Attempts made, which on success is the attempt that succeeded        |
+| `BATS_HELPERS_RETRY_OUTPUT`   | STDOUT and STDERR of the last attempt                                |
+| `BATS_HELPERS_RETRY_ELAPSED`  | Whole seconds spent                                                  |
+
+```bash
+retry_run 10 0.5 curl -sf "http://localhost:8080/health"
+
+assert_string_contains "${BATS_HELPERS_RETRY_OUTPUT}" "\"status\":\"ok\""
+```
+
+When every bound is exhausted the failure names the elapsed time, the attempt count and the last observed state, so the run does not have to be reproduced by hand to find out what it was doing:
+
+```text
+Command 'curl' did not succeed within 5 attempt(s)
+attempts: 5
+elapsed: 4 second(s)
+last status: 7
+last output: 'curl: (7) Failed to connect to localhost port 8080'
+```
+
+#### What an attempt sees
+
+Each attempt runs in a subshell with its output captured, the way `run` does. Two consequences follow from that, and both match `run`:
+
+- `set -e` does not apply inside an attempt, so only the final exit status decides whether the attempt succeeded.
+- A variable an attempt sets does not reach the test. An attempt that has to publish a value writes a file.
+
+A command that does not resolve is rejected before the first attempt rather than retried, so a typo is reported immediately instead of after the whole delay budget has been spent. A command that is expected to appear later is probed for by a function:
+
+```bash
+binary_is_installed() {
+  command -v "${1}" >/dev/null 2>&1
+}
+
+retry_run 10 1 binary_is_installed "mytool"
+```
+
 ### Helpers
 
 | Function Name             | Description                                                                   |
@@ -1253,6 +1353,10 @@ Every variable the library defines, in one place. Each is also covered by the se
 | `BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED` | `fixture_export_codebase`                                     | Set to `1` to enable the export; anything else makes the function a no-op                   |
 | `BATS_HELPERS_BACKUP_DIR`                      | `file_add_var`, `file_restore`, `file_backup_path`            | Backup root. Defaults to `${BATS_TEST_TMPDIR}/bats-helpers-backup`                          |
 | `BATS_HELPERS_CLEANUP_DIR`                     | `cleanup_register`, `cleanup_run`, `cleanup_registry_path`    | Directory holding the cleanup registry. Defaults to `${BATS_TEST_TMPDIR}`                   |
+| `BATS_HELPERS_RETRY_TIMEOUT`                   | `retry_run`                                                   | Overall deadline in whole seconds, on top of the attempt count. Unset means no deadline     |
+| `BATS_HELPERS_RETRY_ATTEMPTS`                  | `retry_run`                                                   | Set by `retry_run` to the attempts made, which on success is the attempt that succeeded     |
+| `BATS_HELPERS_RETRY_OUTPUT`                    | `retry_run`                                                   | Set by `retry_run` to the STDOUT and STDERR of the last attempt                             |
+| `BATS_HELPERS_RETRY_ELAPSED`                   | `retry_run`                                                   | Set by `retry_run` to the whole seconds the retry spent                                     |
 | `BATS_HELPERS_MOCK_TMPDIR`                     | `mock_setup`, `mock_create`                                   | Directory the mocks are written below. Defaults to `${BATS_TEST_TMPDIR}`, and `mock_setup` exports the resolved path |
 | `BATS_HELPERS_MOCK_USER`                       | `mock_get_call_user`                                          | User a mock call is reported as. Defaults to `id -un`                                       |
 | `BATS_HELPERS_MOCK_STRICT`                     | `mock_create`                                                 | Set to `0` to answer the calls a mock's expectations do not cover. Defaults to `1`, and is read when the mock is created |

--- a/load.bash
+++ b/load.bash
@@ -15,6 +15,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/src/assert.file.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/assert.git.bash"
 
 source "$(dirname "${BASH_SOURCE[0]}")/src/cleanup.bash"
+source "$(dirname "${BASH_SOURCE[0]}")/src/retry.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/file.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/fixture.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/dataprovider.bash"

--- a/src/retry.bash
+++ b/src/retry.bash
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+##
+# @file
+# Retry for conditions that become true shortly.
+#
+
+##
+# Runs a command until it succeeds.
+#
+# The command is re-run until it exits zero, until the attempt count is spent or
+# until the deadline is reached, whichever comes first. Nothing is waited for
+# before the first attempt or after the last one, so a condition that is already
+# true costs no delay at all.
+#
+# Each attempt runs in a subshell with its output captured, the way 'run' does,
+# so 'set -e' does not apply inside it and a variable an attempt sets does not
+# reach the test. An attempt that has to publish a value writes a file.
+#
+# Arguments:
+#   1. attempts: Number of attempts to make. Greater than zero.
+#   2. delay: Seconds to wait between attempts. Decimals are allowed.
+#   3. command: Command or assertion to run.
+#   4+. args: Arguments to pass to the command. Optional.
+#
+# Globals:
+#   BATS_HELPERS_RETRY_TIMEOUT: Overall deadline, in whole seconds. Optional.
+#     The retry stops once a failed attempt finds the deadline reached, rather
+#     than waiting again; an attempt already running is not interrupted.
+#   BATS_HELPERS_RETRY_ATTEMPTS: Set to the number of attempts made, which on
+#     success is the attempt that succeeded.
+#   BATS_HELPERS_RETRY_OUTPUT: Set to the STDOUT and STDERR of the last attempt.
+#   BATS_HELPERS_RETRY_ELAPSED: Set to the whole seconds spent.
+#
+# Outputs:
+#   File descriptor 3: A notice naming the attempt the command succeeded on.
+#     Nothing when it succeeded on the first one.
+##
+retry_run() {
+  if [ "$#" -lt 3 ]; then
+    flunk "An attempt count, a delay and a command are required."
+    return 1
+  fi
+
+  local attempts="${1}"
+  local delay="${2}"
+  shift 2
+
+  local -a command_line=("$@")
+  local command_name="${1}"
+
+  ##
+  ## Input validation.
+  ##
+
+  if ! [[ ${attempts} =~ ^-?[0-9]+$ ]]; then
+    flunk "Attempt count '${attempts}' is not an integer."
+    return 1
+  fi
+
+  if [ "${attempts}" -le 0 ]; then
+    flunk "Attempt count must be greater than zero."
+    return 1
+  fi
+
+  if ! [[ ${delay} =~ ^[0-9]*\.?[0-9]+$ ]]; then
+    flunk "Delay '${delay}' is not a non-negative number."
+    return 1
+  fi
+
+  if [ -z "${command_name}" ]; then
+    flunk "Command name must not be empty."
+    return 1
+  fi
+
+  # A name that does not resolve fails every attempt with the same status, so
+  # retrying it only delays the report of something that was wrong from the
+  # start. A command that is expected to appear is probed for by a function.
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    flunk "Command '${command_name}' is not a valid command."
+    return 1
+  fi
+
+  local timeout="${BATS_HELPERS_RETRY_TIMEOUT-}"
+
+  if [ -n "${timeout}" ] && ! [[ ${timeout} =~ ^[0-9]+$ ]]; then
+    flunk "Deadline '${timeout}' is not a whole number of seconds."
+    return 1
+  fi
+
+  ##
+  ## Runner.
+  ##
+
+  BATS_HELPERS_RETRY_ATTEMPTS=0
+  BATS_HELPERS_RETRY_OUTPUT=""
+  BATS_HELPERS_RETRY_ELAPSED=0
+
+  # 'SECONDS' is the only clock available across the Bash versions the library
+  # supports, which is why the deadline is counted in whole seconds.
+  local start="${SECONDS}"
+  local last_status
+  local deadline_reached=0
+
+  while true; do
+    BATS_HELPERS_RETRY_ATTEMPTS=$((BATS_HELPERS_RETRY_ATTEMPTS + 1))
+
+    last_status=0
+    BATS_HELPERS_RETRY_OUTPUT="$("${command_line[@]}" 2>&1)" || last_status="$?"
+
+    BATS_HELPERS_RETRY_ELAPSED=$((SECONDS - start))
+
+    if [ "${last_status}" -eq 0 ]; then
+      # A test that quietly degrades to a fourth attempt reads as a healthy one
+      # unless the run says otherwise.
+      [ "${BATS_HELPERS_RETRY_ATTEMPTS}" -eq 1 ] || echo "Retried: '${command_name}' succeeded on attempt ${BATS_HELPERS_RETRY_ATTEMPTS} of ${attempts} after ${BATS_HELPERS_RETRY_ELAPSED} seconds." >&3
+
+      return 0
+    fi
+
+    if [ "${BATS_HELPERS_RETRY_ATTEMPTS}" -ge "${attempts}" ]; then
+      break
+    fi
+
+    if [ -n "${timeout}" ] && [ "${BATS_HELPERS_RETRY_ELAPSED}" -ge "${timeout}" ]; then
+      deadline_reached=1
+      break
+    fi
+
+    sleep "${delay}"
+  done
+
+  ##
+  ## Failure report.
+  ##
+
+  local bound="${attempts} attempt(s)"
+
+  if [ "${deadline_reached}" = "1" ]; then
+    bound="the ${timeout} second deadline"
+  fi
+
+  local message="Command '${command_name}' did not succeed within ${bound}"
+
+  message="${message}"$'\n'"attempts: ${BATS_HELPERS_RETRY_ATTEMPTS}"
+  message="${message}"$'\n'"elapsed: ${BATS_HELPERS_RETRY_ELAPSED} second(s)"
+  message="${message}"$'\n'"last status: ${last_status}"
+  message="${message}"$'\n'"last output: '${BATS_HELPERS_RETRY_OUTPUT}'"
+
+  format_error "${message}" | flunk
+}

--- a/src/retry.bash
+++ b/src/retry.bash
@@ -139,12 +139,15 @@ retry_run() {
     bound="the ${timeout} second deadline"
   fi
 
-  local message="Command '${command_name}' did not succeed within ${bound}"
+  local message="Command '${command_name}' did not succeed within ${bound}."
 
   message="${message}"$'\n'"attempts: ${BATS_HELPERS_RETRY_ATTEMPTS}"
   message="${message}"$'\n'"elapsed: ${BATS_HELPERS_RETRY_ELAPSED} second(s)"
   message="${message}"$'\n'"last status: ${last_status}"
   message="${message}"$'\n'"last output: '${BATS_HELPERS_RETRY_OUTPUT}'"
 
-  format_error "${message}" | flunk
+  # Reported through 'flunk' rather than 'format_error', which appends the
+  # output the enclosing 'run' captured - unrelated to the retry, and read as
+  # the last attempt's own output that the report already carries.
+  flunk "${message}"
 }

--- a/tests/retry.bats
+++ b/tests/retry.bats
@@ -97,7 +97,7 @@ fixture_assert_elapsed() {
 
   run retry_run 3 0.1 fixture_probe 99
   assert_failure
-  assert_output_contains "Command 'fixture_probe' did not succeed within 3 attempt(s)"
+  assert_output_contains "Command 'fixture_probe' did not succeed within 3 attempt(s)."
   assert_output_contains "attempts: 3"
   assert_output_matches_format "elapsed: %d second(s)"
   assert_output_contains "last status: 1"
@@ -136,7 +136,7 @@ fixture_assert_elapsed() {
 
   run retry_run 1 5 false
   assert_failure
-  assert_output_contains "did not succeed within 1 attempt(s)"
+  assert_output_contains "did not succeed within 1 attempt(s)."
 
   fixture_assert_elapsed "$((SECONDS - start))" 0 1
 }
@@ -158,7 +158,7 @@ fixture_assert_elapsed() {
 
   run retry_run 5 1 false
   assert_failure
-  assert_output_contains "Command 'false' did not succeed within the 0 second deadline"
+  assert_output_contains "Command 'false' did not succeed within the 0 second deadline."
   assert_output_contains "attempts: 1"
 
   mock_assert_not_called "sleep"
@@ -173,7 +173,7 @@ fixture_assert_elapsed() {
 
   run retry_run 10 1 false
   assert_failure
-  assert_output_contains "Command 'false' did not succeed within the 1 second deadline"
+  assert_output_contains "Command 'false' did not succeed within the 1 second deadline."
   assert_output_matches "attempts: [12]"
 
   # The attempt count alone would have taken nine seconds.
@@ -188,7 +188,7 @@ fixture_assert_elapsed() {
 
   run retry_run 3 0.1 false
   assert_failure
-  assert_output_contains "did not succeed within 3 attempt(s)"
+  assert_output_contains "did not succeed within 3 attempt(s)."
 
   assert_equal 2 "$(mock_get_call_num "${mock_sleep}")"
 }

--- a/tests/retry.bats
+++ b/tests/retry.bats
@@ -1,0 +1,342 @@
+#!/usr/bin/env bats
+#
+# Tests for the retry helper.
+#
+# shellcheck disable=SC2030,SC2031
+
+load _test_helper
+
+##
+# Succeeds on the call named by the threshold, and fails before it.
+#
+# The count is kept in a file because every attempt runs in its own subshell.
+#
+# Arguments:
+#   1. threshold: Call the probe starts succeeding on.
+#
+# Globals:
+#   BATS_TEST_TMPDIR: Directory holding the counter.
+#
+# Outputs:
+#   STDOUT: The number of the call.
+##
+fixture_probe() {
+  local threshold="${1}"
+  local counter="${BATS_TEST_TMPDIR}/probe.count"
+
+  local count=0
+
+  if [ -f "${counter}" ]; then
+    count="$(cat "${counter}")"
+  fi
+
+  count=$((count + 1))
+  echo -n "${count}" >"${counter}"
+
+  echo "probed ${count}"
+
+  [ "${count}" -ge "${threshold}" ]
+}
+
+##
+# Prints every argument it receives, one per line and delimited.
+#
+# Arguments:
+#   1+. args: Arguments to print. Optional.
+#
+# Outputs:
+#   STDOUT: One delimited argument per line.
+##
+fixture_echo_args() {
+  printf '[%s]\n' "$@"
+}
+
+##
+# Asserts that a whole number of seconds falls within a range.
+#
+# Arguments:
+#   1. elapsed: Seconds measured.
+#   2. min: Lowest acceptable value.
+#   3. max: Highest acceptable value.
+##
+fixture_assert_elapsed() {
+  local elapsed="${1}"
+  local min="${2}"
+  local max="${3}"
+
+  if [ "${elapsed}" -lt "${min}" ] || [ "${elapsed}" -gt "${max}" ]; then
+    flunk "Elapsed time ${elapsed} is outside the expected range of ${min} to ${max} seconds."
+  fi
+}
+
+@test "retry_run" {
+  retry_run 3 5 true
+
+  assert_equal 1 "${BATS_HELPERS_RETRY_ATTEMPTS}"
+  assert_equal "" "${BATS_HELPERS_RETRY_OUTPUT}"
+  fixture_assert_elapsed "${BATS_HELPERS_RETRY_ELAPSED}" 0 1
+
+  run retry_run 3 0 false
+  assert_failure
+}
+
+@test "retry_run with a condition that becomes true" {
+  local mock_sleep
+  mock_sleep="$(mock_command "sleep")"
+
+  retry_run 5 0.1 fixture_probe 3
+
+  assert_equal 3 "${BATS_HELPERS_RETRY_ATTEMPTS}"
+  assert_equal "probed 3" "${BATS_HELPERS_RETRY_OUTPUT}"
+  assert_equal 2 "$(mock_get_call_num "${mock_sleep}")"
+}
+
+@test "retry_run with an exhausted attempt count" {
+  local mock_sleep
+  mock_sleep="$(mock_command "sleep")"
+
+  run retry_run 3 0.1 fixture_probe 99
+  assert_failure
+  assert_output_contains "Command 'fixture_probe' did not succeed within 3 attempt(s)"
+  assert_output_contains "attempts: 3"
+  assert_output_matches_format "elapsed: %d second(s)"
+  assert_output_contains "last status: 1"
+  assert_output_contains "last output: 'probed 3'"
+
+  assert_equal 3 "$(cat "${BATS_TEST_TMPDIR}/probe.count")"
+  assert_equal 2 "$(mock_get_call_num "${mock_sleep}")"
+}
+
+@test "retry_run sleeps between attempts only" {
+  local mock_sleep
+  mock_sleep="$(mock_command "sleep")"
+
+  run retry_run 3 0.25 false
+  assert_failure
+
+  assert_equal 2 "$(mock_get_call_num "${mock_sleep}")"
+  mock_assert_call_args "${mock_sleep}" "0.25" 1
+  mock_assert_call_args "${mock_sleep}" "0.25" 2
+}
+
+# The delay is large enough that a wait taken before the first attempt would
+# show up in the elapsed time.
+@test "retry_run does not delay before the first attempt" {
+  local start="${SECONDS}"
+
+  retry_run 3 5 true
+
+  fixture_assert_elapsed "$((SECONDS - start))" 0 1
+}
+
+# The only attempt is also the last one, so any wait taken after an attempt
+# would show up in the elapsed time.
+@test "retry_run does not delay after the last attempt" {
+  local start="${SECONDS}"
+
+  run retry_run 1 5 false
+  assert_failure
+  assert_output_contains "did not succeed within 1 attempt(s)"
+
+  fixture_assert_elapsed "$((SECONDS - start))" 0 1
+}
+
+@test "retry_run with a fractional delay" {
+  local mock_sleep
+  mock_sleep="$(mock_command "sleep")"
+
+  run retry_run 2 ".5" false
+  assert_failure
+
+  mock_assert_call_args "${mock_sleep}" ".5" 1
+}
+
+@test "retry_run with a deadline of zero" {
+  mock_command "sleep" >/dev/null
+
+  export BATS_HELPERS_RETRY_TIMEOUT=0
+
+  run retry_run 5 1 false
+  assert_failure
+  assert_output_contains "Command 'false' did not succeed within the 0 second deadline"
+  assert_output_contains "attempts: 1"
+
+  mock_assert_not_called "sleep"
+}
+
+# The one test that lets the clock run, because a mocked 'sleep' leaves the
+# elapsed time at zero and no deadline is ever reached.
+@test "retry_run with a deadline that is reached" {
+  export BATS_HELPERS_RETRY_TIMEOUT=1
+
+  local start="${SECONDS}"
+
+  run retry_run 10 1 false
+  assert_failure
+  assert_output_contains "Command 'false' did not succeed within the 1 second deadline"
+  assert_output_matches "attempts: [12]"
+
+  # The attempt count alone would have taken nine seconds.
+  fixture_assert_elapsed "$((SECONDS - start))" 0 3
+}
+
+@test "retry_run with a deadline that is not reached" {
+  local mock_sleep
+  mock_sleep="$(mock_command "sleep")"
+
+  export BATS_HELPERS_RETRY_TIMEOUT=60
+
+  run retry_run 3 0.1 false
+  assert_failure
+  assert_output_contains "did not succeed within 3 attempt(s)"
+
+  assert_equal 2 "$(mock_get_call_num "${mock_sleep}")"
+}
+
+@test "retry_run with an empty deadline" {
+  export BATS_HELPERS_RETRY_TIMEOUT=""
+
+  retry_run 3 0.1 true
+
+  assert_equal 1 "${BATS_HELPERS_RETRY_ATTEMPTS}"
+}
+
+@test "retry_run with a library assertion" {
+  local file="${BATS_TEST_TMPDIR}/late.txt"
+
+  local mock_sleep
+  mock_sleep="$(mock_command "sleep")"
+  mock_set_status "${mock_sleep}" 0
+  mock_set_side_effect "${mock_sleep}" "touch '${file}'" 2
+
+  assert_file_not_exists "${file}"
+
+  retry_run 5 0.1 assert_file_exists "${file}"
+
+  assert_equal 3 "${BATS_HELPERS_RETRY_ATTEMPTS}"
+  assert_file_exists "${file}"
+
+  run retry_run 2 0.1 assert_file_not_exists "${file}"
+  assert_failure
+  assert_output_contains "File '\${BATS_TEST_TMPDIR}/late.txt' exists, but should not"
+}
+
+@test "retry_run passes arguments verbatim" {
+  retry_run 1 0 fixture_echo_args "with space" "" "hash#" "quote'd"
+
+  assert_equal "[with space]
+[]
+[hash#]
+[quote'd]" "${BATS_HELPERS_RETRY_OUTPUT}"
+}
+
+@test "retry_run resets its result globals" {
+  mock_command "sleep" >/dev/null
+
+  retry_run 5 0.1 fixture_probe 3
+  assert_equal 3 "${BATS_HELPERS_RETRY_ATTEMPTS}"
+  assert_equal "probed 3" "${BATS_HELPERS_RETRY_OUTPUT}"
+
+  retry_run 5 0.1 true
+  assert_equal 1 "${BATS_HELPERS_RETRY_ATTEMPTS}"
+  assert_equal "" "${BATS_HELPERS_RETRY_OUTPUT}"
+}
+
+@test "retry_run reports the attempt it succeeded on" {
+  local notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  mock_command "sleep" >/dev/null
+
+  retry_run 5 0.1 fixture_probe 3 3>"${notice}"
+
+  assert_file_matches_format "${notice}" "Retried: 'fixture_probe' succeeded on attempt 3 of 5 after %d seconds."
+
+  # An immediate success is the common case and stays silent.
+  retry_run 5 0.1 true 3>"${notice}"
+
+  assert_equal "" "$(cat "${notice}")"
+}
+
+@test "retry_run without enough arguments" {
+  run retry_run
+  assert_failure
+  assert_output_contains "An attempt count, a delay and a command are required."
+
+  run retry_run 3
+  assert_failure
+  assert_output_contains "An attempt count, a delay and a command are required."
+
+  run retry_run 3 0.1
+  assert_failure
+  assert_output_contains "An attempt count, a delay and a command are required."
+}
+
+@test "retry_run with an invalid attempt count" {
+  run retry_run "abc" 0.1 true
+  assert_failure
+  assert_output_contains "Attempt count 'abc' is not an integer."
+
+  run retry_run "2.5" 0.1 true
+  assert_failure
+  assert_output_contains "Attempt count '2.5' is not an integer."
+
+  run retry_run "" 0.1 true
+  assert_failure
+  assert_output_contains "Attempt count '' is not an integer."
+
+  run retry_run 0 0.1 true
+  assert_failure
+  assert_output_contains "Attempt count must be greater than zero."
+
+  run retry_run -2 0.1 true
+  assert_failure
+  assert_output_contains "Attempt count must be greater than zero."
+}
+
+@test "retry_run with an invalid delay" {
+  run retry_run 3 "abc" true
+  assert_failure
+  assert_output_contains "Delay 'abc' is not a non-negative number."
+
+  run retry_run 3 "-1" true
+  assert_failure
+  assert_output_contains "Delay '-1' is not a non-negative number."
+
+  run retry_run 3 "1." true
+  assert_failure
+  assert_output_contains "Delay '1.' is not a non-negative number."
+
+  run retry_run 3 "" true
+  assert_failure
+  assert_output_contains "Delay '' is not a non-negative number."
+}
+
+@test "retry_run with an invalid command" {
+  run retry_run 3 0.1 ""
+  assert_failure
+  assert_output_contains "Command name must not be empty."
+
+  run retry_run 3 0.1 "bats_helpers_no_such_command"
+  assert_failure
+  assert_output_contains "Command 'bats_helpers_no_such_command' is not a valid command."
+}
+
+@test "retry_run with an invalid deadline" {
+  export BATS_HELPERS_RETRY_TIMEOUT="abc"
+
+  run retry_run 3 0.1 true
+  assert_failure
+  assert_output_contains "Deadline 'abc' is not a whole number of seconds."
+
+  export BATS_HELPERS_RETRY_TIMEOUT="1.5"
+
+  run retry_run 3 0.1 true
+  assert_failure
+  assert_output_contains "Deadline '1.5' is not a whole number of seconds."
+
+  export BATS_HELPERS_RETRY_TIMEOUT="-1"
+
+  run retry_run 3 0.1 true
+  assert_failure
+  assert_output_contains "Deadline '-1' is not a whole number of seconds."
+}


### PR DESCRIPTION
Closes #191

## Summary

Adds `src/retry.bash`, a new module whose single public function `retry_run <attempts> <delay> <command> [args...]` re-runs any command or assertion until it succeeds, so an asynchronous condition (a background process writing a file, a service coming up, a lock being released) is waited for by re-checking rather than by sleeping a fixed amount of time.

The retry is bounded by the attempt count and, optionally, by `BATS_HELPERS_RETRY_TIMEOUT` (an overall deadline in whole seconds); whichever bound is reached first ends the retry, and the deadline is checked only after a failed attempt so it never interrupts one already in flight.

It composes with the library's existing assertions instead of duplicating them, e.g. `retry_run 10 0.5 assert_file_exists "${f}"`, and exposes the outcome through `BATS_HELPERS_RETRY_ATTEMPTS`, `BATS_HELPERS_RETRY_OUTPUT` and `BATS_HELPERS_RETRY_ELAPSED` for the caller to inspect afterwards.

## Changes

### Library

- `src/retry.bash` (new): `retry_run` validates the attempt count, delay and deadline, rejects a command name that does not resolve before the first attempt rather than retrying a typo, runs each attempt in a subshell with output captured the way `run` does (so `set -e` does not apply inside an attempt and an attempt's variable assignments do not reach the test), sleeps only between attempts (never before the first, never after the last), and on exhaustion reports the bound that was hit, the attempt count, the elapsed time, the last exit status and the last output through `flunk`.
- A success that took more than one attempt writes a notice to file descriptor 3; an immediate success stays silent.
- `load.bash`: sources the new module.

### Tests

- `tests/retry.bats` (new): 20 tests covering validation of every argument, deterministic delay-placement assertions that mock `sleep`, deadline interaction (zero, reached, not reached, empty, invalid), argument passing, result-global resets, the attempt-succeeded notice on file descriptor 3, and wall-clock tests that bound the elapsed time on the paths that let the clock run.

### Documentation

- `README.md`: adds a `### Retry` section (usage, the `Deadline`, `Reporting` and `What an attempt sees` subsections, and the function reference table), a table of contents entry, a feature bullet, and four environment-variable reference rows.
- `CLAUDE.md`: lists `retry.bash` among the `src/` modules.

## Screenshots

N/A

## Before / After

```
BEFORE
──────

  @test "server responds once it is up" {
    ./start-server.sh &

    for i in 1 2 3 4 5; do
      curl -sf "http://localhost:8080/health" && break
      sleep 1
    done                        # exhausts silently: no bound on total
                                 # time, no captured output, no attempt count
  }

AFTER
─────

  load.bash ──sources──> src/retry.bash

  @test "server responds once it is up" {
    ./start-server.sh &

    retry_run 5 1 curl -sf "http://localhost:8080/health"
  }

  BATS_HELPERS_RETRY_ATTEMPTS=1       <- set on every run
  BATS_HELPERS_RETRY_OUTPUT="..."     <- last attempt's STDOUT+STDERR
  BATS_HELPERS_RETRY_ELAPSED=0        <- whole seconds spent

  exhausted after 5 attempts (or BATS_HELPERS_RETRY_TIMEOUT, if set):
  ┌──────────────────────────────────────────────────────┐
  │ Command 'curl' did not succeed within 5 attempt(s).   │
  │ attempts: 5                                           │
  │ elapsed: 4 second(s)                                  │
  │ last status: 7                                        │
  │ last output: 'curl: (7) Failed to connect...'         │
  └──────────────────────────────────────────────────────┘
```
