### PR TITLE
[#186] Added a mock sandbox mode where an unmocked command fails loudly instead of running for real.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a BATS (Bash Automated Testing System) helpers library that provides ass
   - `cleanup.bash`: Deferred cleanup that runs once the current test has finished
   - `retry.bash`: Retry runner for conditions that become true shortly
   - `file.bash`: File utilities for creating, trimming, backing up and restoring files
-  - `mock.bash`: Command mocking - the sandbox, mock creation, responses, argument specifications, strictness, the ordered call log and its assertions
+  - `mock.bash`: Command mocking - the mock directory, mock creation, responses, argument specifications, strictness, sandbox mode, the ordered call log and its assertions
   - `steps.bash`: Step runner for sequential command and string assertions
   - `dataprovider.bash`: Data provider utilities for parameterized tests
   - `fixture.bash`: Test fixture management
@@ -80,7 +80,7 @@ Two exceptions:
 The subject naming a helper is what it acts on, not the file it sits in, so the helpers behind those two bare verbs read `report_*` - `report_decorate`, `report_diff`, `report_stack_trace`, `report_normalise_paths` - even though they live in `src/assert.base.bash`. The failure report is the subject they share.
 
 ### Variable Naming
-Every variable the library reads from the wider environment carries the `BATS_HELPERS_` prefix, for the same namespace reason as the function prefixes: `load.bash` is sourced into the consumer's test shell, so an unprefixed global would collide silently with the consumer's own. The name after the prefix identifies the module and then the subject - `BATS_HELPERS_STEPS_DEBUG`, `BATS_HELPERS_ASSERT_DIR_EXCLUDE`, `BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED`. The mocking modules follow it like every other: `BATS_HELPERS_MOCK_TMPDIR`, `BATS_HELPERS_MOCK_USER` and `BATS_HELPERS_MOCK_STRICT`.
+Every variable the library reads from the wider environment carries the `BATS_HELPERS_` prefix, for the same namespace reason as the function prefixes: `load.bash` is sourced into the consumer's test shell, so an unprefixed global would collide silently with the consumer's own. The name after the prefix identifies the module and then the subject - `BATS_HELPERS_STEPS_DEBUG`, `BATS_HELPERS_ASSERT_DIR_EXCLUDE`, `BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED`. The mocking modules follow it like every other: `BATS_HELPERS_MOCK_TMPDIR`, `BATS_HELPERS_MOCK_USER`, `BATS_HELPERS_MOCK_STRICT` and `BATS_HELPERS_MOCK_SANDBOX_REPORT`.
 
 `STEPS`, `TEST_CASES` and `SCRIPT_FILE` are the three exceptions and stay unprefixed. They are not environment configuration but the test data itself, written on the lines directly above the call that reads them, so the declaration and its use are read together and a long prefix costs more in daily ergonomics than the collision risk costs in rare confusion. `STEPS` and `TEST_CASES` are arrays declared with `declare -a`; `SCRIPT_FILE` is a scalar path.
 
@@ -172,6 +172,8 @@ File headers and function docblocks follow one house style so the library reads 
 The mocking system creates temporary mock executables that record calls and can return configured outputs/exit codes.
 
 Everything mock-related lives in one `src/mock.bash`, in the same way the `assert.*` family splits by subject but each subject stays whole. The one rule the single file has to carry itself is the process boundary: the generated mock is a separate script that sources `assert.string.bash` and `mock.bash` and then runs in its own process, where `assert.base.bash` is *not* loaded. Every function that mock reaches at call time - the log writers, the whole matching engine, the response resolution, forwarding, and the strictness accept and reject pair - therefore must never call `flunk`, which would die as an unknown command under the mock's `set -e`. Each of those functions says so in its docblock; add a `flunk` to one and the mock breaks at run time rather than at lint time, so the docblock line is the only guard.
+
+Sandbox mode crosses the same boundary through a different door: `mock_sandbox_deny` is exported as `command_not_found_handle` and runs in whichever process hit the failed lookup, where nothing is loaded at all. It is bound by the same rule and by a stricter one - it may use builtins only, since the very reason it ran is that a command could not be found.
 
 ### Step Runner
 The `steps.bash` module provides a DSL for defining test sequences with both command mocking and string assertions:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   - [Load library](#load-library)
   - [Assertions](#assertions) - Command run, Line, Exit statuses, Standard error, String, Match modes, File, Git
   - [Data provider](#data-provider) - Parameterized tests, named cases, matrices
-  - [Mocking](#mocking) - Command mocking, Call log, Argument specifications, Strictness
+  - [Mocking](#mocking) - Command mocking, Call log, Argument specifications, Strictness, Sandbox mode
   - [Step runner](#step-runner) - Sequential test assertions
   - [Cleanup](#cleanup) - Deferred per-test cleanup
   - [Retry](#retry) - Conditions that become true shortly
@@ -45,6 +45,7 @@
 - Command mocking with per-call output, exit status and side effects, and responses selected by matched arguments.
 - An ordered log of every mocked call, asserted as a sequence and reported as a unified diff.
 - Mock expectations that fail the test when they go unused or when an unanticipated call arrives.
+- An opt-in sandbox mode where an unmocked command is denied by name, with an allow-list for the commands that must run for real and a report of everything that left the mock boundary.
 - Step runner for sequences of mocked calls and output assertions.
 - Deferred cleanup registered next to the code that created the thing it removes.
 - Retry for anything asynchronous, bounded by an attempt count, a delay and an optional deadline.
@@ -667,7 +668,7 @@ This is a very powerful feature that allows to test complex scenarios as unit te
 | `mock_verify`            | Asserts that every expectation was met                                         | `[mock...]`                             | None             |
 | `mock_log_print`         | Returns every recorded call, in order                                          | None                                    | Call log         |
 
-#### Mock sandbox
+#### Mock directory
 
 `mock_setup` writes the mocks to `${BATS_TEST_TMPDIR}/bats-helpers-mock` and puts that directory first on `PATH`, so BATS removes the mocks together with the rest of the test sandbox and concurrent runs cannot delete each other's mocks.
 
@@ -850,6 +851,89 @@ teardown() {
 ```
 
 With no arguments it verifies every mock of the test; with arguments it verifies only the mocks named. The [step runner](#step-runner) calls it for its own mocks at the end of the assert phase.
+
+#### Sandbox mode
+
+Mocks are prepended to `PATH`, so a command the test forgot to mock resolves to the real one on the machine. A test that misses a network call, a package manager or a destructive command runs it for real, slowly and non-hermetically. Sandbox mode replaces `PATH` with the mock directory and a directory of the commands the test allowed, so a command that is neither mocked nor allowed does not run:
+
+```bash
+setup() {
+  mock_setup
+  mock_sandbox_enable
+}
+
+@test "Deploy" {
+  mock_command "curl" >/dev/null
+
+  run ./deploy.sh
+
+  # 'curl' is answered by its mock. An unmocked 'aws' fails the call with
+  # "Command 'aws' is not mocked and the mock sandbox is enabled." instead of
+  # reaching the real one.
+}
+```
+
+| Function                          | Description                                                     | Arguments        | Returns |
+|-----------------------------------|-----------------------------------------------------------------|------------------|---------|
+| `mock_sandbox_enable`             | Enables the mode. Arguments seed the allow-list                 | `[command...]`   | None    |
+| `mock_sandbox_allow`              | Allows commands to run for real                                 | `command...`     | None    |
+| `mock_sandbox_disable`            | Restores the `PATH` saved when the mode was enabled             | None             | None    |
+| `mock_sandbox_enabled`            | Reports whether the mode is enabled                             | None             | `0` when enabled |
+| `mock_sandbox_report`             | Prints the denied and the escaped commands                      | `[kind]`         | Report  |
+| `mock_path_check`                 | Warns when `PATH` changed after `mock_setup`                    | None             | None    |
+
+The mode is off until `mock_sandbox_enable` is called, so a suite that does not call it is unaffected. Calling it from `setup` turns it on for a whole file, and `mock_sandbox_disable` reopens the real `PATH` mid-test. BATS runs each test in its own process, so nothing has to be restored at the end of one.
+
+> [!WARNING]
+> This is not a security boundary. An absolute path reaches the real command whatever `PATH` holds, so `/usr/bin/curl` and `./script.sh` still run. The mode catches the command a test forgot to mock, not a command determined to run.
+
+#### Allowing a command to run for real
+
+Some commands have to run: a `date` the test cannot predict, a `tar` that has to produce a real archive. `mock_sandbox_allow` puts them back within reach, and every call reaching one is recorded so that it stays visible:
+
+```bash
+mock_sandbox_enable "date" "tar"
+
+# The same, after the fact.
+mock_sandbox_allow "git"
+```
+
+An allowed command has to have a file on `PATH` when it is allowed, so a typo is reported at that line rather than as a puzzling failure later. A shell builtin never needs allowing: the shell answers it without a `PATH` lookup, so the mode never denies it.
+
+The commands the library itself runs stay available, because the assertions, the file helpers and the generated mocks are built out of them: `bash`, `cat`, `chmod`, `cp`, `diff`, `dirname`, `find`, `grep`, `head`, `id`, `ln`, `ls`, `mkdir`, `rm`, `sed`, `stat`, `touch` and `wc`. Mocking one of them shadows the sandbox entry, since the mock directory still comes first on `PATH`. `git` and `tar` are deliberately not in that set, so [git assertions](#git-assertions) and `fixture_export_codebase` need them allowed to run inside the mode.
+
+A [forwarding mock](#argument-specifications) reaches the real command the same way, so `mock_set_forward` inside the sandbox needs its command allowed as well.
+
+#### What escaped
+
+`mock_sandbox_report` names every command that left the mock boundary, each one once, in the order they were first seen:
+
+```text
+Command 'aws' is not mocked and the mock sandbox denied it
+Command 'date' ran for real, allowed by the mock sandbox
+```
+
+Pass `denied` or `allowed` to print one kind alone. `mock_verify` reads both: a denied command fails the verification, because it is a hole in the test, while an allowed one is printed to file descriptor 3, because it ran as the test asked and only has to stay visible.
+
+```bash
+teardown() {
+  mock_verify
+}
+```
+
+Without that call a script that swallows the failed command's exit status leaves the test passing, so wire `mock_verify` up whenever the mode is on.
+
+The message reaches a Bash script under test, not only the test shell, because the mode installs an exported `command_not_found_handle`. A lookup that never consults it - `exec`, a compiled program starting a child, or a shell that does not implement the hook - fails with a plain `command not found` and exit status `127`, and leaves no entry in the report.
+
+#### When PATH is rewritten
+
+Code under test that rewrites `PATH` disables the mocking silently, and the test then passes while exercising the real system - the same failure the sandbox exists to prevent, arriving through a different door. `mock_setup` records the `PATH` it produced and `mock_verify` compares it, so the rewrite is reported rather than left to be guessed at:
+
+```text
+Warning: 'PATH' changed after 'mock_setup' and no longer holds the mock directory '/.../bats-helpers-mock'. Mocked commands are not found and the real commands run instead.
+```
+
+A change that leaves the mock directory in place is reported too, in its own words, since the mocks still answer but everything else may resolve differently. Both go to file descriptor 3, alongside the deprecation notices, and neither fails the test on its own. `mock_path_check` performs the same check on demand.
 
 #### Example
 
@@ -1438,6 +1522,7 @@ Every variable the library defines, in one place. Each is also covered by the se
 | `BATS_HELPERS_MOCK_TMPDIR`                     | `mock_setup`, `mock_create`                                   | Directory the mocks are written below. Defaults to `${BATS_TEST_TMPDIR}`, and `mock_setup` exports the resolved path |
 | `BATS_HELPERS_MOCK_USER`                       | `mock_get_call_user`                                          | User a mock call is reported as. Defaults to `id -un`                                       |
 | `BATS_HELPERS_MOCK_STRICT`                     | `mock_create`                                                 | Set to `0` to answer the calls a mock's expectations do not cover. Defaults to `1`, and is read when the mock is created |
+| `BATS_HELPERS_MOCK_SANDBOX_REPORT`             | `mock_sandbox_deny`                                           | Path to the sandbox report. Exported by `mock_sandbox_enable` so that a denial recorded in a child process reaches it |
 | `BATS_HELPERS_REPORT_COLOR`                    | `format_error`                                                | `0` to never colour a diff, `1` to colour it whenever `diff` supports the flag. Unset or empty defers to `NO_COLOR` |
 | `BATS_HELPERS_DEPRECATION_QUIET`               | every module                                                  | Set to any non-empty value to silence every deprecation notice                              |
 

--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ setup() {
   run ./deploy.sh
 
   # 'curl' is answered by its mock. An unmocked 'aws' fails the call with
-  # "Command 'aws' is not mocked and the mock sandbox is enabled." instead of
+  # "Command 'aws' is not mocked and the mock sandbox is enabled" instead of
   # reaching the real one.
 }
 ```

--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@ mock_sandbox_allow "git"
 
 An allowed command has to have a file on `PATH` when it is allowed, so a typo is reported at that line rather than as a puzzling failure later. A shell builtin never needs allowing: the shell answers it without a `PATH` lookup, so the mode never denies it.
 
-The commands the library itself runs stay available, because the assertions, the file helpers and the generated mocks are built out of them: `bash`, `cat`, `chmod`, `cp`, `diff`, `dirname`, `find`, `grep`, `head`, `id`, `ln`, `ls`, `mkdir`, `rm`, `sed`, `stat`, `touch` and `wc`. Mocking one of them shadows the sandbox entry, since the mock directory still comes first on `PATH`. `git` and `tar` are deliberately not in that set, so [git assertions](#git-assertions) and `fixture_export_codebase` need them allowed to run inside the mode.
+The commands the library and the BATS harness run stay available, because the assertions, the file helpers, the generated mocks and `run` itself are built out of them: `bash`, `cat`, `chmod`, `cp`, `diff`, `dirname`, `find`, `grep`, `head`, `id`, `ln`, `ls`, `mkdir`, `mktemp`, `rm`, `sed`, `stat`, `touch` and `wc`. Mocking one of them shadows the sandbox entry, since the mock directory still comes first on `PATH`. `git` and `tar` are deliberately not in that set, so [git assertions](#git-assertions) and `fixture_export_codebase` need them allowed to run inside the mode.
 
 A [forwarding mock](#argument-specifications) reaches the real command the same way, so `mock_set_forward` inside the sandbox needs its command allowed as well.
 

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -1249,8 +1249,8 @@ mock_strict_reject() {
 ## mocked nor allowed does not run.
 ##
 ## This is not a security boundary. An absolute path reaches the real command
-## whatever PATH holds, and the commands the library itself runs stay available
-## so that the library keeps working inside the mode.
+## whatever PATH holds, and the commands the library and the BATS harness run
+## stay available so that both keep working inside the mode.
 ##
 
 ##
@@ -1276,8 +1276,8 @@ mock_sandbox_enable() {
     return 1
   fi
 
-  # The real PATH is saved once, so that enabling an already-enabled sandbox
-  # records the sandbox over the value it has to be restored to.
+  # The value is saved once, so that enabling an already-enabled sandbox does
+  # not record the sandbox over the PATH it has to be restored to.
   [ -e "${sandbox}/path" ] || printf '%s\n' "${PATH}" >"${sandbox}/path"
 
   mock_sandbox_link_base "${sandbox}/bin" || return 1
@@ -1371,8 +1371,6 @@ mock_sandbox_disable() {
   export -fn mock_sandbox_deny
   unset BATS_HELPERS_MOCK_SANDBOX_REPORT
 
-  # The report outlives the mode, so that it is still readable from a teardown
-  # that runs after the test restored PATH.
   mock_path_record
 }
 
@@ -1487,7 +1485,7 @@ mock_sandbox_base_commands() {
 }
 
 ##
-# Links the commands the library itself runs into the sandbox.
+# Links the commands the library and the BATS harness run into the sandbox.
 #
 # Arguments:
 #   1. bin: Directory to link them into.

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -1471,19 +1471,19 @@ mock_sandbox_deny() {
 }
 
 ##
-# Writes the commands the library itself runs.
+# Writes the commands the library and the BATS harness run.
 #
 # These stay available inside the sandbox, so that the assertions, the file
-# helpers and the generated mocks keep working there. A test that needs one of
-# them denied mocks it: the mock directory comes first on PATH and shadows the
-# link. 'git' and 'tar' are left out, because a mode that allows them by
-# default answers none of the questions it exists to answer.
+# helpers, the generated mocks and 'run' itself keep working there. A test that
+# needs one of them denied mocks it: the mock directory comes first on PATH and
+# shadows the link. 'git' and 'tar' are left out, because a mode that allows
+# them by default answers none of the questions it exists to answer.
 #
 # Outputs:
 #   STDOUT: The command names, separated by spaces.
 ##
 mock_sandbox_base_commands() {
-  echo 'bash cat chmod cp diff dirname find grep head id ln ls mkdir rm sed stat touch wc'
+  echo 'bash cat chmod cp diff dirname find grep head id ln ls mkdir mktemp rm sed stat touch wc'
 }
 
 ##

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -1477,7 +1477,7 @@ mock_sandbox_deny() {
     printf 'denied %s\n' "${name}" >>"${BATS_HELPERS_MOCK_SANDBOX_REPORT}"
   fi
 
-  printf "Command '%s' is not mocked and the mock sandbox is enabled.\n" "${name}" >&2
+  printf "Command '%s' is not mocked and the mock sandbox is enabled\n" "${name}" >&2
 
   return 127
 }

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -14,7 +14,7 @@
 # shellcheck disable=SC1090
 
 ##
-## Sandbox.
+## Mock directory.
 ##
 
 ##
@@ -34,6 +34,8 @@ mock_setup() {
   # The mock directory goes first so that a mocked name is found ahead of the
   # real command. Bats restores PATH after the test, so this reaches no further.
   PATH="${BATS_HELPERS_MOCK_TMPDIR}:${PATH}"
+
+  mock_path_record
 }
 
 ##
@@ -84,6 +86,73 @@ mock_prepare_tmp() {
   mkdir -p "${dir}/bats-helpers-mock" || return 1
 
   echo "${dir}/bats-helpers-mock"
+}
+
+##
+# Records the PATH that the mocks are found on.
+#
+# Globals:
+#   PATH: Written to the record so that a later change to it is detectable.
+##
+mock_path_record() {
+  local dir
+  dir="$(mock_resolve_tmp)" || return 1
+
+  printf '%s\n' "${PATH}" >"${dir}/.path"
+}
+
+##
+# Warns when PATH changed after the mocks were put on it.
+#
+# Code under test that rewrites PATH disables the mocking silently: the test
+# then passes while exercising the real system, which is the failure this
+# reports.
+#
+# Outputs:
+#   File descriptor 3: The warning, when PATH no longer matches the record.
+#
+# Returns:
+#   0 always. The change is reported as a warning rather than by the exit
+#   status, so that a caller can report it without failing on it.
+##
+mock_path_check() {
+  local dir
+  dir="$(mock_resolve_tmp)" || return 1
+
+  local record="${dir}/.path"
+  [ -e "${record}" ] || return 0
+
+  local recorded
+  recorded="$(cat "${record}")"
+
+  [ "${recorded}" = "${PATH}" ] && return 0
+
+  if mock_path_contains "${dir}"; then
+    echo "Warning: 'PATH' changed after 'mock_setup'. The mocks are still found, but a command the test did not mock may resolve differently." >&3
+    return 0
+  fi
+
+  echo "Warning: 'PATH' changed after 'mock_setup' and no longer holds the mock directory '${dir}'. Mocked commands are not found and the real commands run instead." >&3
+}
+
+##
+# Reports whether a directory is on PATH.
+#
+# Arguments:
+#   1. dir: Directory to look for.
+##
+mock_path_contains() {
+  local dir="${1}"
+
+  local -a entries=()
+  IFS=':' read -ra entries <<<"${PATH}"
+
+  local entry
+  for entry in "${entries[@]}"; do
+    [ "${entry}" = "${dir}" ] && return 0
+  done
+
+  return 1
 }
 
 ##
@@ -1014,16 +1083,18 @@ mock_forward_exec() {
 #
 # Arguments:
 #   1. dir: Directory to remove.
+#   2. path: Value to remove it from. Optional, defaults to the current PATH.
 #
 # Outputs:
 #   STDOUT: The remaining PATH entries.
 ##
 mock_forward_path() {
   local dir="${1}"
+  local path="${2-${PATH}}"
   local -a entries=()
   local -a kept=()
 
-  IFS=':' read -ra entries <<<"${PATH}"
+  IFS=':' read -ra entries <<<"${path}"
 
   local entry
   for entry in "${entries[@]}"; do
@@ -1168,6 +1239,340 @@ mock_strict_reject() {
   mock_spec_describe_all "${mock}" >&2
 
   printf '%s\n' "${line}" >>"${mock}.unexpected"
+}
+
+##
+## Sandbox mode.
+##
+## Off until a test enables it. Once enabled, PATH holds the mock directory and
+## a directory of the commands the test allowed, so a command the test neither
+## mocked nor allowed does not run.
+##
+## This is not a security boundary. An absolute path reaches the real command
+## whatever PATH holds, and the commands the library itself runs stay available
+## so that the library keeps working inside the mode.
+##
+
+##
+# Enables the sandbox mode for the current test.
+#
+# Arguments:
+#   1+. command: Commands that must run for real, as 'mock_sandbox_allow' takes
+#       them. Optional.
+#
+# Globals:
+#   PATH: Replaced with the mock directory and the sandbox directory.
+#   BATS_HELPERS_MOCK_SANDBOX_REPORT: Exported with the path to the report, so
+#     that the denial reaches it from whichever process hit the failed lookup.
+##
+mock_sandbox_enable() {
+  local dir
+  dir="$(mock_resolve_tmp)" || return 1
+
+  local sandbox="${dir}/.sandbox"
+
+  if ! mkdir -p "${sandbox}/bin"; then
+    flunk "Sandbox directory '${sandbox}/bin' cannot be created."
+    return 1
+  fi
+
+  # The real PATH is saved once, so that enabling an already-enabled sandbox
+  # records the sandbox over the value it has to be restored to.
+  [ -e "${sandbox}/path" ] || printf '%s\n' "${PATH}" >"${sandbox}/path"
+
+  mock_sandbox_link_base "${sandbox}/bin" || return 1
+
+  if [ "$#" -gt 0 ]; then
+    mock_sandbox_allow "$@" || return 1
+  fi
+
+  BATS_HELPERS_MOCK_SANDBOX_REPORT="${sandbox}/report"
+  export BATS_HELPERS_MOCK_SANDBOX_REPORT
+
+  # Bash consults this on every failed lookup. It is defined here rather than at
+  # file scope so that loading the library leaves the shell's lookups alone, and
+  # exported so that a Bash script under test reports the same way the test
+  # shell does.
+  command_not_found_handle() { mock_sandbox_deny "$@"; }
+  export -f mock_sandbox_deny
+  export -f command_not_found_handle
+
+  PATH="${dir}:${sandbox}/bin"
+
+  mock_path_record
+}
+
+##
+# Allows commands to run for real inside the sandbox.
+#
+# Each call reaching an allowed command is recorded as an escape, so that
+# 'mock_sandbox_report' names what left the mock boundary.
+#
+# Arguments:
+#   1+. command: Command names.
+##
+mock_sandbox_allow() {
+  if [ "$#" -eq 0 ]; then
+    flunk "At least one command name is required."
+    return 1
+  fi
+
+  local dir
+  dir="$(mock_resolve_tmp)" || return 1
+
+  local sandbox="${dir}/.sandbox"
+
+  if ! mkdir -p "${sandbox}/bin"; then
+    flunk "Sandbox directory '${sandbox}/bin' cannot be created."
+    return 1
+  fi
+
+  local real_path
+  real_path="$(mock_sandbox_real_path)" || return 1
+
+  local name
+  local real
+  for name in "$@"; do
+    # 'type -P' searches PATH even when a builtin or a function carries the same
+    # name, which is what the shim needs: a file to hand the call to.
+    real="$(PATH="${real_path}" type -P "${name}")" || real=""
+
+    case "${real}" in
+      /*) ;;
+      *)
+        flunk "Command '${name}' cannot be allowed: it is not on 'PATH'."
+        return 1
+        ;;
+    esac
+
+    mock_sandbox_write_shim "${sandbox}/bin/${name}" "${name}" "${real}" "${sandbox}/report"
+    chmod +x "${sandbox}/bin/${name}"
+  done
+}
+
+##
+# Disables the sandbox mode and restores PATH.
+##
+mock_sandbox_disable() {
+  local dir
+  dir="$(mock_resolve_tmp)" || return 1
+
+  local saved="${dir}/.sandbox/path"
+
+  if [ ! -e "${saved}" ]; then
+    flunk "Mock sandbox is not enabled. Enable it with 'mock_sandbox_enable' first."
+    return 1
+  fi
+
+  PATH="$(cat "${saved}")"
+  rm -f "${saved}"
+
+  unset -f command_not_found_handle
+  export -fn mock_sandbox_deny
+  unset BATS_HELPERS_MOCK_SANDBOX_REPORT
+
+  # The report outlives the mode, so that it is still readable from a teardown
+  # that runs after the test restored PATH.
+  mock_path_record
+}
+
+##
+# Reports whether the sandbox mode is enabled.
+##
+mock_sandbox_enabled() {
+  local dir
+  dir="$(mock_resolve_tmp)" || return 1
+
+  [ -e "${dir}/.sandbox/path" ]
+}
+
+##
+# Prints what left the mock boundary.
+#
+# Arguments:
+#   1. kind: 'denied' for the commands the sandbox did not resolve, 'allowed'
+#      for the ones it let run for real. Optional, defaults to both.
+#
+# Outputs:
+#   STDOUT: One line per command, each named once, in the order the commands
+#           were first seen.
+##
+mock_sandbox_report() {
+  local kind="${1-}"
+
+  case "${kind}" in
+    '' | denied | allowed) ;;
+    *)
+      flunk "Kind '${kind}' is not known. Use 'denied' or 'allowed'."
+      return 1
+      ;;
+  esac
+
+  local dir
+  dir="$(mock_resolve_tmp)" || return 1
+
+  local report="${dir}/.sandbox/report"
+  [ -e "${report}" ] || return 0
+
+  local -a seen=()
+  local line
+  local entry
+  local skip
+
+  while IFS= read -r line; do
+    [ -n "${kind}" ] && [ "${line%% *}" != "${kind}" ] && continue
+
+    skip=0
+    for entry in "${seen[@]}"; do
+      [ "${entry}" = "${line}" ] && skip=1
+    done
+
+    [ "${skip}" = "1" ] && continue
+
+    seen+=("${line}")
+
+    case "${line}" in
+      denied\ *) echo "Command '${line#denied }' is not mocked and the mock sandbox denied it" ;;
+      *) echo "Command '${line#allowed }' ran for real, allowed by the mock sandbox" ;;
+    esac
+  done <"${report}"
+
+  return 0
+}
+
+##
+# Records a command the sandbox did not resolve and reports it.
+#
+# Runs in whichever process hit the failed lookup, where the library is not
+# loaded, so it uses builtins alone and must never call 'flunk'.
+#
+# Arguments:
+#   1. name: Command name.
+#
+# Globals:
+#   BATS_HELPERS_MOCK_SANDBOX_REPORT: Path to the report.
+#
+# Outputs:
+#   STDERR: A diagnostic naming the command.
+#
+# Returns:
+#   127 always, the status of a command that was not found.
+##
+mock_sandbox_deny() {
+  local name="${1}"
+
+  if [ -n "${BATS_HELPERS_MOCK_SANDBOX_REPORT-}" ]; then
+    printf 'denied %s\n' "${name}" >>"${BATS_HELPERS_MOCK_SANDBOX_REPORT}"
+  fi
+
+  printf "Command '%s' is not mocked and the mock sandbox is enabled.\n" "${name}" >&2
+
+  return 127
+}
+
+##
+# Writes the commands the library itself runs.
+#
+# These stay available inside the sandbox, so that the assertions, the file
+# helpers and the generated mocks keep working there. A test that needs one of
+# them denied mocks it: the mock directory comes first on PATH and shadows the
+# link. 'git' and 'tar' are left out, because a mode that allows them by
+# default answers none of the questions it exists to answer.
+#
+# Outputs:
+#   STDOUT: The command names, separated by spaces.
+##
+mock_sandbox_base_commands() {
+  echo 'bash cat chmod cp diff dirname find grep head id ln ls mkdir rm sed stat touch wc'
+}
+
+##
+# Links the commands the library itself runs into the sandbox.
+#
+# Arguments:
+#   1. bin: Directory to link them into.
+##
+mock_sandbox_link_base() {
+  local bin="${1}"
+
+  local real_path
+  real_path="$(mock_sandbox_real_path)" || return 1
+
+  local -a names=()
+  read -ra names <<<"$(mock_sandbox_base_commands)"
+
+  local name
+  local real
+  for name in "${names[@]}"; do
+    # An allowed command reports what it lets through, so its shim is not
+    # replaced by a link that would let the same command through silently.
+    [ -e "${bin}/${name}" ] && continue
+
+    real="$(PATH="${real_path}" type -P "${name}")" || real=""
+
+    # A command the machine does not have is nothing to link.
+    case "${real}" in
+      /*) ln -sf "${real}" "${bin}/${name}" ;;
+    esac
+  done
+
+  return 0
+}
+
+##
+# Writes the PATH that the real commands are found on.
+#
+# The mock directory is dropped from it, so that a command which is both mocked
+# and allowed resolves to the real command rather than back into its own mock.
+#
+# Outputs:
+#   STDOUT: The PATH saved when the sandbox was enabled, else the current one,
+#           in both cases without the mock directory.
+##
+mock_sandbox_real_path() {
+  local dir
+  dir="$(mock_resolve_tmp)" || return 1
+
+  local saved="${dir}/.sandbox/path"
+  local path="${PATH}"
+
+  [ -e "${saved}" ] && path="$(cat "${saved}")"
+
+  mock_forward_path "${dir}" "${path}"
+}
+
+##
+# Writes the script that runs an allowed command and records the escape.
+#
+# Arguments:
+#   1. shim: Path to write the script to.
+#   2. name: Command name.
+#   3. real: Path to the real command.
+#   4. report: Path to the report.
+##
+mock_sandbox_write_shim() {
+  local shim="${1}"
+  local name="${2}"
+  local real="${3}"
+  local report="${4}"
+
+  # Every value is quoted for the shell rather than interpolated raw, for the
+  # same reason 'mock_write' quotes: the directory holding them is
+  # consumer-supplied through BATS_HELPERS_MOCK_TMPDIR.
+  local name_quoted
+  local real_quoted
+  local report_quoted
+  printf -v name_quoted '%q' "${name}"
+  printf -v real_quoted '%q' "${real}"
+  printf -v report_quoted '%q' "${report}"
+
+  cat <<EOF >"${shim}"
+#!/usr/bin/env bash
+
+printf 'allowed %s\n' ${name_quoted} >>${report_quoted}
+
+exec ${real_quoted} "\$@"
+EOF
 }
 
 ##
@@ -1650,8 +2055,15 @@ mock_assert_not_called() {
 ##
 # Asserts that every expectation of every mock was met.
 #
+# The sandbox is a property of the test rather than of one mock, so its report
+# is covered whichever mocks are named.
+#
 # Arguments:
 #   1+. Mocks to verify. Optional, defaults to every mock of the test.
+#
+# Outputs:
+#   File descriptor 3: The commands the sandbox allowed to run for real, and
+#     the warning that PATH changed after 'mock_setup'.
 ##
 mock_verify() {
   local -a mocks=()
@@ -1678,6 +2090,19 @@ mock_verify() {
       problems+=("${problem}")
     done < <(mock_verify_mock "${mock}")
   done
+
+  mock_path_check
+
+  # A denied command is a hole in the test, so it fails the verification. An
+  # allowed one ran as the test asked it to and only has to stay visible.
+  while IFS= read -r problem; do
+    problems+=("${problem}")
+  done < <(mock_sandbox_report 'denied')
+
+  local escape
+  while IFS= read -r escape; do
+    echo "${escape}" >&3
+  done < <(mock_sandbox_report 'allowed')
 
   [ "${#problems[@]}" -eq 0 ] && return 0
 

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -108,6 +108,9 @@ mock_path_record() {
 # then passes while exercising the real system, which is the failure this
 # reports.
 #
+# Globals:
+#   PATH: Compared against the record.
+#
 # Outputs:
 #   File descriptor 3: The warning, when PATH no longer matches the record.
 #
@@ -133,6 +136,8 @@ mock_path_check() {
   fi
 
   echo "Warning: 'PATH' changed after 'mock_setup' and no longer holds the mock directory '${dir}'. Mocked commands are not found and the real commands run instead." >&3
+
+  return 0
 }
 
 ##
@@ -140,6 +145,9 @@ mock_path_check() {
 #
 # Arguments:
 #   1. dir: Directory to look for.
+#
+# Globals:
+#   PATH: Searched for the directory.
 ##
 mock_path_contains() {
   local dir="${1}"
@@ -1293,6 +1301,7 @@ mock_sandbox_enable() {
   # file scope so that loading the library leaves the shell's lookups alone, and
   # exported so that a Bash script under test reports the same way the test
   # shell does.
+  # shellcheck disable=SC2329 # Bash calls this itself on a failed lookup.
   command_not_found_handle() { mock_sandbox_deny "$@"; }
   export -f mock_sandbox_deny
   export -f command_not_found_handle
@@ -1351,7 +1360,12 @@ mock_sandbox_allow() {
 }
 
 ##
-# Disables the sandbox mode and restores PATH.
+# Disables the sandbox mode.
+#
+# Globals:
+#   PATH: Restored to the value saved when the mode was enabled.
+#   BATS_HELPERS_MOCK_SANDBOX_REPORT: Unset. The report itself is kept, so that
+#     'mock_verify' still reads it from a teardown.
 ##
 mock_sandbox_disable() {
   local dir
@@ -1522,6 +1536,9 @@ mock_sandbox_link_base() {
 #
 # The mock directory is dropped from it, so that a command which is both mocked
 # and allowed resolves to the real command rather than back into its own mock.
+#
+# Globals:
+#   PATH: Used when the sandbox has no saved value yet.
 #
 # Outputs:
 #   STDOUT: The PATH saved when the sandbox was enabled, else the current one,

--- a/tests/mock.bats
+++ b/tests/mock.bats
@@ -1036,6 +1036,309 @@ bats_require_minimum_version 1.13.0
 }
 
 ##
+## Sandbox mode.
+##
+## Every test here disables the sandbox before it ends, so that the assertions
+## that follow and BATS' own bookkeeping run with the real PATH.
+##
+
+@test "mock_sandbox_enable" {
+  mock_command "curl" >/dev/null
+
+  mock_sandbox_enable
+
+  run curl --version
+  assert_success
+
+  # 'run -127' stops bats warning about the status it would otherwise read as a
+  # mistake in the test.
+  run -127 definitely_not_a_real_command
+  mock_sandbox_disable
+
+  assert_failure --status 127
+  assert_output_contains "Command 'definitely_not_a_real_command' is not mocked and the mock sandbox is enabled."
+}
+
+@test "mock_sandbox_enable - the library keeps working inside the sandbox" {
+  mock_command "curl" >/dev/null
+
+  mock_sandbox_enable
+
+  curl --version
+
+  # 'diff', 'cat' and 'sed' back these three, so passing here is what proves the
+  # commands the library itself runs stayed available.
+  mock_assert_calls "curl '--version'"
+  mock_verify
+
+  run assert_equal "one" "two"
+  mock_sandbox_disable
+
+  assert_failure
+}
+
+@test "mock_sandbox_enable - the allow-list can be seeded" {
+  mock_sandbox_enable "basename"
+
+  run basename "${BATS_TEST_TMPDIR}/real.txt"
+  mock_sandbox_disable
+
+  assert_success
+  assert_output "real.txt"
+}
+
+@test "mock_sandbox_allow" {
+  mock_sandbox_enable
+
+  run -127 basename "${BATS_TEST_TMPDIR}/real.txt"
+  assert_failure --status 127
+
+  mock_sandbox_allow "basename"
+
+  run basename "${BATS_TEST_TMPDIR}/real.txt"
+  mock_sandbox_disable
+
+  assert_success
+  assert_output "real.txt"
+
+  run mock_sandbox_report
+  assert_success
+  assert_output_contains "Command 'basename' is not mocked and the mock sandbox denied it"
+  assert_output_contains "Command 'basename' ran for real, allowed by the mock sandbox"
+}
+
+@test "mock_sandbox_allow - an allowed command is not replaced by a silent link" {
+  echo "content" >"${BATS_TEST_TMPDIR}/file.txt"
+
+  # 'cat' is one of the commands the library itself runs, so enabling the
+  # sandbox after it was allowed has a shim to leave alone.
+  mock_sandbox_allow "cat"
+  mock_sandbox_enable
+
+  run cat "${BATS_TEST_TMPDIR}/file.txt"
+  mock_sandbox_disable
+
+  assert_success
+  assert_output "content"
+
+  run mock_sandbox_report 'allowed'
+  assert_success
+  assert_output_contains "Command 'cat' ran for real, allowed by the mock sandbox"
+}
+
+@test "mock_sandbox_allow - validation" {
+  run mock_sandbox_allow
+  assert_failure
+  assert_output_contains "At least one command name is required."
+
+  run mock_sandbox_allow "definitely_not_a_real_command"
+  assert_failure
+  assert_output_contains "Command 'definitely_not_a_real_command' cannot be allowed: it is not on 'PATH'."
+}
+
+@test "mock_sandbox_disable" {
+  path_before="${PATH}"
+
+  mock_sandbox_enable
+  mock_sandbox_disable
+
+  assert_equal "${path_before}" "${PATH}"
+
+  # The handler is gone, so the shell reports the failed lookup in its own words.
+  run -127 definitely_not_a_real_command
+  assert_failure --status 127
+  assert_output_not_contains "the mock sandbox is enabled"
+
+  run mock_sandbox_disable
+  assert_failure
+  assert_output_contains "Mock sandbox is not enabled. Enable it with 'mock_sandbox_enable' first."
+}
+
+@test "mock_sandbox_enabled" {
+  run mock_sandbox_enabled
+  assert_failure
+
+  mock_sandbox_enable
+  mock_sandbox_enabled
+  mock_sandbox_disable
+
+  run mock_sandbox_enabled
+  assert_failure
+}
+
+@test "mock_sandbox_report" {
+  run mock_sandbox_report
+  assert_success
+  assert_output ""
+
+  run mock_sandbox_report "elsewhere"
+  assert_failure
+  assert_output_contains "Kind 'elsewhere' is not known. Use 'denied' or 'allowed'."
+
+  mock_sandbox_enable
+
+  run -127 definitely_not_a_real_command
+  run -127 definitely_not_a_real_command
+  mock_sandbox_disable
+
+  # Named once, however many times it was called.
+  run mock_sandbox_report 'denied'
+  assert_success
+  assert_output "Command 'definitely_not_a_real_command' is not mocked and the mock sandbox denied it"
+
+  run mock_sandbox_report 'allowed'
+  assert_success
+  assert_output ""
+}
+
+@test "mock_sandbox_deny" {
+  # Without a report to write to, the diagnostic still names the command.
+  run -127 mock_sandbox_deny "curl"
+  assert_failure --status 127
+  assert_output_contains "Command 'curl' is not mocked and the mock sandbox is enabled."
+
+  mock_sandbox_enable
+
+  run -127 mock_sandbox_deny "curl"
+  mock_sandbox_disable
+
+  assert_failure --status 127
+
+  run mock_sandbox_report 'denied'
+  assert_success
+  assert_output "Command 'curl' is not mocked and the mock sandbox denied it"
+}
+
+@test "mock_sandbox_real_path" {
+  assert_equal "$(mock_forward_path "${BATS_HELPERS_MOCK_TMPDIR}")" "$(mock_sandbox_real_path)"
+
+  path_before="${PATH}"
+
+  mock_sandbox_enable
+  real_path="$(mock_sandbox_real_path)"
+  mock_sandbox_disable
+
+  assert_equal "$(mock_forward_path "${BATS_HELPERS_MOCK_TMPDIR}" "${path_before}")" "${real_path}"
+}
+
+@test "mock_sandbox_link_base - a command the machine does not have is skipped" {
+  mkdir -p "${BATS_HELPERS_MOCK_TMPDIR}/.sandbox/bin"
+  echo "" >"${BATS_HELPERS_MOCK_TMPDIR}/.sandbox/path"
+
+  mock_sandbox_link_base "${BATS_HELPERS_MOCK_TMPDIR}/.sandbox/bin"
+
+  assert_dir_empty "${BATS_HELPERS_MOCK_TMPDIR}/.sandbox/bin"
+
+  # PATH was never replaced here, so only the saved value has to go back.
+  rm -f "${BATS_HELPERS_MOCK_TMPDIR}/.sandbox/path"
+}
+
+@test "The sandbox reaches a Bash script under test" {
+  script="${BATS_TEST_TMPDIR}/script.sh"
+  echo '#!/usr/bin/env bash' >"${script}"
+  echo 'definitely_not_a_real_command' >>"${script}"
+  chmod +x "${script}"
+
+  mock_sandbox_enable
+
+  run -127 "${script}"
+  mock_sandbox_disable
+
+  assert_failure --status 127
+  assert_output_contains "Command 'definitely_not_a_real_command' is not mocked and the mock sandbox is enabled."
+
+  run mock_sandbox_report 'denied'
+  assert_success
+  assert_output "Command 'definitely_not_a_real_command' is not mocked and the mock sandbox denied it"
+}
+
+@test "A forwarding mock inside the sandbox needs the command allowed" {
+  mock_basename="$(mock_command "basename")"
+  mock_set_forward "${mock_basename}"
+
+  spec="$(mock_spec_add "${mock_basename}")"
+  mock_spec_arg "${spec}" 1 equals "mocked"
+  mock_spec_set_output "${spec}" "from the mock"
+
+  mock_sandbox_enable
+
+  run -127 basename "${BATS_TEST_TMPDIR}/real.txt"
+  assert_failure --status 127
+  assert_output_contains "is not available to forward to"
+
+  mock_sandbox_allow "basename"
+
+  # The command is both mocked and allowed, so the shim has to hold the real
+  # command rather than the mock that would hand the call straight back to it.
+  assert_file_not_contains "${BATS_HELPERS_MOCK_TMPDIR}/.sandbox/bin/basename" "${BATS_HELPERS_MOCK_TMPDIR}/mock."
+
+  run basename "${BATS_TEST_TMPDIR}/real.txt"
+  mock_sandbox_disable
+
+  assert_success
+  assert_output "real.txt"
+}
+
+@test "mock_verify - a denied command fails the verification" {
+  mock_sandbox_enable
+
+  run -127 definitely_not_a_real_command
+  mock_sandbox_disable
+
+  run mock_verify
+  assert_failure
+  assert_output_contains "Command 'definitely_not_a_real_command' is not mocked and the mock sandbox denied it"
+}
+
+@test "mock_verify - an allowed command is reported without failing" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  mock_sandbox_enable "basename"
+
+  basename "${BATS_TEST_TMPDIR}/real.txt" >/dev/null
+
+  mock_sandbox_disable
+
+  mock_verify 3>"${notice}"
+
+  assert_file_contains "${notice}" "Command 'basename' ran for real, allowed by the mock sandbox"
+}
+
+@test "mock_path_check" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  mock_path_check 3>"${notice}"
+  assert_equal "" "$(cat "${notice}")"
+
+  PATH="${PATH}:${BATS_TEST_TMPDIR}/extra"
+  mock_path_check 3>"${notice}"
+  assert_file_contains "${notice}" "Warning: 'PATH' changed after 'mock_setup'. The mocks are still found, but a command the test did not mock may resolve differently."
+
+  PATH="/usr/bin:/bin"
+  mock_path_check 3>"${notice}"
+  assert_file_contains "${notice}" "and no longer holds the mock directory"
+  assert_file_contains "${notice}" "Mocked commands are not found and the real commands run instead."
+}
+
+@test "mock_path_check - without a record" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+
+  rm -f "${BATS_HELPERS_MOCK_TMPDIR}/.path"
+  PATH="/usr/bin:/bin"
+
+  mock_path_check 3>"${notice}"
+
+  assert_equal "" "$(cat "${notice}")"
+}
+
+@test "mock_path_contains" {
+  mock_path_contains "${BATS_HELPERS_MOCK_TMPDIR}"
+
+  run mock_path_contains "${BATS_TEST_TMPDIR}/not-on-path"
+  assert_failure
+}
+
+##
 ## Call log.
 ##
 

--- a/tests/mock.bats
+++ b/tests/mock.bats
@@ -1239,7 +1239,11 @@ bats_require_minimum_version 1.13.0
 
 @test "mock_sandbox_link_base - a command the machine does not have is skipped" {
   mkdir -p "${BATS_HELPERS_MOCK_TMPDIR}/.sandbox/bin"
-  echo "" >"${BATS_HELPERS_MOCK_TMPDIR}/.sandbox/path"
+  mkdir -p "${BATS_TEST_TMPDIR}/empty"
+
+  # A directory holding nothing resolves no command, where an empty PATH would
+  # resolve the working directory instead.
+  echo "${BATS_TEST_TMPDIR}/empty" >"${BATS_HELPERS_MOCK_TMPDIR}/.sandbox/path"
 
   mock_sandbox_link_base "${BATS_HELPERS_MOCK_TMPDIR}/.sandbox/bin"
 
@@ -1322,16 +1326,19 @@ bats_require_minimum_version 1.13.0
 
 @test "mock_path_check" {
   notice="${BATS_TEST_TMPDIR}/notice.txt"
+  path_before="${PATH}"
 
   mock_path_check 3>"${notice}"
   assert_equal "" "$(cat "${notice}")"
 
   PATH="${PATH}:${BATS_TEST_TMPDIR}/extra"
   mock_path_check 3>"${notice}"
+  PATH="${path_before}"
   assert_file_contains "${notice}" "Warning: 'PATH' changed after 'mock_setup'. The mocks are still found, but a command the test did not mock may resolve differently."
 
   PATH="/usr/bin:/bin"
   mock_path_check 3>"${notice}"
+  PATH="${path_before}"
   assert_file_contains "${notice}" "and no longer holds the mock directory"
   assert_file_contains "${notice}" "Mocked commands are not found and the real commands run instead."
 }

--- a/tests/mock.bats
+++ b/tests/mock.bats
@@ -1077,6 +1077,22 @@ bats_require_minimum_version 1.13.0
   assert_failure
 }
 
+@test "mock_sandbox_enable - the BATS harness keeps working inside the sandbox" {
+  mock_curl="$(mock_command "curl")"
+
+  mock_sandbox_enable
+
+  export MY_VAR="my value"
+
+  # 'run --separate-stderr' shells out to 'mktemp' for the stream it splits off.
+  run --separate-stderr curl "arg"
+  mock_sandbox_disable
+
+  assert_success
+  assert_stderr ""
+  assert_equal "my value" "$(mock_get_call_env "${mock_curl}" "MY_VAR")"
+}
+
 @test "mock_sandbox_enable - the allow-list can be seeded" {
   mock_sandbox_enable "basename"
 

--- a/tests/mock.bats
+++ b/tests/mock.bats
@@ -1056,7 +1056,7 @@ bats_require_minimum_version 1.13.0
   mock_sandbox_disable
 
   assert_failure --status 127
-  assert_output_contains "Command 'definitely_not_a_real_command' is not mocked and the mock sandbox is enabled."
+  assert_output_contains "Command 'definitely_not_a_real_command' is not mocked and the mock sandbox is enabled"
 }
 
 @test "mock_sandbox_enable - the library keeps working inside the sandbox" {
@@ -1211,7 +1211,7 @@ bats_require_minimum_version 1.13.0
   # Without a report to write to, the diagnostic still names the command.
   run -127 mock_sandbox_deny "curl"
   assert_failure --status 127
-  assert_output_contains "Command 'curl' is not mocked and the mock sandbox is enabled."
+  assert_output_contains "Command 'curl' is not mocked and the mock sandbox is enabled"
 
   mock_sandbox_enable
 
@@ -1265,7 +1265,7 @@ bats_require_minimum_version 1.13.0
   mock_sandbox_disable
 
   assert_failure --status 127
-  assert_output_contains "Command 'definitely_not_a_real_command' is not mocked and the mock sandbox is enabled."
+  assert_output_contains "Command 'definitely_not_a_real_command' is not mocked and the mock sandbox is enabled"
 
   run mock_sandbox_report 'denied'
   assert_success


### PR DESCRIPTION
Closes #186

## Summary

Adds an opt-in sandbox mode to `src/mock.bash` so a command the test forgot to mock fails loudly instead of silently running for real. Enabling it replaces `PATH` with the mock directory plus a sandbox bin directory pre-populated with the commands the library and the BATS harness themselves need, so a lookup that misses both is neither mocked nor allowed. The denial is delivered through an exported `command_not_found_handle`, which also reaches a Bash script under test, and every denial or allowed escape is recorded so `mock_sandbox_report` and `mock_verify` can surface it. The mode stays off until `mock_sandbox_enable` is called, and README.md documents it as explicitly not a security boundary since an absolute path still bypasses it.

## Changes

### Sandbox mode (`src/mock.bash`)
- Added `mock_sandbox_enable [command...]`, which replaces `PATH` with the mock directory and a `.sandbox/bin` directory, links in a fixed base set of commands the library and BATS harness rely on (`bash cat chmod cp diff dirname find grep head id ln ls mkdir mktemp rm sed stat touch wc`), and optionally seeds the allow-list from its arguments.
- Added `mock_sandbox_allow` to add commands to the allow-list after the fact; each allowed command gets a generated shim under `.sandbox/bin` that records the escape and execs the real binary, and allowing a command not on `PATH` fails immediately rather than at call time.
- Added `mock_sandbox_disable` to restore the `PATH` saved at enable time and tear down the exported `command_not_found_handle` and `mock_sandbox_deny`.
- Added `mock_sandbox_enabled` as a predicate and `mock_sandbox_report [kind]` to print denied and/or allowed commands, each named once regardless of call count.
- Added `mock_sandbox_deny`, exported as `command_not_found_handle`, which records a denial and prints a diagnostic; it runs in whichever process hit the failed lookup (including a Bash script under test) where nothing but builtins are guaranteed to exist, so it never calls `flunk`.
- Added the supporting helpers `mock_sandbox_base_commands`, `mock_sandbox_link_base`, `mock_sandbox_real_path` and `mock_sandbox_write_shim`.

### PATH-integrity checks (`src/mock.bash`)
- Added `mock_path_record` (called from `mock_setup` and after every sandbox transition) to snapshot `PATH` to `.path`, `mock_path_check` to warn on file descriptor 3 when `PATH` no longer matches that snapshot, and `mock_path_contains` to test whether a directory is still on `PATH`.
- `mock_forward_path` now takes an optional second `path` argument so `mock_sandbox_real_path` can strip the mock directory from a saved `PATH` rather than only the live one. Without that, a command which is both mocked and allowed resolved back into its own mock and the two exec'd each other in a loop.

### `mock_verify` integration (`src/mock.bash`)
- `mock_verify` now calls `mock_path_check`, fails the test when the sandbox report contains a denied command, and prints every allowed escape to file descriptor 3 alongside the existing deprecation notices.

### Documentation (`README.md`, `CLAUDE.md`)
- Added a "Sandbox mode" section to README.md covering the function table, an allow-listing example, what escapes and how `mock_sandbox_report` names it, and how a `PATH` rewrite under test is reported.
- Renamed the existing "Mock sandbox" README heading (which described the mock directory `mock_setup` writes to) to "Mock directory", so "sandbox" now names one thing in the document.
- Added `BATS_HELPERS_MOCK_SANDBOX_REPORT` to the README's environment variable reference table.
- Updated CLAUDE.md's module summary and variable-naming section to mention sandbox mode, and added a paragraph explaining that `mock_sandbox_deny` crosses the same process boundary as the rest of the mock but through `command_not_found_handle`, and is bound by the stricter rule of using builtins only.

### Tests (`tests/mock.bats`)
- Added 20 tests covering enabling and disabling the mode, seeding and extending the allow-list, validation failures, the base-command set keeping both the library and the BATS harness working, `mock_verify` failing on denials and reporting escapes without failing, `PATH`-integrity warnings, forwarding inside the mode, and a real Bash child script under test being denied through the exported handle.

## Before / After

```
Before: mock_setup alone
-------------------------

PATH = mock_dir : <real PATH>

  test calls "aws s3 cp ..."
         |
         v
  mock_dir/aws          -----> not found (no mock created)
         |
         v
  falls through to <real PATH>
         |
         v
  /usr/local/bin/aws     -----> runs for real, silently, non-hermetically
```

```
After: mock_sandbox_enable on, command denied
-----------------------------------------------

PATH = mock_dir : sandbox_dir/bin

  test calls "aws s3 cp ..."
         |
         v
  mock_dir/aws                -----> not found (no mock created)
         |
         v
  sandbox_dir/bin/aws          -----> not linked (not base, not allow-listed)
         |
         v
  command_not_found_handle "aws"     (exported, reaches Bash scripts too)
         |
         v
  denied, exit 127, recorded in report
         |
         v
  mock_verify                  -----> fails, names 'aws'
```

```
After: mock_sandbox_enable on, command allowed
-------------------------------------------------

  test calls "date +%s"   (mock_sandbox_allow "date")
         |
         v
  mock_dir/date                -----> not found
         |
         v
  sandbox_dir/bin/date          -----> shim found
         |
         v
  records 'allowed date', execs real /bin/date
         |
         v
  mock_verify                  -----> passes, notice on file descriptor 3
```
