### PR TITLE
[#192] Gave the interactive script helper a deadline and prompt assertions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
   - [Step runner](#step-runner) - Sequential test assertions
   - [Cleanup](#cleanup) - Deferred per-test cleanup
   - [Retry](#retry) - Conditions that become true shortly
+  - [Interactive scripts](#interactive-scripts) - Scripted answers, deadline, prompt order
   - [Helpers](#helpers) - Utility functions, inline fixture trees
   - [Environment variables](#environment-variables) - Full variable reference
   - [Deprecations](#deprecations) - Renamed functions and variables
@@ -52,7 +53,7 @@
 - Data provider for running one function over many test cases, with named cases, per-case arity, a chosen assertion and matrix expansion.
 - Fixture and file utilities for building and restoring test sandboxes.
 - A plain-text archive for declaring a whole fixture file tree inline in the test, serialising a directory back to it, and asserting a directory against it with per-file diffs.
-- TUI helper for driving interactive scripts with scripted answers.
+- TUI helper for driving interactive scripts with scripted answers, bounded by a deadline and asserted against the prompts the script printed.
 
 ## 📦 Installation
 
@@ -1291,6 +1292,76 @@ binary_is_installed() {
 retry_run 10 1 binary_is_installed "mytool"
 ```
 
+### Interactive scripts
+
+A script that asks questions is driven by naming it in `SCRIPT_FILE` and handing `tui_run` one answer per prompt, in the order the script asks for them:
+
+```bash
+@test "Installer" {
+  export SCRIPT_FILE="./install.sh"
+
+  tui_run "My site" "" "yes"
+
+  assert_output_contains "Installation complete"
+}
+```
+
+| Function                  | Description                                                          | Arguments      | Returns |
+|---------------------------|----------------------------------------------------------------------|----------------|---------|
+| `tui_run`                 | Runs the script named by `SCRIPT_FILE`, feeding it answers on STDIN  | `[answers...]` | None    |
+| `tui_assert_prompts`      | Asserts the prompts appeared in order, ignoring case                 | `[prompts...]` | None    |
+| `tui_assert_prompts_case` | Asserts the prompts appeared in order, case-sensitively              | `[prompts...]` | None    |
+
+Each answer is submitted followed by a newline, and an empty answer submits a blank line, so a prompt is left at its default by passing `""`. Answers reach the script byte for byte: an apostrophe, a `%` directive, a backslash escape or a space is not decoded on the way in.
+
+`tui_run` fills `output`, `status` and `lines` the way `run` does, so the script is asserted on with the usual command assertions.
+
+#### Deadline
+
+Every run is bounded. A script that keeps asking after its answers are spent is terminated and reported, rather than blocking until the whole suite is killed:
+
+```text
+Script './install.sh' did not finish within the 60 second timeout
+elapsed: 60 second(s)
+```
+
+The report carries everything the script printed before it was terminated, so the last prompt it reached names the answer that is missing.
+
+`BATS_HELPERS_TUI_TIMEOUT` sets the deadline, and defaults to `60`:
+
+```bash
+export BATS_HELPERS_TUI_TIMEOUT=5
+```
+
+It is in whole seconds, because `SECONDS` is the only clock available across the Bash versions the library supports. It cannot be turned off: a script that legitimately takes longer is given a larger number, which keeps every run bounded by something.
+
+#### Prompt order
+
+Answers are matched to prompts by position alone, so a test that answered every question one field early looks exactly like one that answered correctly. `tui_assert_prompts` asserts what the script asked, and in which order:
+
+```bash
+tui_run "My site" "" "yes"
+
+tui_assert_prompts "Site name" "Machine name" "Install profile"
+```
+
+Each prompt is searched for in what is left of the output after the prompt before it matched, so the same prompts in another order are reported rather than passed:
+
+```text
+Prompt 'Install profile' does not appear in the remaining output
+matched: 2 of 3
+```
+
+The number of prompts must also match the number of answers the last run submitted, in either direction, which is what catches an answer sequence that has drifted:
+
+```text
+Script was answered 3 time(s), but 2 prompt(s) are expected
+```
+
+`BATS_HELPERS_TUI_ANSWERS` holds that count. Calling the assertion before any script has run is an error rather than a pass.
+
+A prompt is matched as a substring, ignoring case; `tui_assert_prompts_case` matches case-sensitively. Only what the script prints itself can be asserted on: Bash writes a `read -p` prompt only when STDIN is a terminal, so a script asking that way leaves nothing in the output to match.
+
 ### Helpers
 
 | Function Name             | Description                                                                   |
@@ -1309,7 +1380,6 @@ retry_run 10 1 binary_is_installed "mytool"
 | `string_random`           | Generates a random alphanumeric string, 8 characters long by default          |
 | `string_match`            | Reports whether a needle matches a haystack, without asserting on it          |
 | `string_format_to_regex`  | Translates a format string into an extended regular expression                |
-| `tui_run`                 | Runs the script named by `SCRIPT_FILE`, feeding it a list of answers on STDIN |
 | `flunk`                   | Fails the test with a message, its stack trace and stable paths               |
 | `format_error`            | Formats a failure report as a titled block of aligned rows                    |
 
@@ -1510,6 +1580,8 @@ Every variable the library defines, in one place. Each is also covered by the se
 | `STEPS`                                        | `steps_run`                                                   | Array of steps to process                                                                   |
 | `TEST_CASES`                                   | `dataprovider_run`                                            | Array of test cases, each row ending with its expected value                                |
 | `SCRIPT_FILE`                                  | `tui_run`                                                     | Path to the script to run, relative to the current directory                                |
+| `BATS_HELPERS_TUI_TIMEOUT`                     | `tui_run`                                                     | Whole seconds the script is given to finish. Defaults to `60`                               |
+| `BATS_HELPERS_TUI_ANSWERS`                     | `tui_assert_prompts`, `tui_assert_prompts_case`               | Set by `tui_run` to the number of answers submitted                                         |
 | `BATS_HELPERS_STEPS_DEBUG`                     | `steps_run`                                                   | Set to `1` to print every parsing and matching decision to file descriptor 3                |
 | `BATS_HELPERS_ASSERT_DIR_EXCLUDE`              | `assert_dir_contains_string`, `assert_dir_not_contains_string` | Array of directory names to exclude from the search, on top of the always-excluded four     |
 | `BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED` | `fixture_export_codebase`                                     | Set to `1` to enable the export; anything else makes the function a no-op                   |
@@ -1566,6 +1638,14 @@ Every helper in a module shares one prefix - `steps_*`, `mock_*`, `file_*`, `str
 assert_contains "needle" "some needle in a haystack"
 
 assert_string_contains "some needle in a haystack" "needle"
+```
+
+The `nothing` answer to `tui_run` is deprecated in the same way. An empty string is what sends a blank line now, which makes the literal string `nothing` answerable again:
+
+```bash
+tui_run "My site" "nothing" "yes"
+
+tui_run "My site" "" "yes"
 ```
 
 The notice is written to file descriptor 3, so it shows up in the BATS output without being captured by `run` or by command substitution:

--- a/README.md
+++ b/README.md
@@ -1312,7 +1312,7 @@ A script that asks questions is driven by naming it in `SCRIPT_FILE` and handing
 | `tui_assert_prompts`      | Asserts the prompts appeared in order, ignoring case                 | `[prompts...]` | None    |
 | `tui_assert_prompts_case` | Asserts the prompts appeared in order, case-sensitively              | `[prompts...]` | None    |
 
-Each answer is submitted followed by a newline, and an empty answer submits a blank line, so a prompt is left at its default by passing `""`. Answers reach the script byte for byte: an apostrophe, a `%` directive, a backslash escape or a space is not decoded on the way in.
+Each answer is submitted followed by a newline, and an empty answer submits a blank line, so a prompt is left at its default by passing `""`. Every other answer reaches the script byte for byte: an apostrophe, a `%` directive, a backslash escape or a space is not decoded on the way in. The one exception is the deprecated `nothing`, which is still read as a request for a blank line rather than as those seven characters.
 
 `tui_run` fills `output`, `status` and `lines` the way `run` does, so the script is asserted on with the usual command assertions.
 
@@ -1640,7 +1640,7 @@ assert_contains "needle" "some needle in a haystack"
 assert_string_contains "some needle in a haystack" "needle"
 ```
 
-The `nothing` answer to `tui_run` is deprecated in the same way. An empty string is what sends a blank line now, which makes the literal string `nothing` answerable again:
+The `nothing` answer to `tui_run` is deprecated in the same way. An empty string is what sends a blank line now, and `nothing` still sends one while printing a notice, so the literal string becomes answerable once it is removed:
 
 ```bash
 tui_run "My site" "nothing" "yes"

--- a/README.md
+++ b/README.md
@@ -1321,10 +1321,17 @@ Each answer is submitted followed by a newline, and an empty answer submits a bl
 Every run is bounded. A script that keeps asking after its answers are spent is terminated and reported, rather than blocking until the whole suite is killed:
 
 ```text
-Script './install.sh' did not finish within the 60 second timeout.
-elapsed: 60 second(s)
-output: 'Welcome to the installer
-Site name: '
+-- Script did not finish within the deadline --
+script (1 line):
+./install.sh
+deadline (1 line):
+60 second(s)
+elapsed (1 line):
+60 second(s)
+output (2 lines):
+Welcome to the installer
+Site name: 
+--
 ```
 
 The report carries everything the script printed before it was terminated, so the last prompt it reached names the answer that is missing.
@@ -1350,14 +1357,26 @@ tui_assert_prompts "Site name" "Machine name" "Install profile"
 Each prompt is searched for in what is left of the output after the prompt before it matched, so the same prompts in another order are reported rather than passed:
 
 ```text
-Prompt 'Install profile' does not appear in the remaining output
-matched: 2 of 3
+-- Prompt does not appear in the remaining output --
+prompt (1 line):
+Install profile
+matched (1 line):
+2 of 3
+remaining output (2 lines):
+ [my_site]: 
+Installation complete
+--
 ```
+
+The remainder starts immediately after the prompt that matched, which is why it opens mid-line.
 
 The number of prompts must also match the number of answers the last run submitted, in either direction, which is what catches an answer sequence that has drifted:
 
 ```text
-Script was answered 3 time(s), but 2 prompt(s) are expected
+-- Answer count does not match the prompt count --
+answers : 3
+prompts : 2
+--
 ```
 
 `BATS_HELPERS_TUI_ANSWERS` holds that count. Calling the assertion before any script has run is an error rather than a pass.

--- a/README.md
+++ b/README.md
@@ -1321,8 +1321,10 @@ Each answer is submitted followed by a newline, and an empty answer submits a bl
 Every run is bounded. A script that keeps asking after its answers are spent is terminated and reported, rather than blocking until the whole suite is killed:
 
 ```text
-Script './install.sh' did not finish within the 60 second timeout
+Script './install.sh' did not finish within the 60 second timeout.
 elapsed: 60 second(s)
+output: 'Welcome to the installer
+Site name: '
 ```
 
 The report carries everything the script printed before it was terminated, so the last prompt it reached names the answer that is missing.

--- a/README.md
+++ b/README.md
@@ -1383,6 +1383,8 @@ prompts : 2
 
 A prompt is matched as a substring, ignoring case; `tui_assert_prompts_case` matches case-sensitively. Only what the script prints itself can be asserted on: Bash writes a `read -p` prompt only when STDIN is a terminal, so a script asking that way leaves nothing in the output to match.
 
+Nothing in the output marks a prompt as one, either. A script that echoes its answers back can therefore satisfy a prompt with an answer holding the same text, so pick prompt text an answer cannot stand in for.
+
 ### Helpers
 
 | Function Name             | Description                                                                   |

--- a/src/tui.bash
+++ b/src/tui.bash
@@ -29,6 +29,10 @@
 #   status: Set by 'run' to the exit status of the script.
 ##
 tui_run() {
+  ##
+  ## Input validation.
+  ##
+
   if [ -z "${SCRIPT_FILE-}" ]; then
     flunk "SCRIPT_FILE is not set."
     return 1
@@ -65,6 +69,10 @@ tui_run() {
     return 1
   fi
 
+  ##
+  ## Runner.
+  ##
+
   local answers=("$@")
   local input=""
   local answer
@@ -96,15 +104,24 @@ tui_run() {
 
   run tui_exec "${script_path}" "${input_file}" "${output_file}" "${expiry_file}" "${timeout}"
 
+  ##
+  ## Failure report.
+  ##
+
   [ -f "${expiry_file}" ] || return 0
 
   local elapsed
   elapsed="$(cat "${expiry_file}")"
 
-  local message="Script '${SCRIPT_FILE}' did not finish within the ${timeout} second timeout"
-  message="${message}"$'\n'"elapsed: ${elapsed} second(s)"
+  local message="Script '${SCRIPT_FILE}' did not finish within the ${timeout} second timeout."
 
-  format_error "${message}" | flunk
+  message="${message}"$'\n'"elapsed: ${elapsed} second(s)"
+  message="${message}"$'\n'"output: '${output-}'"
+
+  # Reported through 'flunk' rather than 'format_error', because this is a
+  # runtime failure of the run rather than an assertion about it, and the output
+  # the report already carries is the one 'format_error' would append.
+  flunk "${message}"
 }
 
 ##

--- a/src/tui.bash
+++ b/src/tui.bash
@@ -113,15 +113,11 @@ tui_run() {
   local elapsed
   elapsed="$(cat "${expiry_file}")"
 
-  local message="Script '${SCRIPT_FILE}' did not finish within the ${timeout} second timeout."
-
-  message="${message}"$'\n'"elapsed: ${elapsed} second(s)"
-  message="${message}"$'\n'"output: '${output-}'"
-
-  # Reported through 'flunk' rather than 'format_error', because this is a
-  # runtime failure of the run rather than an assertion about it, and the output
-  # the report already carries is the one 'format_error' would append.
-  flunk "${message}"
+  format_error "Script did not finish within the deadline" \
+    "script" "${SCRIPT_FILE}" \
+    "deadline" "${timeout} second(s)" \
+    "elapsed" "${elapsed} second(s)" \
+    "output" "${output-}" | flunk
 }
 
 ##
@@ -259,7 +255,9 @@ tui_prompts_assert_match() {
   local count="$#"
 
   if [ "${count}" -ne "${BATS_HELPERS_TUI_ANSWERS}" ]; then
-    format_error "Script was answered ${BATS_HELPERS_TUI_ANSWERS} time(s), but ${count} prompt(s) are expected" | flunk
+    format_error "Answer count does not match the prompt count" \
+      "answers" "${BATS_HELPERS_TUI_ANSWERS}" \
+      "prompts" "${count}" | flunk
     return 1
   fi
 
@@ -292,7 +290,10 @@ tui_prompts_assert_match() {
     prefix="${haystack%%"${needle}"*}"
 
     if [ "${#prefix}" -eq "${#haystack}" ]; then
-      format_error "Prompt '${prompt}' does not appear in the remaining output"$'\n'"matched: ${matched} of ${count}" | flunk
+      format_error "Prompt does not appear in the remaining output" \
+        "prompt" "${prompt}" \
+        "matched" "${matched} of ${count}" \
+        "remaining output" "${remaining}" | flunk
       return 1
     fi
 

--- a/src/tui.bash
+++ b/src/tui.bash
@@ -63,9 +63,7 @@ tui_run() {
   local dir="${BATS_TEST_TMPDIR-}"
 
   if [ -z "${dir}" ]; then
-    # Written directly rather than through 'flunk', whose path rewriting needs
-    # the non-empty sandbox path that is missing here.
-    echo "TUI sandbox cannot be resolved: 'BATS_TEST_TMPDIR' is not set." >&2
+    flunk "TUI sandbox cannot be resolved: 'BATS_TEST_TMPDIR' is not set."
     return 1
   fi
 
@@ -229,6 +227,10 @@ tui_assert_prompts_case() {
 # rather than passing. The number of prompts must match the number of answers
 # the last run submitted, which is what catches an answer landing against the
 # wrong prompt.
+#
+# Nothing in the output marks a prompt as one, so a script that echoes its
+# answers back can satisfy a prompt with an answer holding the same text. Prompt
+# text an answer cannot contain is what keeps the assertion honest.
 #
 # Arguments:
 #   1. case_sensitive: '1' to match case-sensitively, '0' to ignore case.

--- a/src/tui.bash
+++ b/src/tui.bash
@@ -7,16 +7,26 @@
 ##
 # Runs a TUI script, feeding it a list of answers on STDIN.
 #
-# Each answer is submitted followed by a newline. The literal answer 'nothing'
-# submits an empty line, so a prompt can be left at its default.
+# Each answer is submitted followed by a newline. An empty answer submits a
+# blank line, so a prompt can be left at its default.
+#
+# The script is given a deadline, so one that keeps asking after its answers are
+# spent is terminated and reported with everything it printed, rather than
+# blocking until the suite is killed.
 #
 # Arguments:
-#   1. answers: Answers to submit, one per argument, in the order the script
-#      prompts for them.
+#   1+. answers: Answers to submit, one per argument, in the order the script
+#      prompts for them. Optional.
 #
 # Globals:
 #   SCRIPT_FILE: Path to the script to run. Relative paths resolve against the
 #     current directory.
+#   BATS_HELPERS_TUI_TIMEOUT: Seconds the script is given to finish. Defaults
+#     to 60.
+#   BATS_HELPERS_TUI_ANSWERS: Set to the number of answers submitted.
+#   BATS_TEST_TMPDIR: Per-test sandbox holding the script's input and output.
+#   output: Set by 'run' to what the script printed.
+#   status: Set by 'run' to the exit status of the script.
 ##
 tui_run() {
   if [ -z "${SCRIPT_FILE-}" ]; then
@@ -34,24 +44,234 @@ tui_run() {
     return 1
   fi
 
+  local timeout="${BATS_HELPERS_TUI_TIMEOUT:-60}"
+
+  if ! [[ ${timeout} =~ ^-?[0-9]+$ ]]; then
+    flunk "Timeout '${timeout}' is not a whole number of seconds."
+    return 1
+  fi
+
+  if [ "${timeout}" -le 0 ]; then
+    flunk "Timeout must be greater than zero."
+    return 1
+  fi
+
+  local dir="${BATS_TEST_TMPDIR-}"
+
+  if [ -z "${dir}" ]; then
+    # Written directly rather than through 'flunk', whose path rewriting needs
+    # the non-empty sandbox path that is missing here.
+    echo "TUI sandbox cannot be resolved: 'BATS_TEST_TMPDIR' is not set." >&2
+    return 1
+  fi
+
   local answers=("$@")
   local input=""
-  local i
-  local val
+  local answer
 
-  for i in "${answers[@]}"; do
-    val="${i}"
-    [ "${i}" = "nothing" ] && val=""
-    input="${input}${val}"$'\n'
+  for answer in "${answers[@]}"; do
+    if [ "${answer}" = "nothing" ]; then
+      [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: the 'nothing' answer will be removed in the next version. Use an empty string instead." >&3
+      answer=""
+    fi
+
+    input="${input}${answer}"$'\n'
   done
+
+  BATS_HELPERS_TUI_ANSWERS="${#answers[@]}"
 
   # A bare './' would break an absolute path, and omitting it would look up a
   # relative one on PATH.
   local script_path="${SCRIPT_FILE}"
   [ "${script_path#/}" = "${script_path}" ] && script_path="./${script_path}"
 
-  # The answers and the path are passed as positional parameters rather than
-  # interpolated, and written with '%s' rather than '%b', so that an apostrophe,
-  # a '%' directive, a backslash escape or a space reaches the script literally.
-  run bash -c 'printf "%s" "$1" | "$2"' _ "${input}" "${script_path}"
+  local input_file="${dir%/}/bats-helpers-tui.in"
+  local output_file="${dir%/}/bats-helpers-tui.out"
+  local expiry_file="${dir%/}/bats-helpers-tui.expiry"
+
+  # Written with '%s' rather than '%b' so that an apostrophe, a '%' directive, a
+  # backslash escape or a space reaches the script literally.
+  printf '%s' "${input}" >"${input_file}"
+  rm -f "${expiry_file}"
+
+  run tui_exec "${script_path}" "${input_file}" "${output_file}" "${expiry_file}" "${timeout}"
+
+  [ -f "${expiry_file}" ] || return 0
+
+  local elapsed
+  elapsed="$(cat "${expiry_file}")"
+
+  local message="Script '${SCRIPT_FILE}' did not finish within the ${timeout} second timeout"
+  message="${message}"$'\n'"elapsed: ${elapsed} second(s)"
+
+  format_error "${message}" | flunk
+}
+
+##
+# Runs a script with its answers on STDIN, terminating it at a deadline.
+#
+# The script runs in the background and a watchdog terminates it once the
+# deadline has passed, because 'timeout' is absent on some of the platforms the
+# library supports. Both background jobs redirect their own streams and close
+# file descriptor 3, so neither can hold open the capture that 'run' reads from.
+#
+# The watchdog records the overrun only once its signal has been delivered, so a
+# script that finished in the same instant is not reported as having overrun.
+#
+# Arguments:
+#   1. script_path: Script to run.
+#   2. input_file: File holding the answers.
+#   3. output_file: File the script's STDOUT and STDERR are written to.
+#   4. expiry_file: File written with the elapsed seconds when the deadline
+#      passes, and left absent when it does not.
+#   5. timeout: Seconds the script is given to finish.
+#
+# Outputs:
+#   STDOUT: Everything the script printed, including what it printed before it
+#     was terminated.
+#
+# Returns:
+#   The exit status of the script.
+##
+tui_exec() {
+  local script_path="${1}"
+  local input_file="${2}"
+  local output_file="${3}"
+  local expiry_file="${4}"
+  local timeout="${5}"
+
+  local start="${SECONDS}"
+
+  "${script_path}" <"${input_file}" >"${output_file}" 2>&1 3>&- &
+  local script_pid="$!"
+
+  # The wait is broken into short sleeps so that killing the watchdog leaves at
+  # most a fraction of a second of it behind.
+  (
+    while [ "$((SECONDS - start))" -lt "${timeout}" ]; do
+      sleep 0.1
+    done
+
+    kill -TERM "${script_pid}" 2>/dev/null || exit 0
+    printf '%s\n' "$((SECONDS - start))" >"${expiry_file}"
+
+    # A script that traps the first signal is not given the choice twice.
+    sleep 1
+    kill -KILL "${script_pid}" 2>/dev/null
+  ) >/dev/null 2>&1 3>&- &
+  local watchdog_pid="$!"
+
+  local status=0
+  wait "${script_pid}" || status="$?"
+
+  kill -TERM "${watchdog_pid}" 2>/dev/null || true
+  wait "${watchdog_pid}" 2>/dev/null || true
+
+  cat "${output_file}"
+
+  return "${status}"
+}
+
+##
+## Assertions.
+##
+
+##
+# Asserts that the script prompted in the given order, ignoring case.
+#
+# Arguments:
+#   1+. prompts: Expected prompts, one per argument, in the order the script
+#      printed them. Optional; no arguments asserts that no answer was
+#      submitted.
+##
+tui_assert_prompts() {
+  tui_prompts_assert_match 0 "$@"
+}
+
+##
+# Asserts that the script prompted in the given order, case-sensitively.
+#
+# Arguments:
+#   1+. prompts: Expected prompts, one per argument, in the order the script
+#      printed them. Optional; no arguments asserts that no answer was
+#      submitted.
+##
+tui_assert_prompts_case() {
+  tui_prompts_assert_match 1 "$@"
+}
+
+##
+# Asserts that the captured output holds the prompts in order.
+#
+# Each prompt is searched for in what is left of the output after the prompt
+# before it matched, so a sequence that appears in another order is reported
+# rather than passing. The number of prompts must match the number of answers
+# the last run submitted, which is what catches an answer landing against the
+# wrong prompt.
+#
+# Arguments:
+#   1. case_sensitive: '1' to match case-sensitively, '0' to ignore case.
+#   2+. prompts: Expected prompts, in the order the script printed them.
+#
+# Globals:
+#   BATS_HELPERS_TUI_ANSWERS: Number of answers the last 'tui_run' submitted.
+#   output: Output captured by the last 'tui_run'.
+##
+tui_prompts_assert_match() {
+  if [ "$#" -lt 1 ]; then
+    flunk "A case sensitivity flag is required."
+    return 1
+  fi
+
+  local case_sensitive="${1}"
+  shift
+
+  if [ -z "${BATS_HELPERS_TUI_ANSWERS-}" ]; then
+    flunk "No script has been run. Run 'tui_run' first."
+    return 1
+  fi
+
+  local count="$#"
+
+  if [ "${count}" -ne "${BATS_HELPERS_TUI_ANSWERS}" ]; then
+    format_error "Script was answered ${BATS_HELPERS_TUI_ANSWERS} time(s), but ${count} prompt(s) are expected" | flunk
+    return 1
+  fi
+
+  local remaining="${output-}"
+  local matched=0
+  local prompt
+  local haystack
+  local needle
+  local prefix
+
+  for prompt in "$@"; do
+    if [ -z "${prompt}" ]; then
+      flunk "Prompt must not be empty."
+      return 1
+    fi
+
+    haystack="${remaining}"
+    needle="${prompt}"
+
+    # Folding both sides is what makes the position of the match, rather than
+    # only its presence, available for an insensitive comparison: prefix removal
+    # does not honour 'nocasematch'.
+    if [ "${case_sensitive}" != "1" ]; then
+      haystack="${haystack,,}"
+      needle="${needle,,}"
+    fi
+
+    # '%%' strips the longest matching suffix, leaving the text before the first
+    # occurrence. The needle is quoted so that it is read literally.
+    prefix="${haystack%%"${needle}"*}"
+
+    if [ "${#prefix}" -eq "${#haystack}" ]; then
+      format_error "Prompt '${prompt}' does not appear in the remaining output"$'\n'"matched: ${matched} of ${count}" | flunk
+      return 1
+    fi
+
+    remaining="${remaining:$((${#prefix} + ${#needle}))}"
+    matched=$((matched + 1))
+  done
 }

--- a/src/tui.bash
+++ b/src/tui.bash
@@ -115,8 +115,10 @@ tui_run() {
 # library supports. Both background jobs redirect their own streams and close
 # file descriptor 3, so neither can hold open the capture that 'run' reads from.
 #
-# The watchdog records the overrun only once its signal has been delivered, so a
-# script that finished in the same instant is not reported as having overrun.
+# Monitor mode gives the script a process group of its own, so that the deadline
+# reaches whatever the script started rather than only the script itself. The
+# group is signalled alongside the script rather than instead of it, so a shell
+# that did not honour the request still leaves a bounded run.
 #
 # Arguments:
 #   1. script_path: Script to run.
@@ -142,8 +144,10 @@ tui_exec() {
 
   local start="${SECONDS}"
 
+  set -m
   "${script_path}" <"${input_file}" >"${output_file}" 2>&1 3>&- &
   local script_pid="$!"
+  set +m
 
   # The wait is broken into short sleeps so that killing the watchdog leaves at
   # most a fraction of a second of it behind.
@@ -152,12 +156,16 @@ tui_exec() {
       sleep 0.1
     done
 
-    kill -TERM "${script_pid}" 2>/dev/null || exit 0
+    kill -0 "${script_pid}" 2>/dev/null || exit 0
     printf '%s\n' "$((SECONDS - start))" >"${expiry_file}"
+
+    kill -TERM -- -"${script_pid}" 2>/dev/null || true
+    kill -TERM "${script_pid}" 2>/dev/null || true
 
     # A script that traps the first signal is not given the choice twice.
     sleep 1
-    kill -KILL "${script_pid}" 2>/dev/null
+    kill -KILL -- -"${script_pid}" 2>/dev/null || true
+    kill -KILL "${script_pid}" 2>/dev/null || true
   ) >/dev/null 2>&1 3>&- &
   local watchdog_pid="$!"
 

--- a/tests/deprecation.bats
+++ b/tests/deprecation.bats
@@ -147,6 +147,16 @@ fixture_add() {
   assert_file_contains "${notice}" "Deprecated: 'restore_file' will be removed in the next version. Use 'file_restore' instead."
 }
 
+@test "nothing answer" {
+  notice="${BATS_TEST_TMPDIR}/notice.txt"
+  export SCRIPT_FILE="tests/fixtures/tui_script.sh"
+
+  tui_run "nothing" "custom answer2" 3>"${notice}"
+
+  assert_output_contains "default answer1"
+  assert_file_contains "${notice}" "Deprecated: the 'nothing' answer will be removed in the next version. Use an empty string instead."
+}
+
 @test "RUN_STEPS_DEBUG" {
   notice="${BATS_TEST_TMPDIR}/notice.txt"
   export RUN_STEPS_DEBUG=1

--- a/tests/fixtures/tui_script_prompts.sh
+++ b/tests/fixtures/tui_script_prompts.sh
@@ -31,6 +31,8 @@ answer1="${answer}"
 ask "Answer2" "default answer2"
 answer2="${answer}"
 
-echo "${answer1}"
-echo "${answer2}"
+# Printed with 'printf' because 'echo' would read an answer of '-n', '-e' or
+# '-E' as one of its own flags and swallow it.
+printf '%s\n' "${answer1}"
+printf '%s\n' "${answer2}"
 # LCOV_EXCL_STOP

--- a/tests/fixtures/tui_script_prompts.sh
+++ b/tests/fixtures/tui_script_prompts.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Fixture script to test TUI prompts and deadlines.
+# LCOV_EXCL_START
+set -e
+
+ask() {
+  local prompt="$1"
+  local default="${2-}"
+
+  # Printed rather than passed to 'read -p', which shows nothing when STDIN is
+  # not a terminal, and printed outside a command substitution so that it
+  # reaches the output instead of being captured.
+  printf '%s [%s]: \n' "${prompt}" "${default}"
+
+  answer=""
+
+  # An unanswered prompt waits rather than giving up at EOF, the way a script
+  # reading from a terminal does.
+  while ! read -r answer; do
+    sleep 0.1
+  done
+
+  [ -n "${answer}" ] || answer="${default}"
+}
+
+echo "Static script output"
+
+ask "Answer1" "default answer1"
+answer1="${answer}"
+
+ask "Answer2" "default answer2"
+answer2="${answer}"
+
+echo "${answer1}"
+echo "${answer2}"
+# LCOV_EXCL_STOP

--- a/tests/fixtures/tui_script_silent.sh
+++ b/tests/fixtures/tui_script_silent.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Fixture script to test a TUI script that prompts for nothing.
+# LCOV_EXCL_START
+set -e
+
+echo "Static script output"
+# LCOV_EXCL_STOP

--- a/tests/fixtures/tui_script_worker.sh
+++ b/tests/fixtures/tui_script_worker.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Fixture script to test that a deadline reaches what a TUI script started.
+# LCOV_EXCL_START
+set -e
+
+# The worker outlives the deadline unless the whole process group is signalled.
+sleep 30 &
+
+echo "$!" >"${WORKER_PID_FILE}"
+
+echo "Static script output"
+
+# Never answered, so the deadline is what ends this script.
+while true; do
+  sleep 0.1
+done
+# LCOV_EXCL_STOP

--- a/tests/tui.bats
+++ b/tests/tui.bats
@@ -197,8 +197,10 @@ process_is_gone() {
   run tui_run "one"
 
   assert_failure
-  assert_output_contains "Script 'tests/fixtures/tui_script_prompts.sh' did not finish within the 2 second timeout."
-  assert_output_matches_format "elapsed: %d second(s)"
+  assert_output_contains "Script did not finish within the deadline"
+  assert_output_contains "tests/fixtures/tui_script_prompts.sh"
+  assert_output_contains "elapsed"
+  assert_output_matches_format "%d second(s)"
   assert_output_contains "Static script output"
   assert_output_contains "Answer2 [default answer2]:"
 }
@@ -265,14 +267,15 @@ process_is_gone() {
   tui_run "one" "two"
   run tui_assert_prompts "Answer1" "Answer3"
   assert_failure
-  assert_output_contains "Prompt 'Answer3' does not appear in the remaining output"
-  assert_output_contains "matched: 1 of 2"
+  assert_output_contains "Prompt does not appear in the remaining output"
+  assert_output_contains "Answer3"
+  assert_output_contains "1 of 2"
 
   tui_run "one" "two"
   run tui_assert_prompts "Answer2" "Answer1"
   assert_failure
-  assert_output_contains "Prompt 'Answer1' does not appear in the remaining output"
-  assert_output_contains "matched: 1 of 2"
+  assert_output_contains "Prompt does not appear in the remaining output"
+  assert_output_contains "1 of 2"
 }
 
 @test "tui_assert_prompts_case" {
@@ -284,8 +287,9 @@ process_is_gone() {
   tui_run "one" "two"
   run tui_assert_prompts_case "ANSWER1" "ANSWER2"
   assert_failure
-  assert_output_contains "Prompt 'ANSWER1' does not appear in the remaining output"
-  assert_output_contains "matched: 0 of 2"
+  assert_output_contains "Prompt does not appear in the remaining output"
+  assert_output_contains "ANSWER1"
+  assert_output_contains "0 of 2"
 }
 
 @test "Answer count does not match the prompt count" {
@@ -294,12 +298,16 @@ process_is_gone() {
   tui_run "one" "two"
   run tui_assert_prompts "Answer1"
   assert_failure
-  assert_output_contains "Script was answered 2 time(s), but 1 prompt(s) are expected"
+  assert_output_contains "Answer count does not match the prompt count"
+  assert_output_contains "answers : 2"
+  assert_output_contains "prompts : 1"
 
   tui_run "one" "two"
   run tui_assert_prompts "Answer1" "Answer2" "Answer3"
   assert_failure
-  assert_output_contains "Script was answered 2 time(s), but 3 prompt(s) are expected"
+  assert_output_contains "Answer count does not match the prompt count"
+  assert_output_contains "answers : 2"
+  assert_output_contains "prompts : 3"
 }
 
 @test "Script that prompts for nothing" {
@@ -312,7 +320,9 @@ process_is_gone() {
   tui_run
   run tui_assert_prompts "Answer1"
   assert_failure
-  assert_output_contains "Script was answered 0 time(s), but 1 prompt(s) are expected"
+  assert_output_contains "Answer count does not match the prompt count"
+  assert_output_contains "answers : 0"
+  assert_output_contains "prompts : 1"
 }
 
 @test "Prompts asserted before a script has run" {

--- a/tests/tui.bats
+++ b/tests/tui.bats
@@ -6,6 +6,10 @@
 
 load _test_helper
 
+process_is_gone() {
+  ! kill -0 "${1}" 2>/dev/null
+}
+
 @test "Interactive" {
   export SCRIPT_FILE="tests/fixtures/tui_script.sh"
 
@@ -197,6 +201,18 @@ load _test_helper
   assert_output_matches_format "elapsed: %d second(s)"
   assert_output_contains "Static script output"
   assert_output_contains "Answer2 [default answer2]:"
+}
+
+@test "Deadline reaches the processes the script started" {
+  export SCRIPT_FILE="tests/fixtures/tui_script_worker.sh"
+  export WORKER_PID_FILE="${BATS_TEST_TMPDIR}/worker.pid"
+  export BATS_HELPERS_TUI_TIMEOUT=2
+
+  run tui_run "one"
+  assert_failure
+
+  worker_pid="$(cat "${WORKER_PID_FILE}")"
+  retry_run 20 0.1 process_is_gone "${worker_pid}"
 }
 
 @test "Deadline is configurable" {

--- a/tests/tui.bats
+++ b/tests/tui.bats
@@ -197,7 +197,7 @@ process_is_gone() {
   run tui_run "one"
 
   assert_failure
-  assert_output_contains "Script 'tests/fixtures/tui_script_prompts.sh' did not finish within the 2 second timeout"
+  assert_output_contains "Script 'tests/fixtures/tui_script_prompts.sh' did not finish within the 2 second timeout."
   assert_output_matches_format "elapsed: %d second(s)"
   assert_output_contains "Static script output"
   assert_output_contains "Answer2 [default answer2]:"

--- a/tests/tui.bats
+++ b/tests/tui.bats
@@ -24,12 +24,26 @@ load _test_helper
   export SCRIPT_FILE="tests/fixtures/tui_script.sh"
 
   declare -a answers=(
-    "nothing"
+    ""
     "custom answer2"
   )
   tui_run "${answers[@]}"
 
   assert_output_contains "Static script output"
+  assert_output_contains "default answer1"
+  assert_output_contains "custom answer2"
+}
+
+@test "Deprecated 'nothing' answer submits a blank line" {
+  export SCRIPT_FILE="tests/fixtures/tui_script.sh"
+  export BATS_HELPERS_DEPRECATION_QUIET=1
+
+  declare -a answers=(
+    "nothing"
+    "custom answer2"
+  )
+  tui_run "${answers[@]}"
+
   assert_output_contains "default answer1"
   assert_output_contains "custom answer2"
 }
@@ -60,6 +74,14 @@ load _test_helper
   assert_output_contains 'literal\ctruncate'
 }
 
+@test "Answer count is published" {
+  export SCRIPT_FILE="tests/fixtures/tui_script.sh"
+
+  tui_run "custom answer1" "custom answer2"
+
+  assert_equal 2 "${BATS_HELPERS_TUI_ANSWERS}"
+}
+
 @test "Absolute script path containing a space" {
   cp "${BATS_TEST_DIRNAME}/fixtures/tui_script.sh" "${BATS_TEST_TMPDIR}/tui script.sh"
   export SCRIPT_FILE="${BATS_TEST_TMPDIR}/tui script.sh"
@@ -87,7 +109,7 @@ load _test_helper
   unset SCRIPT_FILE
 
   declare -a answers=(
-    "nothing"
+    ""
     "custom answer2"
   )
   run tui_run "${answers[@]}"
@@ -99,7 +121,7 @@ load _test_helper
   unset SCRIPT_FILE
 
   declare -a answers=(
-    "nothing"
+    ""
     "custom answer2"
   )
 
@@ -113,7 +135,7 @@ load _test_helper
   export SCRIPT_FILE="tests/fixtures/tui_script_nonexisting.sh"
 
   declare -a answers=(
-    "nothing"
+    ""
     "custom answer2"
   )
   run tui_run "${answers[@]}"
@@ -125,7 +147,7 @@ load _test_helper
   export SCRIPT_FILE="tests/fixtures"
 
   declare -a answers=(
-    "nothing"
+    ""
     "custom answer2"
   )
   run tui_run "${answers[@]}"
@@ -137,7 +159,7 @@ load _test_helper
   export SCRIPT_FILE="tests/fixtures/tui_script_nonexisting.sh"
 
   declare -a answers=(
-    "nothing"
+    ""
     "custom answer2"
   )
 
@@ -145,4 +167,161 @@ load _test_helper
   tui_run "${answers[@]}" 2>/dev/null || recovered=1
 
   assert_equal 1 "${recovered}"
+}
+
+@test "Sandbox cannot be resolved" {
+  export SCRIPT_FILE="tests/fixtures/tui_script.sh"
+  sandbox="${BATS_TEST_TMPDIR}"
+  BATS_TEST_TMPDIR=""
+
+  run tui_run "custom answer1" "custom answer2"
+
+  BATS_TEST_TMPDIR="${sandbox}"
+
+  assert_failure
+  assert_output_contains "TUI sandbox cannot be resolved: 'BATS_TEST_TMPDIR' is not set."
+}
+
+##
+## Deadline.
+##
+
+@test "Script that prompts more times than it has answers" {
+  export SCRIPT_FILE="tests/fixtures/tui_script_prompts.sh"
+  export BATS_HELPERS_TUI_TIMEOUT=2
+
+  run tui_run "one"
+
+  assert_failure
+  assert_output_contains "Script 'tests/fixtures/tui_script_prompts.sh' did not finish within the 2 second timeout"
+  assert_output_matches_format "elapsed: %d second(s)"
+  assert_output_contains "Static script output"
+  assert_output_contains "Answer2 [default answer2]:"
+}
+
+@test "Deadline is configurable" {
+  export SCRIPT_FILE="tests/fixtures/tui_script_prompts.sh"
+  export BATS_HELPERS_TUI_TIMEOUT=30
+
+  tui_run "one" "two"
+
+  assert_output_contains "one"
+  assert_output_contains "two"
+}
+
+@test "Deadline is not a whole number of seconds" {
+  export SCRIPT_FILE="tests/fixtures/tui_script.sh"
+  export BATS_HELPERS_TUI_TIMEOUT="1.5"
+
+  run tui_run "custom answer1" "custom answer2"
+
+  assert_failure
+  assert_output_contains "Timeout '1.5' is not a whole number of seconds."
+}
+
+@test "Deadline is not greater than zero" {
+  export SCRIPT_FILE="tests/fixtures/tui_script.sh"
+
+  export BATS_HELPERS_TUI_TIMEOUT=0
+  run tui_run "custom answer1" "custom answer2"
+  assert_failure
+  assert_output_contains "Timeout must be greater than zero."
+
+  export BATS_HELPERS_TUI_TIMEOUT=-1
+  run tui_run "custom answer1" "custom answer2"
+  assert_failure
+  assert_output_contains "Timeout must be greater than zero."
+}
+
+##
+## Prompt assertions.
+##
+
+@test "tui_assert_prompts" {
+  export SCRIPT_FILE="tests/fixtures/tui_script_prompts.sh"
+
+  tui_run "one" "two"
+  tui_assert_prompts "Answer1" "Answer2"
+
+  tui_run "one" "two"
+  tui_assert_prompts "ANSWER1" "ANSWER2"
+
+  tui_run "one" "two"
+  run tui_assert_prompts "Answer1" "Answer3"
+  assert_failure
+  assert_output_contains "Prompt 'Answer3' does not appear in the remaining output"
+  assert_output_contains "matched: 1 of 2"
+
+  tui_run "one" "two"
+  run tui_assert_prompts "Answer2" "Answer1"
+  assert_failure
+  assert_output_contains "Prompt 'Answer1' does not appear in the remaining output"
+  assert_output_contains "matched: 1 of 2"
+}
+
+@test "tui_assert_prompts_case" {
+  export SCRIPT_FILE="tests/fixtures/tui_script_prompts.sh"
+
+  tui_run "one" "two"
+  tui_assert_prompts_case "Answer1" "Answer2"
+
+  tui_run "one" "two"
+  run tui_assert_prompts_case "ANSWER1" "ANSWER2"
+  assert_failure
+  assert_output_contains "Prompt 'ANSWER1' does not appear in the remaining output"
+  assert_output_contains "matched: 0 of 2"
+}
+
+@test "Answer count does not match the prompt count" {
+  export SCRIPT_FILE="tests/fixtures/tui_script_prompts.sh"
+
+  tui_run "one" "two"
+  run tui_assert_prompts "Answer1"
+  assert_failure
+  assert_output_contains "Script was answered 2 time(s), but 1 prompt(s) are expected"
+
+  tui_run "one" "two"
+  run tui_assert_prompts "Answer1" "Answer2" "Answer3"
+  assert_failure
+  assert_output_contains "Script was answered 2 time(s), but 3 prompt(s) are expected"
+}
+
+@test "Script that prompts for nothing" {
+  export SCRIPT_FILE="tests/fixtures/tui_script_silent.sh"
+
+  tui_run
+  assert_output_contains "Static script output"
+  tui_assert_prompts
+
+  tui_run
+  run tui_assert_prompts "Answer1"
+  assert_failure
+  assert_output_contains "Script was answered 0 time(s), but 1 prompt(s) are expected"
+}
+
+@test "Prompts asserted before a script has run" {
+  unset BATS_HELPERS_TUI_ANSWERS
+
+  run tui_assert_prompts "Answer1"
+
+  assert_failure
+  assert_output_contains "No script has been run. Run 'tui_run' first."
+}
+
+@test "Empty prompt" {
+  export SCRIPT_FILE="tests/fixtures/tui_script_prompts.sh"
+
+  tui_run "one" "two"
+
+  run tui_assert_prompts "Answer1" ""
+
+  assert_failure
+  assert_output_contains "Prompt must not be empty."
+}
+
+@test "Missing case sensitivity flag" {
+  run tui_prompts_assert_match
+
+  assert_failure
+  assert_output_contains "A case sensitivity flag is required."
 }

--- a/tests/tui.bats
+++ b/tests/tui.bats
@@ -335,9 +335,13 @@ process_is_gone() {
   assert_output_contains "Prompt must not be empty."
 }
 
-@test "Missing case sensitivity flag" {
-  run tui_prompts_assert_match
+@test "tui_prompts_assert_match" {
+  export SCRIPT_FILE="tests/fixtures/tui_script_prompts.sh"
 
+  tui_run "one" "two"
+  tui_prompts_assert_match 0 "Answer1" "Answer2"
+
+  run tui_prompts_assert_match
   assert_failure
   assert_output_contains "A case sensitivity flag is required."
 }


### PR DESCRIPTION
Closes #192

## Summary

`tui_run` used to run the target script in a single foreground pipeline that wrote every answer to its STDIN and never read anything back, so a script that kept prompting after its answers were spent blocked forever and only the CI job timeout ended it. Every run is now bounded by a deadline: the script runs in the background under its own process group, and a watchdog terminates the group once the deadline passes and reports the elapsed time together with everything the script printed before it was stopped. `BATS_HELPERS_TUI_TIMEOUT` sets that deadline in whole seconds and defaults to `60`. Because `timeout` is absent on some of the platforms the library supports, the deadline is enforced in-shell rather than by shelling out to it.

Two assertions close the second half of the blindness. `tui_assert_prompts` and `tui_assert_prompts_case` check that the prompts a script printed appear in the captured output in the expected order, and that their number matches the number of answers the run submitted, in either direction - which is what catches an answer sequence that has drifted one field early. Separately, an empty string now submits a blank line, so the `nothing` token that used to be the only way to express one is deprecated and the literal string becomes answerable once it is removed.

## Changes

### The deadline

- `tui_run` validates `BATS_HELPERS_TUI_TIMEOUT` as a whole number greater than zero, resolves the sandbox, writes the answers to a file rather than piping them, and delegates the run to a new `tui_exec`.
- `tui_exec` starts the script in the background under monitor mode, so it gets a process group of its own, and starts a watchdog beside it. Once the deadline passes the watchdog records the elapsed seconds and signals the group and the script together, escalating from `TERM` to `KILL` after a grace second for a script that traps the first signal. Signalling the group is what makes the deadline reach a worker the script started, rather than only the script itself; signalling the script as well keeps the run bounded on a shell that did not honour the process-group request.
- Both background jobs redirect their own streams and close file descriptor 3, so neither can hold open the capture that `run` reads from - `run` captures through command substitution, so a leaked descriptor would hang the very thing the deadline exists to prevent.
- An overrun is reported through `format_error` as a titled block of aligned rows carrying the script, the deadline, the elapsed seconds and the script's own output.

### The prompt assertions

- `tui_assert_prompts` and `tui_assert_prompts_case` are one-line wrappers over a shared `tui_prompts_assert_match`, matching the way the `assert_string_*` family names case sensitivity in the assertion rather than passing it as a flag.
- Each prompt is searched for in what is left of the output after the prompt before it matched, so the same prompts in another order are reported rather than passed. Matching folds both sides when case is ignored, because prefix removal does not honour `nocasematch` and the position of the match - not just its presence - is what the scan needs.
- The prompt count must equal `BATS_HELPERS_TUI_ANSWERS`, which `tui_run` sets to the number of answers it submitted.
- The limitation is documented rather than implied: nothing in the output marks a prompt as one, so a script that echoes its answers back can satisfy a prompt with an answer holding the same text.

### The blank answer

- An empty answer submits a blank line. `nothing` still does, and prints a deprecation notice on file descriptor 3, silenced by `BATS_HELPERS_DEPRECATION_QUIET` like every other notice in the library.

### Tests and documentation

- `tests/tui.bats` covers the deadline (an overrun, a configurable deadline, a non-integer, zero and negative deadline, an unresolved sandbox), the deadline reaching a worker the script spawned, and every branch of the prompt assertions - order, case sensitivity, both directions of a count mismatch, an empty prompt, and asserting before any run.
- `tests/deprecation.bats` covers the `nothing` notice alongside the library's other deprecations.
- Three fixtures: one that prompts twice and waits rather than giving up at EOF, one that prompts for nothing, and one that spawns a background worker.
- `README.md` gains an `Interactive scripts` section covering the deadline, prompt order and the limitation, moves `tui_run` out of the generic helpers table into it, and documents `BATS_HELPERS_TUI_TIMEOUT`, `BATS_HELPERS_TUI_ANSWERS` and the `nothing` deprecation.

## Before / After

```
BEFORE - one foreground pipeline, nothing read back
─────────────────────────────────────────────────────
  tui_run()
      │
      ▼
  run bash -c 'printf "%s" "$answers" | "$script"'
      │
      ▼
  ┌────────────────────────────────┐
  │ script reads answers from STDIN │
  │ prints prompts and output       │
  └────────────────────────────────┘
      │
      │  script asks once more than it was answered
      ▼
  blocks on a spent STDIN
      │
      ▼
  pipeline never returns  ── the whole suite hangs


AFTER - a bounded run in its own process group, asserted post-hoc
──────────────────────────────────────────────────────────────────
  tui_run()
      │
      ├─ validate deadline and sandbox
      ├─ answers ──▶ bats-helpers-tui.in
      ▼
  run tui_exec(script, in, out, expiry, deadline)
      │
      ├──────────────────────────┬──────────────────────────────┐
      ▼                          ▼                              │
  ┌──────────────────┐   ┌────────────────────────────────┐     │
  │ script           │   │ watchdog                        │     │
  │ own process      │   │  poll until the deadline        │     │
  │ group (set -m)   │   │  elapsed ──▶ expiry file        │     │
  │ stdout ──▶ file  │   │  TERM group + pid               │     │
  │ fd 3 closed      │   │  grace second, then KILL both   │     │
  └──────────────────┘   └────────────────────────────────┘     │
      │                                                          │
      ▼                                                          │
  wait for the script, then print what it wrote ◄────────────────┘
      │
      ▼
  expiry file present?
      ├─ yes ─▶ -- Script did not finish within the deadline --
      │         script / deadline / elapsed / output
      └─ no  ─▶ output, status and lines set the way run sets them
                    │
                    ▼
        tui_assert_prompts [_case]
          prompts matched in order, each after the last
          count checked against BATS_HELPERS_TUI_ANSWERS
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive script execution with configurable answers, timeouts, output capture, and environment variables.
  * Added case-sensitive and case-insensitive prompt-order assertions.
  * Added detailed timeout and prompt-validation feedback.

* **Documentation**
  * Expanded interactive scripting API documentation and usage guidance.
  * Documented the recommended empty-string answer and deprecated `nothing` answer.

* **Bug Fixes**
  * Improved timeout handling and cleanup of background processes.
  * Added validation for prompt and answer counts, empty prompts, and sandbox configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
