### PR TITLE
Corrected documentation that disagreed with the code and retargeted deprecations at 'v2.1'.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ Prose documentation lives in `docs/`, one page per module of `src/`, so the ques
 
 `README.md` holds only what a reader needs before choosing a page: the feature list, installation, the loader snippet, the index of documentation pages, the API reference table, and the contributing pointer. Prose that explains how a helper behaves belongs on the helper's page, never in the README.
 
-The API reference table in `README.md` is the index of the entire public surface: one row per public function, giving the name as inline code, a link to the source file that defines it, a one-line description, and a link to the heading that documents it. It is ordered by module in `load.bash` source order, and within a module in the order the functions are defined.
+The API reference table in `README.md` is the index of the entire public surface: one row per public function, giving the name as inline code, a link to the source file that defines it, a one-line description, and a link to the heading that documents it. It is ordered by module in `load.bash` source order, and within a module in the order that module's page presents its functions, so the Documentation column runs down each page's sections in turn rather than jumping between them.
 
 **Any change to the public surface updates the documentation in the same commit**, and the change is not complete until all of the following hold:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,9 +1,9 @@
 # Migration
 
-Every name below still works and will keep working until `v2`. Each one prints a notice on file descriptor 3 when it is used, naming its replacement, so it shows up in the BATS output without being captured by `run` or by command substitution:
+Every name below still works and will keep working until `v2.1`. Each one prints a notice on file descriptor 3 when it is used, naming its replacement, so it shows up in the BATS output without being captured by `run` or by command substitution:
 
 ```text
-Deprecated: 'assert_not_git_repo' will be removed in the next version. Use 'assert_git_not_repo' instead.
+Deprecated: 'assert_not_git_repo' will be removed in v2.1. Use 'assert_git_not_repo' instead.
 ```
 
 Set `BATS_HELPERS_DEPRECATION_QUIET` to any non-empty value to silence those notices while you migrate:

--- a/docs/assertions-command.md
+++ b/docs/assertions-command.md
@@ -8,17 +8,17 @@ Source: [`src/assert.command.bash`](../src/assert.command.bash)
 
 Use these after running a command with `run`.
 
-| Function Name                | Description                                            |
-|------------------------------|--------------------------------------------------------|
-| `assert_success`             | Asserts that a command succeeds                        |
-| `assert_failure`             | Asserts that a command fails                           |
-| `assert_output`              | Asserts that a command outputs an exact string         |
-| `assert_output_contains`     | Checks if output contains a specific string            |
-| `assert_output_not_contains` | Checks if output does not contain a specific string    |
-| `assert_output_matches`      | Checks if output matches a regular expression          |
-| `assert_output_not_matches`  | Checks if output does not match a regular expression   |
-| `assert_output_matches_format`     | Checks if output matches a format string         |
-| `assert_output_not_matches_format` | Checks if output does not match a format string  |
+| Function Name                       | Description                                          |
+|-------------------------------------|------------------------------------------------------|
+| `assert_success`                    | Asserts that a command succeeds                      |
+| `assert_failure`                    | Asserts that a command fails                         |
+| `assert_output`                     | Asserts that a command outputs an exact string       |
+| `assert_output_contains`            | Asserts that output contains a substring             |
+| `assert_output_not_contains`        | Asserts that output does not contain a substring     |
+| `assert_output_matches`             | Asserts that output matches a regular expression     |
+| `assert_output_not_matches`         | Asserts that output does not match a regular expression |
+| `assert_output_matches_format`      | Asserts that output matches a format string          |
+| `assert_output_not_matches_format`  | Asserts that output does not match a format string   |
 
 The six `contains`, `matches` and `matches_format` assertions each have a `_case` twin that matches case-sensitively - `assert_output_contains_case`, `assert_output_not_matches_format_case` and so on. See [Match modes](match-modes.md).
 
@@ -79,17 +79,17 @@ assert_status_command_not_found
 
 ## Standard error
 
-| Function Name                | Description                                                 |
-|------------------------------|-------------------------------------------------------------|
-| `assert_stderr`              | Asserts that a command writes an exact string to STDERR     |
-| `assert_stderr_contains`     | Checks if STDERR contains a specific string                 |
-| `assert_stderr_not_contains` | Checks if STDERR does not contain a specific string         |
-| `assert_stderr_matches`      | Checks if STDERR matches a regular expression               |
-| `assert_stderr_not_matches`  | Checks if STDERR does not match a regular expression        |
-| `assert_stderr_matches_format`     | Checks if STDERR matches a format string              |
-| `assert_stderr_not_matches_format` | Checks if STDERR does not match a format string       |
-| `assert_stderr_empty`        | Asserts that a command wrote nothing to STDERR              |
-| `assert_stderr_captured`     | Asserts that STDERR was captured separately from the output |
+| Function Name                       | Description                                                 |
+|-------------------------------------|-------------------------------------------------------------|
+| `assert_stderr`                     | Asserts that a command writes an exact string to STDERR     |
+| `assert_stderr_contains`            | Asserts that STDERR contains a substring                    |
+| `assert_stderr_not_contains`        | Asserts that STDERR does not contain a substring            |
+| `assert_stderr_matches`             | Asserts that STDERR matches a regular expression            |
+| `assert_stderr_not_matches`         | Asserts that STDERR does not match a regular expression     |
+| `assert_stderr_matches_format`      | Asserts that STDERR matches a format string                 |
+| `assert_stderr_not_matches_format`  | Asserts that STDERR does not match a format string          |
+| `assert_stderr_empty`               | Asserts that a command wrote nothing to STDERR              |
+| `assert_stderr_captured`            | Asserts that STDERR was captured separately from the output |
 
 The six `contains`, `matches` and `matches_format` assertions each have a `_case` twin that matches case-sensitively. See [Match modes](match-modes.md).
 

--- a/docs/assertions-file.md
+++ b/docs/assertions-file.md
@@ -10,19 +10,19 @@ Source: [`src/assert.file.bash`](../src/assert.file.bash)
 |----------------------------------|--------------------------------------------------------|
 | `assert_file_exists`             | Asserts that a file exists                             |
 | `assert_file_not_exists`         | Asserts that a file does not exist                     |
-| `assert_file_contains`           | Checks if a file contains a specific string            |
-| `assert_file_not_contains`       | Checks if a file does not contain a specific string    |
-| `assert_file_matches`            | Checks if a file matches a regular expression          |
-| `assert_file_not_matches`        | Checks if a file does not match a regular expression   |
-| `assert_file_matches_format`     | Checks if a file matches a format string               |
-| `assert_file_not_matches_format` | Checks if a file does not match a format string        |
+| `assert_file_contains`           | Asserts that a file contains a string                  |
+| `assert_file_not_contains`       | Asserts that a file does not contain a string          |
+| `assert_file_matches`            | Asserts that a file matches a regular expression       |
+| `assert_file_not_matches`        | Asserts that a file does not match a regular expression |
+| `assert_file_matches_format`     | Asserts that a file matches a format string            |
+| `assert_file_not_matches_format` | Asserts that a file does not match a format string     |
 | `assert_files_equal`             | Asserts that two files are equal                       |
 | `assert_files_equal_ignore_spaces` | Asserts that two files are equal, ignoring blank lines and whitespace changes |
 | `assert_files_not_equal`         | Asserts that two files are not equal                   |
 | `assert_files_not_equal_ignore_spaces` | Asserts that two files are not equal, ignoring blank lines and whitespace changes |
-| `assert_file_mode`               | Checks the file permission mode                        |
-| `assert_binary_files_equal`      | Checks if two binary files are equal                   |
-| `assert_binary_files_not_equal`  | Checks if two binary files are not equal               |
+| `assert_file_mode`               | Asserts the file permission mode                       |
+| `assert_binary_files_equal`      | Asserts that two binary files are equal                |
+| `assert_binary_files_not_equal`  | Asserts that two binary files are not equal            |
 
 ## Directories and symlinks
 

--- a/docs/assertions-git.md
+++ b/docs/assertions-git.md
@@ -10,8 +10,8 @@ Source: [`src/assert.git.bash`](../src/assert.git.bash)
 | `assert_git_not_repo`         | Asserts that a directory is not a git repository |
 | `assert_git_clean`            | Asserts that a git repository is clean           |
 | `assert_git_not_clean`        | Asserts that a git repository is not clean       |
-| `assert_git_file_tracked`     | Checks if a file is tracked in git               |
-| `assert_git_file_not_tracked` | Checks if a file is not tracked in git           |
+| `assert_git_file_tracked`     | Asserts that a file is tracked in git            |
+| `assert_git_file_not_tracked` | Asserts that a file is not tracked in git        |
 
 `assert_git_file_tracked` and `assert_git_file_not_tracked` report through the exit status alone and print no message.
 

--- a/docs/assertions-line.md
+++ b/docs/assertions-line.md
@@ -12,12 +12,12 @@ Assert a line by index. A negative index counts back from the end, so `-1` is th
 |----------------------------------|--------------------------------------------------------------------|
 | `assert_line`                    | Asserts that the line at an index equals a string                  |
 | `assert_line_not`                | Asserts that the line at an index does not equal a string          |
-| `assert_line_contains`           | Checks if the line at an index contains a string                   |
-| `assert_line_not_contains`       | Checks if the line at an index does not contain a string           |
-| `assert_line_matches`            | Checks if the line at an index matches a regular expression        |
-| `assert_line_not_matches`        | Checks if the line at an index does not match a regular expression |
-| `assert_line_matches_format`     | Checks if the line at an index matches a format string             |
-| `assert_line_not_matches_format` | Checks if the line at an index does not match a format string      |
+| `assert_line_contains`           | Asserts that the line at an index contains a string                |
+| `assert_line_not_contains`       | Asserts that the line at an index does not contain a string        |
+| `assert_line_matches`            | Asserts that the line at an index matches a regular expression     |
+| `assert_line_not_matches`        | Asserts that the line at an index does not match a regular expression |
+| `assert_line_matches_format`     | Asserts that the line at an index matches a format string          |
+| `assert_line_not_matches_format` | Asserts that the line at an index does not match a format string   |
 
 ## Any line
 
@@ -27,12 +27,12 @@ Assert that some line matches, without pinning which one. The positive reads `an
 |-------------------------------------|--------------------------------------------------------|
 | `assert_any_line`                   | Asserts that some line equals a string                 |
 | `assert_no_line`                    | Asserts that no line equals a string                   |
-| `assert_any_line_contains`          | Checks if some line contains a string                  |
-| `assert_no_line_contains`           | Checks if no line contains a string                    |
-| `assert_any_line_matches`           | Checks if some line matches a regular expression       |
-| `assert_no_line_matches`            | Checks if no line matches a regular expression         |
-| `assert_any_line_matches_format`    | Checks if some line matches a format string            |
-| `assert_no_line_matches_format`     | Checks if no line matches a format string              |
+| `assert_any_line_contains`          | Asserts that some line contains a string               |
+| `assert_no_line_contains`           | Asserts that no line contains a string                 |
+| `assert_any_line_matches`           | Asserts that some line matches a regular expression    |
+| `assert_no_line_matches`            | Asserts that no line matches a regular expression      |
+| `assert_any_line_matches_format`    | Asserts that some line matches a format string         |
+| `assert_no_line_matches_format`     | Asserts that no line matches a format string           |
 
 ## Counts
 
@@ -72,7 +72,7 @@ assert_line_count_contains 2 "error"
 An index outside the captured lines is an error naming both the index and the number of lines, rather than a comparison against an empty string that would read as an ordinary mismatch:
 
 ```text
-Line index 5 is out of range for output with 2 lines.
+Line index '5' is out of range for output with 2 lines.
 ```
 
 A failure shows the offending line in context rather than the whole stream. The mark overwrites the indent instead of being inserted, so the lines stay in the same column:

--- a/docs/mocking.md
+++ b/docs/mocking.md
@@ -15,12 +15,12 @@ Source: [`src/mock.bash`](../src/mock.bash)
 
 | Function                | Description                                                | Arguments                        | Returns   |
 |-------------------------|------------------------------------------------------------|----------------------------------|-----------|
-| `mock_setup`            | Setup mock support. Call from `setup()`                    | None                             | None      |
+| `mock_setup`            | Sets mocking up. Call from `setup()`                       | None                             | None      |
 | `mock_create`           | Creates a mock program that can be tracked                 | None                             | Mock path |
-| `mock_command`          | Mock provided command                                      | `command_name`                   | Mock path |
+| `mock_command`          | Mocks the provided command                                 | `command_name`                   | Mock path |
 | `mock_set_output`       | Sets the output of the mock                                | `mock`, `output`, `[call_index]` | None      |
 | `mock_set_status`       | Sets the exit status of the mock                           | `mock`, `status`, `[call_index]` | None      |
-| `mock_set_side_effect`  | Sets shell code to run when mock executes                  | `mock`, `code`, `[call_index]`   | None      |
+| `mock_set_side_effect`  | Sets shell code to run when the mock executes              | `mock`, `code`, `[call_index]`   | None      |
 | `mock_set_strict`       | Rejects the calls the mock's expectations do not cover     | `mock`, `[enabled]`              | None      |
 | `mock_set_forward`      | Runs the real command for calls no specification accepts   | `mock`, `[enabled]`              | None      |
 | `mock_spec_add`         | Adds an argument specification to the mock                 | `mock`                           | Spec      |
@@ -35,11 +35,11 @@ Source: [`src/mock.bash`](../src/mock.bash)
 
 | Function                 | Description                                                                    | Arguments                               | Returns          |
 |--------------------------|--------------------------------------------------------------------------------|-----------------------------------------|------------------|
-| `mock_get_call_args`     | Returns arguments the mock was called with                                     | `mock`, `[call_index]`                  | Arguments string |
-| `mock_get_call_num`      | Returns number of times mock was called                                        | `mock`                                  | Call count       |
-| `mock_get_call_user`     | Returns user the mock was called with                                          | `mock`, `[call_index]`                  | User name        |
-| `mock_get_call_env`      | Returns env variable value from mock call                                      | `mock`, `var_name`, `[call_index]`      | Variable value   |
-| `mock_assert_call_args`  | Checks the arguments the mock was called with, where `*` matches any arguments | `mock`, `expected_args`, `[call_index]` | `0` when matched |
+| `mock_get_call_args`     | Returns the arguments the mock was called with                                 | `mock`, `[call_index]`                  | Arguments string |
+| `mock_get_call_num`      | Returns the number of times the mock was called                                | `mock`                                  | Call count       |
+| `mock_get_call_user`     | Returns the user the mock was called with                                      | `mock`, `[call_index]`                  | User name        |
+| `mock_get_call_env`      | Returns an environment variable value from a mock call                         | `mock`, `var_name`, `[call_index]`      | Variable value   |
+| `mock_assert_call_args`  | Asserts the arguments the mock was called with, where `*` matches any arguments | `mock`, `expected_args`, `[call_index]` | `0` when matched |
 | `mock_assert_calls`      | Asserts the ordered sequence of every mocked call                              | `expected_call...`                      | None             |
 | `mock_assert_no_calls`   | Asserts that no mocked command outside the excluded ones was called            | None                                    | None             |
 | `mock_assert_called`     | Asserts that a command was called                                              | `command_name`                          | None             |

--- a/docs/retry.md
+++ b/docs/retry.md
@@ -78,15 +78,20 @@ retry_run 10 0.5 curl -sf "http://localhost:8080/health"
 assert_string_contains "${BATS_HELPERS_RETRY_OUTPUT}" "\"status\":\"ok\""
 ```
 
-When every bound is exhausted the failure names the elapsed time, the attempt count and the last observed state, so the run does not have to be reproduced by hand to find out what it was doing:
+When every bound is exhausted the failure names the bound that was reached, the elapsed time, the attempt count and the last observed state, so the run does not have to be reproduced by hand to find out what it was doing:
 
 ```text
-Command 'curl' did not succeed within 5 attempt(s).
-attempts: 5
-elapsed: 4 second(s)
-last status: 7
-last output: 'curl: (7) Failed to connect to localhost port 8080'
+-- Command did not succeed within the retry limit --
+command     : curl
+limit       : 5 attempt(s)
+attempts    : 5
+elapsed     : 4 second(s)
+last status : 7
+last output : curl: (7) Failed to connect to localhost port 8080
+--
 ```
+
+The `limit` row names whichever bound ended the retry, so an exhausted attempt count reads as `5 attempt(s)` and an exhausted deadline as `the 10 second deadline`.
 
 ## What an attempt sees
 

--- a/docs/steps.md
+++ b/docs/steps.md
@@ -1,8 +1,8 @@
 # Step runner
 
-When working with mocks, you would have to setup a mock for each command call with the expected argument numbers, return value, possible output and an index of the call. Then, you would run the code to be tested and run assertions for each of the mocked commands. For large scripts maintaining both parts becomes a tedious task.
+Mocking by hand means setting up a mock for each command call with its expected arguments, return value, possible output and call index, then running the code under test and asserting against each mock in turn. For a large script, keeping those two halves in step becomes a tedious task.
 
-The step runner allows to setup and process a sequence of string and mocked command assertions. It helps to make maintenance of complex tests easier.
+The step runner sets up and processes a sequence of string and mocked command assertions, so both halves are declared once in one array.
 
 Source: [`src/steps.bash`](../src/steps.bash)
 
@@ -81,7 +81,7 @@ Mock a command with the given status, optional output, and optional side effect.
   - Use `*` as wildcard to accept any arguments
 - `<mock_status>` - exit status to return (optional):
   - If not specified, `0` exit code will be used
-  - Can be omitted if only `<mock_output>` is needed
+  - Can be omitted and the output given in its place, unless that output is all digits, which parses as a status
 - `<mock_output>` - output to return (optional)
 - `<mock_side_effect>` - Bash code executed when mock is called (optional):
   - Useful for creating files/directories, setting env vars, logging, simulating complex behaviors

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -76,6 +76,10 @@ prompt (1 line):
 Install profile
 matched (1 line):
 2 of 3
+match mode (1 line):
+literal
+case (1 line):
+insensitive
 remaining output (2 lines):
  [my_site]: 
 Installation complete

--- a/src/assert.command.bash
+++ b/src/assert.command.bash
@@ -48,7 +48,7 @@ assert_failure() {
   local expected=""
 
   if [ "${1-}" = "--status" ]; then
-    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_failure --status' will be removed in the next version. Use 'assert_failure_status' instead." >&3
+    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_failure --status' will be removed in v2.1. Use 'assert_failure_status' instead." >&3
 
     if [ "$#" -lt 2 ]; then
       flunk "Option '--status' requires an exit status."

--- a/src/assert.file.bash
+++ b/src/assert.file.bash
@@ -401,7 +401,7 @@ _file_dir_exclude_names() {
   if [ -n "${BATS_HELPERS_ASSERT_DIR_EXCLUDE+x}" ]; then
     exclude_dirs+=("${BATS_HELPERS_ASSERT_DIR_EXCLUDE[@]}")
   elif [ -n "${ASSERT_DIR_EXCLUDE+x}" ]; then
-    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'ASSERT_DIR_EXCLUDE' will be removed in the next version. Use 'BATS_HELPERS_ASSERT_DIR_EXCLUDE' instead." >&3
+    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'ASSERT_DIR_EXCLUDE' will be removed in v2.1. Use 'BATS_HELPERS_ASSERT_DIR_EXCLUDE' instead." >&3
     exclude_dirs+=("${ASSERT_DIR_EXCLUDE[@]}")
   fi
 
@@ -777,7 +777,7 @@ assert_files_equal() {
   local ignore_spaces="${3:-0}"
 
   if [ "${ignore_spaces}" = 1 ]; then
-    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: the 'ignore_spaces' argument of 'assert_files_equal' will be removed in the next version. Use 'assert_files_equal_ignore_spaces' instead." >&3
+    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: the 'ignore_spaces' argument of 'assert_files_equal' will be removed in v2.1. Use 'assert_files_equal_ignore_spaces' instead." >&3
   fi
 
   _file_assert_equal 0 "${ignore_spaces}" "${1}" "${2}"
@@ -812,7 +812,7 @@ assert_files_not_equal() {
   local ignore_spaces="${3:-0}"
 
   if [ "${ignore_spaces}" = 1 ]; then
-    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: the 'ignore_spaces' argument of 'assert_files_not_equal' will be removed in the next version. Use 'assert_files_not_equal_ignore_spaces' instead." >&3
+    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: the 'ignore_spaces' argument of 'assert_files_not_equal' will be removed in v2.1. Use 'assert_files_not_equal_ignore_spaces' instead." >&3
   fi
 
   _file_assert_equal 1 "${ignore_spaces}" "${1}" "${2}"

--- a/src/assert.git.bash
+++ b/src/assert.git.bash
@@ -147,20 +147,20 @@ assert_git_not_clean() {
 }
 
 ##
-## Deprecated aliases, removed in the next version.
+## Deprecated aliases, removed in v2.1.
 ##
 
 assert_not_git_repo() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_not_git_repo' will be removed in the next version. Use 'assert_git_not_repo' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_not_git_repo' will be removed in v2.1. Use 'assert_git_not_repo' instead." >&3
   assert_git_not_repo "$@"
 }
 
 assert_git_file_is_tracked() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_git_file_is_tracked' will be removed in the next version. Use 'assert_git_file_tracked' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_git_file_is_tracked' will be removed in v2.1. Use 'assert_git_file_tracked' instead." >&3
   assert_git_file_tracked "$@"
 }
 
 assert_git_file_is_not_tracked() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_git_file_is_not_tracked' will be removed in the next version. Use 'assert_git_file_not_tracked' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_git_file_is_not_tracked' will be removed in v2.1. Use 'assert_git_file_not_tracked' instead." >&3
   assert_git_file_not_tracked "$@"
 }

--- a/src/assert.string.bash
+++ b/src/assert.string.bash
@@ -668,20 +668,20 @@ string_random() {
 }
 
 ##
-## Deprecated aliases, removed in the next version.
+## Deprecated aliases, removed in v2.1.
 ##
 
 assert_contains() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_contains' will be removed in the next version. Use 'assert_string_contains' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_contains' will be removed in v2.1. Use 'assert_string_contains' instead." >&3
   assert_string_contains "${2-}" "${1-}"
 }
 
 assert_not_contains() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_not_contains' will be removed in the next version. Use 'assert_string_not_contains' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'assert_not_contains' will be removed in v2.1. Use 'assert_string_not_contains' instead." >&3
   assert_string_not_contains "${2-}" "${1-}"
 }
 
 random_string() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'random_string' will be removed in the next version. Use 'string_random' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'random_string' will be removed in v2.1. Use 'string_random' instead." >&3
   string_random "$@"
 }

--- a/src/file.bash
+++ b/src/file.bash
@@ -99,7 +99,7 @@ file_backup_path() {
   if [ -n "${BATS_HELPERS_FILE_BACKUP_DIR-}" ]; then
     root="${BATS_HELPERS_FILE_BACKUP_DIR}"
   elif [ -n "${BATS_HELPERS_BACKUP_DIR-}" ]; then
-    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'BATS_HELPERS_BACKUP_DIR' will be removed in the next version. Use 'BATS_HELPERS_FILE_BACKUP_DIR' instead." >&3
+    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'BATS_HELPERS_BACKUP_DIR' will be removed in v2.1. Use 'BATS_HELPERS_FILE_BACKUP_DIR' instead." >&3
     root="${BATS_HELPERS_BACKUP_DIR}"
   else
     root="${BATS_TEST_TMPDIR:+${BATS_TEST_TMPDIR}/bats-helpers-backup}"
@@ -161,30 +161,30 @@ file_restore() {
 }
 
 ##
-## Deprecated aliases, removed in the next version.
+## Deprecated aliases, removed in v2.1.
 ##
 
 mktouch() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'mktouch' will be removed in the next version. Use 'file_mktouch' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'mktouch' will be removed in v2.1. Use 'file_mktouch' instead." >&3
   file_mktouch "$@"
 }
 
 trim_file() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'trim_file' will be removed in the next version. Use 'file_trim' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'trim_file' will be removed in v2.1. Use 'file_trim' instead." >&3
   file_trim "$@"
 }
 
 read_env() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'read_env' will be removed in the next version. Use 'file_read_env' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'read_env' will be removed in v2.1. Use 'file_read_env' instead." >&3
   file_read_env "$@"
 }
 
 add_var_to_file() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'add_var_to_file' will be removed in the next version. Use 'file_add_var' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'add_var_to_file' will be removed in v2.1. Use 'file_add_var' instead." >&3
   file_add_var "$@"
 }
 
 restore_file() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'restore_file' will be removed in the next version. Use 'file_restore' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'restore_file' will be removed in v2.1. Use 'file_restore' instead." >&3
   file_restore "$@"
 }

--- a/src/fixture.bash
+++ b/src/fixture.bash
@@ -23,7 +23,7 @@ fixture_export_codebase() {
   if [ -n "${BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED-}" ]; then
     enabled="${BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED}"
   elif [ -n "${BATS_FIXTURE_EXPORT_CODEBASE_ENABLED-}" ]; then
-    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'BATS_FIXTURE_EXPORT_CODEBASE_ENABLED' will be removed in the next version. Use 'BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED' instead." >&3
+    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'BATS_FIXTURE_EXPORT_CODEBASE_ENABLED' will be removed in v2.1. Use 'BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED' instead." >&3
     enabled="${BATS_FIXTURE_EXPORT_CODEBASE_ENABLED}"
   fi
 

--- a/src/mock.bash
+++ b/src/mock.bash
@@ -58,7 +58,7 @@ _mock_resolve_tmp() {
   if [ -n "${BATS_HELPERS_MOCK_TMPDIR-}" ]; then
     dir="${BATS_HELPERS_MOCK_TMPDIR}"
   elif [ -n "${BATS_MOCK_TMPDIR-}" ]; then
-    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'BATS_MOCK_TMPDIR' will be removed in the next version. Use 'BATS_HELPERS_MOCK_TMPDIR' instead." >&3
+    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'BATS_MOCK_TMPDIR' will be removed in v2.1. Use 'BATS_HELPERS_MOCK_TMPDIR' instead." >&3
     dir="${BATS_MOCK_TMPDIR}"
   else
     dir="${BATS_TEST_TMPDIR-}"
@@ -193,7 +193,7 @@ mock_create() {
   # The notice is emitted here rather than from the mock, which runs as a
   # separate process with no file descriptor 3 to write to.
   if [ -z "${BATS_HELPERS_MOCK_USER-}" ] && [ -n "${_USER-}" ]; then
-    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: '_USER' will be removed in the next version. Use 'BATS_HELPERS_MOCK_USER' instead." >&3
+    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: '_USER' will be removed in v2.1. Use 'BATS_HELPERS_MOCK_USER' instead." >&3
   fi
 
   local index
@@ -2197,10 +2197,10 @@ _mock_verify_mock() {
 }
 
 ##
-## Deprecated aliases, removed in the next version.
+## Deprecated aliases, removed in v2.1.
 ##
 
 setup_mock() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'setup_mock' will be removed in the next version. Use 'mock_setup' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'setup_mock' will be removed in v2.1. Use 'mock_setup' instead." >&3
   mock_setup "$@"
 }

--- a/src/steps.bash
+++ b/src/steps.bash
@@ -61,7 +61,7 @@ steps_run() {
   local mocked_commands_var="${2-}"
 
   if [ -z "${BATS_HELPERS_STEPS_DEBUG-}" ] && [ -n "${RUN_STEPS_DEBUG-}" ]; then
-    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'RUN_STEPS_DEBUG' will be removed in the next version. Use 'BATS_HELPERS_STEPS_DEBUG' instead." >&3
+    [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'RUN_STEPS_DEBUG' will be removed in v2.1. Use 'BATS_HELPERS_STEPS_DEBUG' instead." >&3
   fi
 
   if [ -z "${STEPS+x}" ]; then
@@ -121,7 +121,6 @@ steps_run() {
       command_parts=("${command_parts[@]/# /}")
       command_parts=("${command_parts[@]/% /}")
 
-      # Extract the command binary and its arguments from the first command part.
       local full_command
       IFS=' ' read -ra full_command <<<"${command_parts[0]:1}" # Removing '@'.
       local command_binary="${full_command[0]}"
@@ -131,7 +130,6 @@ steps_run() {
       local mock_output="${command_parts[2]-}"
       local mock_side_effect="${command_parts[3]-}"
 
-      # Restore escaped hashes in all parsed components.
       command_args="${command_args//${ESCAPED_HASH_PLACEHOLDER}/#}"
       mock_status="${mock_status//${ESCAPED_HASH_PLACEHOLDER}/#}"
       mock_output="${mock_output//${ESCAPED_HASH_PLACEHOLDER}/#}"
@@ -159,7 +157,6 @@ steps_run() {
       _steps_debug_sub "Command index for '${command_binary}' is '${command_index}'."
 
       if [ "${phase}" = "${PHASE_SETUP}" ]; then
-        # Get mock from passed array or create a new one.
         if [ -z "${mocked_commands["${command_binary}"]-}" ]; then
           mock="$(mock_command "${command_binary}")"
           mocked_commands["${command_binary}"]=${mock}
@@ -203,7 +200,6 @@ steps_run() {
         fi
         _steps_debug_sub "        actual args : ${mock_args_actual}"
 
-        # Use wildcard-aware assertion.
         if ! mock_assert_call_args "${mock}" "${command_args}" "${command_index}"; then
           flunk "Mocked command '${command_binary}' was called with arguments '${mock_args_actual}', but '${command_args}' was expected."
           return 1
@@ -312,10 +308,10 @@ _steps_debug_write() {
 }
 
 ##
-## Deprecated aliases, removed in the next version.
+## Deprecated aliases, removed in v2.1.
 ##
 
 run_steps() {
-  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'run_steps' will be removed in the next version. Use 'steps_run' instead." >&3
+  [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: 'run_steps' will be removed in v2.1. Use 'steps_run' instead." >&3
   steps_run "$@"
 }

--- a/src/tui.bash
+++ b/src/tui.bash
@@ -79,7 +79,7 @@ tui_run() {
 
   for answer in "${answers[@]}"; do
     if [ "${answer}" = "nothing" ]; then
-      [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: the 'nothing' answer will be removed in the next version. Use an empty string instead." >&3
+      [ -n "${BATS_HELPERS_DEPRECATION_QUIET-}" ] || echo "Deprecated: the 'nothing' answer will be removed in v2.1. Use an empty string instead." >&3
       answer=""
     fi
 

--- a/tests/deprecation.bats
+++ b/tests/deprecation.bats
@@ -15,7 +15,7 @@ load _test_helper
 
   assert_not_git_repo "${BATS_TEST_TMPDIR}/fixture/not_git_repo" 3>"${notice}"
 
-  assert_file_contains "${notice}" "Deprecated: 'assert_not_git_repo' will be removed in the next version. Use 'assert_git_not_repo' instead."
+  assert_file_contains "${notice}" "Deprecated: 'assert_not_git_repo' will be removed in v2.1. Use 'assert_git_not_repo' instead."
 }
 
 @test "assert_git_file_is_tracked" {
@@ -27,7 +27,7 @@ load _test_helper
 
   assert_git_file_is_tracked "1.txt" "${BATS_TEST_TMPDIR}/fixture/git_repo" 3>"${notice}"
 
-  assert_file_contains "${notice}" "Deprecated: 'assert_git_file_is_tracked' will be removed in the next version. Use 'assert_git_file_tracked' instead."
+  assert_file_contains "${notice}" "Deprecated: 'assert_git_file_is_tracked' will be removed in v2.1. Use 'assert_git_file_tracked' instead."
 }
 
 @test "assert_git_file_is_not_tracked" {
@@ -40,7 +40,7 @@ load _test_helper
 
   assert_git_file_is_not_tracked "2.txt" "${BATS_TEST_TMPDIR}/fixture/git_repo" 3>"${notice}"
 
-  assert_file_contains "${notice}" "Deprecated: 'assert_git_file_is_not_tracked' will be removed in the next version. Use 'assert_git_file_not_tracked' instead."
+  assert_file_contains "${notice}" "Deprecated: 'assert_git_file_is_not_tracked' will be removed in v2.1. Use 'assert_git_file_not_tracked' instead."
 }
 
 @test "assert_contains" {
@@ -48,7 +48,7 @@ load _test_helper
 
   assert_contains "needle" "some needle in a haystack" 3>"${notice}"
 
-  assert_file_contains "${notice}" "Deprecated: 'assert_contains' will be removed in the next version. Use 'assert_string_contains' instead."
+  assert_file_contains "${notice}" "Deprecated: 'assert_contains' will be removed in v2.1. Use 'assert_string_contains' instead."
 }
 
 @test "assert_not_contains" {
@@ -56,7 +56,7 @@ load _test_helper
 
   assert_not_contains "otherneedle" "some needle in a haystack" 3>"${notice}"
 
-  assert_file_contains "${notice}" "Deprecated: 'assert_not_contains' will be removed in the next version. Use 'assert_string_not_contains' instead."
+  assert_file_contains "${notice}" "Deprecated: 'assert_not_contains' will be removed in v2.1. Use 'assert_string_not_contains' instead."
 }
 
 @test "random_string" {
@@ -67,7 +67,7 @@ load _test_helper
   assert_success
   assert_equal 5 "${#output}"
   assert_empty "${output//[a-zA-Z0-9]/}"
-  assert_file_contains "${notice}" "Deprecated: 'random_string' will be removed in the next version. Use 'string_random' instead."
+  assert_file_contains "${notice}" "Deprecated: 'random_string' will be removed in v2.1. Use 'string_random' instead."
 }
 
 @test "run_steps" {
@@ -79,7 +79,7 @@ load _test_helper
   run echo "Some Substring"
   run_steps "assert" 3>"${notice}"
 
-  assert_file_contains "${notice}" "Deprecated: 'run_steps' will be removed in the next version. Use 'steps_run' instead."
+  assert_file_contains "${notice}" "Deprecated: 'run_steps' will be removed in v2.1. Use 'steps_run' instead."
 }
 
 @test "setup_mock" {
@@ -88,7 +88,7 @@ load _test_helper
   setup_mock 3>"${notice}"
 
   assert_dir_exists "${BATS_HELPERS_MOCK_TMPDIR}"
-  assert_file_contains "${notice}" "Deprecated: 'setup_mock' will be removed in the next version. Use 'mock_setup' instead."
+  assert_file_contains "${notice}" "Deprecated: 'setup_mock' will be removed in v2.1. Use 'mock_setup' instead."
 }
 
 @test "mktouch" {
@@ -97,7 +97,7 @@ load _test_helper
   mktouch "${BATS_TEST_TMPDIR}/dir1/dir2/file.txt" 3>"${notice}"
 
   assert_file_exists "${BATS_TEST_TMPDIR}/dir1/dir2/file.txt"
-  assert_file_contains "${notice}" "Deprecated: 'mktouch' will be removed in the next version. Use 'file_mktouch' instead."
+  assert_file_contains "${notice}" "Deprecated: 'mktouch' will be removed in v2.1. Use 'file_mktouch' instead."
 }
 
 @test "file_add_var with the deprecated backup directory variable" {
@@ -108,7 +108,7 @@ load _test_helper
   file_add_var "${BATS_TEST_TMPDIR}/.env" "VAR" "value" 3>"${notice}"
 
   assert_file_exists "${BATS_TEST_TMPDIR}/backups/${BATS_TEST_TMPDIR#/}/.env"
-  assert_file_contains "${notice}" "Deprecated: 'BATS_HELPERS_BACKUP_DIR' will be removed in the next version. Use 'BATS_HELPERS_FILE_BACKUP_DIR' instead."
+  assert_file_contains "${notice}" "Deprecated: 'BATS_HELPERS_BACKUP_DIR' will be removed in v2.1. Use 'BATS_HELPERS_FILE_BACKUP_DIR' instead."
 }
 
 @test "assert_failure with the deprecated status option" {
@@ -117,7 +117,7 @@ load _test_helper
   run bash -c 'exit 2'
   assert_failure --status 2 3>"${notice}"
 
-  assert_file_contains "${notice}" "Deprecated: 'assert_failure --status' will be removed in the next version. Use 'assert_failure_status' instead."
+  assert_file_contains "${notice}" "Deprecated: 'assert_failure --status' will be removed in v2.1. Use 'assert_failure_status' instead."
 }
 
 @test "assert_files_equal and assert_files_not_equal with the deprecated ignore_spaces argument" {
@@ -129,8 +129,8 @@ load _test_helper
   assert_files_equal "${BATS_TEST_TMPDIR}/text.txt" "${BATS_TEST_TMPDIR}/text_newline.txt" 1 3>"${notice}"
   assert_files_not_equal "${BATS_TEST_TMPDIR}/text.txt" "${BATS_TEST_TMPDIR}/text_changed.txt" 1 3>>"${notice}"
 
-  assert_file_contains "${notice}" "Deprecated: the 'ignore_spaces' argument of 'assert_files_equal' will be removed in the next version. Use 'assert_files_equal_ignore_spaces' instead."
-  assert_file_contains "${notice}" "Deprecated: the 'ignore_spaces' argument of 'assert_files_not_equal' will be removed in the next version. Use 'assert_files_not_equal_ignore_spaces' instead."
+  assert_file_contains "${notice}" "Deprecated: the 'ignore_spaces' argument of 'assert_files_equal' will be removed in v2.1. Use 'assert_files_equal_ignore_spaces' instead."
+  assert_file_contains "${notice}" "Deprecated: the 'ignore_spaces' argument of 'assert_files_not_equal' will be removed in v2.1. Use 'assert_files_not_equal_ignore_spaces' instead."
 }
 
 @test "trim_file" {
@@ -141,7 +141,7 @@ load _test_helper
   trim_file "${BATS_TEST_TMPDIR}/file.txt" 3>"${notice}"
 
   assert_file_not_contains "${BATS_TEST_TMPDIR}/file.txt" "line2"
-  assert_file_contains "${notice}" "Deprecated: 'trim_file' will be removed in the next version. Use 'file_trim' instead."
+  assert_file_contains "${notice}" "Deprecated: 'trim_file' will be removed in v2.1. Use 'file_trim' instead."
 }
 
 @test "read_env" {
@@ -154,7 +154,7 @@ load _test_helper
 
   assert_success
   assert_output_contains "val1"
-  assert_file_contains "${notice}" "Deprecated: 'read_env' will be removed in the next version. Use 'file_read_env' instead."
+  assert_file_contains "${notice}" "Deprecated: 'read_env' will be removed in v2.1. Use 'file_read_env' instead."
 
   popd
 }
@@ -166,12 +166,12 @@ load _test_helper
   add_var_to_file "${BATS_TEST_TMPDIR}/.env" "VAR" "value" 3>"${notice}"
 
   assert_file_contains "${BATS_TEST_TMPDIR}/.env" "VAR=value"
-  assert_file_contains "${notice}" "Deprecated: 'add_var_to_file' will be removed in the next version. Use 'file_add_var' instead."
+  assert_file_contains "${notice}" "Deprecated: 'add_var_to_file' will be removed in v2.1. Use 'file_add_var' instead."
 
   restore_file "${BATS_TEST_TMPDIR}/.env" 3>>"${notice}"
 
   assert_file_not_contains "${BATS_TEST_TMPDIR}/.env" "VAR=value"
-  assert_file_contains "${notice}" "Deprecated: 'restore_file' will be removed in the next version. Use 'file_restore' instead."
+  assert_file_contains "${notice}" "Deprecated: 'restore_file' will be removed in v2.1. Use 'file_restore' instead."
 }
 
 @test "tui_run with the deprecated nothing answer" {
@@ -181,7 +181,7 @@ load _test_helper
   tui_run "nothing" "custom answer2" 3>"${notice}"
 
   assert_output_contains "default answer1"
-  assert_file_contains "${notice}" "Deprecated: the 'nothing' answer will be removed in the next version. Use an empty string instead."
+  assert_file_contains "${notice}" "Deprecated: the 'nothing' answer will be removed in v2.1. Use an empty string instead."
 }
 
 @test "steps_run with the deprecated debug variable" {
@@ -194,7 +194,7 @@ load _test_helper
   )
   steps_run "assert" 3>"${notice}"
 
-  assert_file_contains "${notice}" "Deprecated: 'RUN_STEPS_DEBUG' will be removed in the next version. Use 'BATS_HELPERS_STEPS_DEBUG' instead."
+  assert_file_contains "${notice}" "Deprecated: 'RUN_STEPS_DEBUG' will be removed in v2.1. Use 'BATS_HELPERS_STEPS_DEBUG' instead."
   assert_file_contains "${notice}" "  > Total steps : 1"
 }
 
@@ -206,7 +206,7 @@ load _test_helper
 
   assert_dir_not_contains_string "${BATS_TEST_TMPDIR}/fixture" "existing" 3>"${notice}"
 
-  assert_file_contains "${notice}" "Deprecated: 'ASSERT_DIR_EXCLUDE' will be removed in the next version. Use 'BATS_HELPERS_ASSERT_DIR_EXCLUDE' instead."
+  assert_file_contains "${notice}" "Deprecated: 'ASSERT_DIR_EXCLUDE' will be removed in v2.1. Use 'BATS_HELPERS_ASSERT_DIR_EXCLUDE' instead."
 }
 
 @test "_mock_prepare_tmp with the deprecated temporary directory variable" {
@@ -218,7 +218,7 @@ load _test_helper
 
   assert_success
   assert_output "${BATS_TEST_TMPDIR}/custom/bats-helpers-mock"
-  assert_file_contains "${notice}" "Deprecated: 'BATS_MOCK_TMPDIR' will be removed in the next version. Use 'BATS_HELPERS_MOCK_TMPDIR' instead."
+  assert_file_contains "${notice}" "Deprecated: 'BATS_MOCK_TMPDIR' will be removed in v2.1. Use 'BATS_HELPERS_MOCK_TMPDIR' instead."
 }
 
 @test "mock_get_call_user with the deprecated user variable" {
@@ -229,7 +229,7 @@ load _test_helper
   curl example.com
 
   assert_equal "someoneelse" "$(mock_get_call_user "${mock_curl}")"
-  assert_file_contains "${notice}" "Deprecated: '_USER' will be removed in the next version. Use 'BATS_HELPERS_MOCK_USER' instead."
+  assert_file_contains "${notice}" "Deprecated: '_USER' will be removed in v2.1. Use 'BATS_HELPERS_MOCK_USER' instead."
 }
 
 @test "fixture_export_codebase with the deprecated enable variable" {
@@ -240,7 +240,7 @@ load _test_helper
   fixture_export_codebase "${BATS_TEST_TMPDIR}/build" 3>"${notice}"
 
   assert_file_exists "${BATS_TEST_TMPDIR}/build/README.md"
-  assert_file_contains "${notice}" "Deprecated: 'BATS_FIXTURE_EXPORT_CODEBASE_ENABLED' will be removed in the next version. Use 'BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED' instead."
+  assert_file_contains "${notice}" "Deprecated: 'BATS_FIXTURE_EXPORT_CODEBASE_ENABLED' will be removed in v2.1. Use 'BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED' instead."
 }
 
 @test "Prefixed variables take precedence and emit no notices" {


### PR DESCRIPTION
## Summary

This is a documentation-and-consistency polish pass over the bats-helpers library, with no behavioural changes. It corrects four documentation samples that had drifted from what the code actually prints, normalizes function-description wording across five API reference pages onto the phrasing the README's API reference table already uses, and retargets every deprecation removal notice from the vague "the next version" to the concrete "v2.1" across `src/`, `tests/deprecation.bats`, and `MIGRATION.md`. It also removes four comments from `src/steps.bash` that only restated the line below them, and corrects the API-table ordering rule stated in `CLAUDE.md` so it describes the ordering the table actually follows.

## Changes

- **Documentation samples corrected to match actual output** - `docs/assertions-line.md`'s out-of-range sample now quotes the index the way `src/assert.line.bash` actually does; `docs/retry.md`'s exhausted-retry sample now shows the real `format_error` block (title, `command`, `limit`, `attempts`, `elapsed`, `last status`, `last output` rows) and explains the `limit` row; `docs/steps.md` corrects how `<mock_status>` can be omitted; `docs/tui.md`'s sample output gains the `match mode` and `case` rows the code actually prints.
- **Function-description wording normalized** - `docs/assertions-command.md`, `docs/assertions-file.md`, `docs/assertions-git.md`, `docs/assertions-line.md`, and `docs/mocking.md` reword table rows from "Checks if..." / "Checks the..." to "Asserts that..." / "Asserts the...", matching the phrasing already used in the README's API reference table.
- **Deprecation removal target retargeted to `v2.1`** - every "will be removed in the next version" notice across `src/assert.command.bash`, `src/assert.file.bash`, `src/assert.git.bash`, `src/assert.string.bash`, `src/file.bash`, `src/fixture.bash`, `src/mock.bash`, `src/steps.bash`, and `src/tui.bash`, plus every matching assertion in `tests/deprecation.bats`, now names `v2.1`; `MIGRATION.md`'s intro line moves from `v2` to `v2.1` to match.
- **WHAT-comments removed from `src/steps.bash`** - four comments that only restated the statement directly below them are dropped, leaving the code to speak for itself.
- **API-table ordering rule corrected in `CLAUDE.md`** - the rule describing the README API reference table's within-module ordering now states that it follows the order each module's documentation page presents its functions, rather than `load.bash` definition order.

## Before / After

```text
┌────────────────────────────────────────────────────────────────────────┐
│ docs/assertions-line.md sample vs. what the code actually prints       │
│                                                                        │
│   BEFORE  "Line index 5 is out of range for output with 2 lines."      │
│   CODE    "Line index '5' is out of range for output with 2 lines."    │
│   AFTER   "Line index '5' is out of range for output with 2 lines."    │
│            ^ sample now matches the code                               │
│                                                                        │
├────────────────────────────────────────────────────────────────────────┤
│                                                                        │
│ MIGRATION.md intro vs. every deprecation notice in src/ and tests/     │
│                                                                        │
│   BEFORE  intro: "...until v2."      notices: "...the next version."   │
│   AFTER   intro: "...until v2.1."    notices: "...v2.1."               │
│            ^ one target, one wording everywhere                        │
│                                                                        │
└────────────────────────────────────────────────────────────────────────┘
```
